### PR TITLE
feat: add option to only parse commits for current working directory

### DIFF
--- a/docs/automatic-releases/github-actions.rst
+++ b/docs/automatic-releases/github-actions.rst
@@ -104,7 +104,9 @@ multiple projects.
        repository_password: ${{ secrets.PYPI_TOKEN }}
 
 .. note::
-  The release notes posted to GitHub will not currently distinguish which
-  project they are from (see `this issue`_).
+  There is only partly support for monorepo (see `this issue`_).
+  In order to use this action, you should at least configure (in each project):
+  ``use_only_cwd_commits = true`` and a unique ``tag_format``.
+  Only ``version_source = commit`` (default) is supported.
 
 .. _this issue: https://github.com/python-semantic-release/python-semantic-release/issues/168

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -561,3 +561,22 @@ This is useful if the auth token does not have permission to push, but the syste
 (an ssh deploy key for instance) does.
 
 Default: `false`
+
+.. _config-use_only_cwd_commits:
+
+``use_only_cwd_commits``
+------------------------
+Only consider commits that are relevant for the current working directory when parsing commits.
+This can be helpful for a monorepo, where commits to one component should not trigger
+new versions for all other components as well.
+
+Default: `false`
+
+.. note::
+  Only valid if ``version_source = commit``.
+  You will probably also need to set a unique ``tag_format`` for each component.
+  Monorepo support is still only partly supported (see `this issue`_).
+
+.. _this issue: https://github.com/relekang/python-semantic-release/issues/168
+  
+  

--- a/semantic_release/defaults.cfg
+++ b/semantic_release/defaults.cfg
@@ -46,3 +46,4 @@ upload_to_pypi=true
 upload_to_release=true
 version_source=commit
 prerelease_tag=beta
+use_only_cwd_commits=false

--- a/semantic_release/settings.py
+++ b/semantic_release/settings.py
@@ -50,6 +50,7 @@ def _config_from_ini(paths):
         "upload_to_repository",
         "upload_to_release",
         "tag_commit",
+        "use_only_cwd_commits",
     }
 
     # Iterate through the sections so that default values are applied

--- a/semantic_release/vcs_helpers.py
+++ b/semantic_release/vcs_helpers.py
@@ -17,8 +17,11 @@ from .helpers import LoggedFunction
 from .settings import config
 
 _repo: Optional[Repo]
+_sub_directory = "."
 try:
     _repo = Repo(".", search_parent_directories=True)
+    if config.get("use_only_cwd_commits") and config.get("version_source") == "commit":
+        _sub_directory = os.path.relpath(os.getcwd(), _repo.working_dir)
 except InvalidGitRepositoryError:
     _repo = None
 
@@ -79,7 +82,7 @@ def get_commit_log(from_rev=None, to_rev=None):
     elif to_rev:
         rev = f"{to_rev}..."
 
-    for commit in repo().iter_commits(rev):
+    for commit in repo().iter_commits(rev, paths=_sub_directory):
         yield (commit.hexsha, commit.message.replace("\r\n", "\n"))
 
 


### PR DESCRIPTION
When running the application from a sub-directory in the VCS, the option use_only_cwd_commits will filter out commits that does not changes the current working directory, similar to running commands like `git log -- .` in a sub-directory.

Relevant, but not complete solution, for #168.