### PR TITLE
feat(repository): fixes #521, adding support for TWINE_CERT

### DIFF
--- a/docs/envvars.rst
+++ b/docs/envvars.rst
@@ -159,3 +159,7 @@ Custom repository (package index) URL to upload the package to.
 Takes precedence over :ref:`config-repository_url`
 
 See :ref:`automatic-dist-upload` for more about uploads to custom repositories.
+
+``TWINE_CERT``
+------------------
+Path to alternative CA bundle to use for SSL verification to repository. `See here for more information <https://twine.readthedocs.io/en/stable/>`

--- a/semantic_release/repository.py
+++ b/semantic_release/repository.py
@@ -2,9 +2,7 @@
 """
 import logging
 import os
-from dataclasses import InitVar
-from dataclasses import asdict as dataclass_asdict
-from dataclasses import dataclass, field
+from dataclasses import InitVar, asdict as dataclass_asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -126,6 +124,13 @@ class ArtifactRepo:
         pass them to Twine which then validates and loads the config.
         """
         params = {name: val for name, val in dataclass_asdict(self).items() if val}
+        cacert = os.environ.get("TWINE_CERT", None)
+        if cacert:
+            if not Path(cacert).is_file():
+                raise ImproperConfigurationError(
+                    f"TWINE_CERT env variable set, but file does not exist. Value: {cacert}"
+                )
+            params["cacert"] = cacert
         settings = TwineSettings(**params, **addon_kwargs)
 
         return settings

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -202,19 +202,14 @@ def test_upload_with_custom_settings(mock_is_file, mock_upload):
     },
 )
 @mock.patch("semantic_release.repository.Path.is_file", return_value=False)
-def test_upload_with_invalid_twine_cert(mock_is_file):
+@mock.patch.object(ArtifactRepo, "_handle_credentials_init")
+def test_upload_with_invalid_twine_cert(mock_is_file, mock_handle_creds):
     repo = ArtifactRepo(Path("custom-dist"))
+
     with pytest.raises(ImproperConfigurationError) as ex:
         repo.upload(noop=False, verbose=True, skip_existing=True)
 
     assert "TWINE_CERT env variable set, but file does not exist" in str(ex.value)
-
-
-@mock.patch.object(ArtifactRepo, "_handle_credentials_init")
-@mock.patch("semantic_release.repository.twine_upload")
-def test_upload_with_noop(mock_upload, mock_handle_creds):
-    ArtifactRepo(Path("dist")).upload(noop=True, verbose=False, skip_existing=False)
-    assert not mock_upload.called
 
 
 @mock.patch.object(ArtifactRepo, "_handle_credentials_init")


### PR DESCRIPTION
Adds support for TWINE_CERT, as proposed [here](https://github.com/python-semantic-release/python-semantic-release/issues/521).