### PR TITLE
feat(history): Add to settings commit_analyzer

### DIFF
--- a/semantic_release/cli.py
+++ b/semantic_release/cli.py
@@ -20,7 +20,7 @@ from .history import (
     get_previous_version,
     set_new_version,
 )
-from .history.logs import generate_changelog
+from .settings import current_commit_analyzer
 from .hvcs import (
     check_build_status,
     check_token,
@@ -79,6 +79,8 @@ COMMON_OPTIONS = [
     ),
     overload_configuration,
 ]
+
+commit_analyzer = current_commit_analyzer()
 
 
 def common_options(func):
@@ -210,9 +212,9 @@ def changelog(*, unreleased=False, noop=False, post=False, **kwargs):
 
     # Generate the changelog
     if unreleased:
-        log = generate_changelog(current_version, None)
+        log = commit_analyzer(current_version, None)
     else:
-        log = generate_changelog(previous_version, current_version)
+        log = commit_analyzer(previous_version, current_version)
 
     owner, name = get_repository_owner_and_name()
     # print is used to keep the changelog on stdout, separate from log messages
@@ -262,7 +264,7 @@ def publish(retry: bool = False, noop: bool = False, **kwargs):
         retry=retry,
         noop=noop,
     ):
-        log = generate_changelog(current_version)
+        log = commit_analyzer(current_version)
         changelog_md = markdown_changelog(
             owner,
             name,

--- a/semantic_release/defaults.cfg
+++ b/semantic_release/defaults.cfg
@@ -38,3 +38,4 @@ upload_to_repository=true
 upload_to_pypi=true
 upload_to_release=true
 version_source=commit
+commit_analyzer=semantic_release.history.logs.generate_changelog

--- a/semantic_release/history/logs.py
+++ b/semantic_release/history/logs.py
@@ -97,6 +97,8 @@ def generate_changelog(from_version: str, to_version: str = None) -> dict:
     if from_version:
         rev = from_version
 
+    commit_parser = current_commit_parser()
+
     found_the_release = to_version is None
     for _hash, commit_message in get_commit_log(rev):
         if not found_the_release:
@@ -116,7 +118,7 @@ def generate_changelog(from_version: str, to_version: str = None) -> dict:
             break
 
         try:
-            message = current_commit_parser()(commit_message)
+            message = commit_parser(commit_message)
             if message.type not in changes:
                 logger.debug(f"Creating new changelog section for {message.type} ")
                 changes[message.type] = list()

--- a/semantic_release/settings.py
+++ b/semantic_release/settings.py
@@ -112,12 +112,32 @@ def current_changelog_components() -> List[Callable]:
             module = ".".join(parts[:-1])
             # The final part is the name of the component function
             components.append(getattr(importlib.import_module(module), parts[-1]))
-        except (ImportError, AttributeError) as error:
+        except (ImportError, AttributeError):
             raise ImproperConfigurationError(
                 f'Unable to import changelog component "{path}"'
             )
 
     return components
+
+
+def current_commit_analyzer() -> Callable:
+    """Get the currently-configured commit_analyzer
+
+    :raises ImproperConfigurationError: if ImportError or AttributeError is raised
+    :returns: Commit analyzer
+    """
+    try:
+        # All except the last part is the import path
+        parts = config.get("commit_analyzer").split(".")
+        module = ".".join(parts[:-1])
+        # The final part is the name of the parse function
+        return getattr(importlib.import_module(module), parts[-1])
+    except (ImportError, AttributeError) as error:
+        raise ImproperConfigurationError(f'Unable to import commit analyzer "{error}"')
+    except ValueError:
+        raise ImproperConfigurationError(
+            f'Wrong path for import: {config.get("commit_analyzer")!r}'
+        )
 
 
 def overload_configuration(func):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -514,7 +514,7 @@ def test_publish_should_do_nothing_when_not_should_bump_version(mocker):
     mocker.patch("semantic_release.cli.checkout")
     mocker.patch("semantic_release.cli.get_new_version", lambda *x: "2.0.0")
     mocker.patch("semantic_release.cli.evaluate_version_bump", lambda *x: "feature")
-    mocker.patch("semantic_release.cli.generate_changelog")
+    mocker.patch("semantic_release.cli.commit_analyzer")
     mock_log = mocker.patch("semantic_release.cli.post_changelog")
     mock_repository = mocker.patch.object(ArtifactRepo, "upload")
     mock_upload_release = mocker.patch("semantic_release.cli.upload_to_release")
@@ -558,7 +558,7 @@ def test_publish_should_call_functions(mocker):
         return_value=("relekang", "python-semantic-release"),
     )
     mocker.patch("semantic_release.cli.evaluate_version_bump", lambda *x: "feature")
-    mocker.patch("semantic_release.cli.generate_changelog")
+    mocker.patch("semantic_release.cli.commit_analyzer")
     mocker.patch("semantic_release.cli.markdown_changelog", lambda *x, **y: "CHANGES")
     mocker.patch("semantic_release.cli.update_changelog_file")
     mocker.patch("semantic_release.cli.bump_version")
@@ -604,7 +604,7 @@ def test_publish_should_skip_build_when_command_is_empty(mocker):
         return_value=("relekang", "python-semantic-release"),
     )
     mocker.patch("semantic_release.cli.evaluate_version_bump", lambda *x: "feature")
-    mocker.patch("semantic_release.cli.generate_changelog")
+    mocker.patch("semantic_release.cli.commit_analyzer")
     mocker.patch("semantic_release.cli.markdown_changelog", lambda *x, **y: "CHANGES")
     mocker.patch("semantic_release.cli.update_changelog_file")
     mocker.patch("semantic_release.cli.bump_version")
@@ -759,7 +759,7 @@ def test_publish_giterror_when_posting(mocker):
         "semantic_release.cli.check_token", return_value=True
     )
     mock_generate = mocker.patch(
-        "semantic_release.cli.generate_changelog", return_value="super changelog"
+        "semantic_release.cli.commit_analyzer", return_value="super changelog"
     )
     mock_markdown = mocker.patch(
         "semantic_release.cli.markdown_changelog", return_value="super md changelog"
@@ -845,7 +845,7 @@ def test_changelog_noop(mocker):
         "semantic_release.cli.get_previous_version", return_value="previous"
     )
     mock_generate_changelog = mocker.patch(
-        "semantic_release.cli.generate_changelog", return_value="super changelog"
+        "semantic_release.cli.commit_analyzer", return_value="super changelog"
     )
     mock_markdown_changelog = mocker.patch(
         "semantic_release.cli.markdown_changelog", return_value="super changelog"
@@ -870,7 +870,7 @@ def test_changelog_post_unreleased_no_token(mocker):
         "semantic_release.cli.get_previous_version", return_value="previous"
     )
     mock_generate_changelog = mocker.patch(
-        "semantic_release.cli.generate_changelog", return_value="super changelog"
+        "semantic_release.cli.commit_analyzer", return_value="super changelog"
     )
     mock_markdown_changelog = mocker.patch(
         "semantic_release.cli.markdown_changelog", return_value="super changelog"
@@ -899,7 +899,7 @@ def test_changelog_post_complete(mocker):
         "semantic_release.cli.get_previous_version", return_value="previous"
     )
     mock_generate_changelog = mocker.patch(
-        "semantic_release.cli.generate_changelog", return_value="super changelog"
+        "semantic_release.cli.commit_analyzer", return_value="super changelog"
     )
     mock_markdown_changelog = mocker.patch(
         "semantic_release.cli.markdown_changelog", return_value="super md changelog"


### PR DESCRIPTION
Add to settings commit_analyzer  (#404)

- default value `semantic_release.history.logs.generate_changelog`
- function for get `semantic_release.settings.current_commit_analyzer`