### PR TITLE
feat: add signing options to action

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,11 @@ RUN set -ex; \
     apt-get install -y --no-install-recommends \
         git-lfs
 
+#install backported stable vesion of git, which supports ssh signing
+RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list; \
+    apt-get update;\
+    apt-get install -y git/bullseye-backports
+
 ENV PYTHONPATH /semantic-release
 
 COPY . /semantic-release

--- a/action.sh
+++ b/action.sh
@@ -10,6 +10,8 @@ export REPOSITORY_PASSWORD="${INPUT_REPOSITORY_PASSWORD}"
 export PATH="${PATH}:/semantic-release/.venv/bin"
 export GIT_COMMITTER_NAME="${INPUT_GIT_COMMITTER_NAME:="github-actions"}"
 export GIT_COMMITTER_EMAIL="${INPUT_GIT_COMMITTER_EMAIL:="github-actions@github.com"}"
+export SSH_PRIVATE_SIGNING_KEY="${INPUT_SSH_PRIVATE_SIGNING_KEY}"
+export SSH_PUBLIC_SIGNING_KEY="${INPUT_SSH_PUBLIC_SIGNING_KEY}"
 
 # Change to configured directory
 cd "${INPUT_DIRECTORY}"
@@ -17,6 +19,26 @@ cd "${INPUT_DIRECTORY}"
 # Set Git details
 git config --global user.name "$GIT_COMMITTER_NAME"
 git config --global user.email "$GIT_COMMITTER_EMAIL"
+
+if [[  -n $SSH_PUBLIC_SIGNING_KEY && -n $SSH_PRIVATE_SIGNING_KEY ]]; then
+    echo "SSH Key pair found, configuring signing..."
+    mkdir ~/.ssh
+    echo -e "$SSH_PRIVATE_SIGNING_KEY" >> ~/.ssh/signing_key
+    cat ~/.ssh/signing_key
+    echo -e "$SSH_PUBLIC_SIGNING_KEY" >> ~/.ssh/signing_key.pub
+    cat ~/.ssh/signing_key.pub
+    chmod 600 ~/.ssh/signing_key && chmod 600 ~/.ssh/signing_key.pub
+    eval "$(ssh-agent)"
+    ssh-add ~/.ssh/signing_key
+    git config --global gpg.format ssh
+    git config --global user.signingKey ~/.ssh/signing_key
+    git config --global commit.gpgsign true
+    git config --global user.email $GIT_COMMITTER_EMAIL
+    git config --global user.name $GIT_COMMITTER_NAME
+    touch ~/.ssh/allowed_signers
+    echo "$GIT_COMMITTER_EMAIL $SSH_PUBLIC_SIGNING_KEY" > ~/.ssh/allowed_signers
+    git config --global gpg.ssh.allowedSignersFile ~/.ssh/allowed_signers
+fi
 
 # Run Semantic Release
 /semantic-release/.venv/bin/python \

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,12 @@ inputs:
   git_committer_email:
     description: 'The email address for the “committer” field'
     required: false
+  ssh_public_signing_key:
+    description: 'The ssh public key used to sign commits'
+    required: false
+  ssh_private_signing_key:
+    description: 'The ssh private key used to sign commits'
+    required: false
 
 runs:
   using: 'docker'

--- a/docs/action.rst
+++ b/docs/action.rst
@@ -56,6 +56,7 @@ Custom Users
 The name of the account used to commit. If customized, it must be associated with the provided token. 
 
 default: `github-actions`
+
 required: false
 
 .. _action-git-committer-email:
@@ -66,6 +67,7 @@ required: false
 The email of the account used to commit. If customized, it must be associated with the provided token. 
 
 default: `actions@github.com>`
+
 required: false
 
 .. _action-ssh-public-signing-key:
@@ -94,6 +96,7 @@ Additional Options
 ----------
 
 Sub-directory to cd into before running semantic-release
+
 required: false
 
 .. _action-additional-options:

--- a/docs/action.rst
+++ b/docs/action.rst
@@ -1,0 +1,106 @@
+.. _action:
+
+Action
+*************
+
+Configuring the action is done in ``.yml`` file of your workflow. The action takes these arguments:
+
+
+Tokens
+========
+.. _action-github-token:
+
+``github_token``
+----------
+
+The GitHub token used to push release notes and new commits/tags.
+
+required: false
+
+.. _action-pypi-token:
+
+``pypi_token``
+----------
+
+The PyPI API token
+
+required: false
+
+Artifact Repository
+========
+.. _action-git-repository-username:
+
+``repository_username``
+----------
+
+The username with project access to push to Artifact Repository
+
+required: false
+
+.. _action-git-repository-password:
+
+``repository_password``
+----------
+
+The password or token to the account specified in repository_username
+
+required: false
+
+Custom Users
+========
+.. _action-git-committer-name:
+
+``git_committer_name``
+----------
+
+The name of the account used to commit. If customized, it must be associated with the provided token. 
+
+default: `github-actions`
+required: false
+
+.. _action-git-committer-email:
+
+``git_committer_email``
+----------
+
+The email of the account used to commit. If customized, it must be associated with the provided token. 
+
+default: `actions@github.com>`
+required: false
+
+.. _action-ssh-public-signing-key:
+
+``ssh_public_signing_key``
+----------
+
+The public key used to verify a commit. If customized, it must be associated with the same account as the provided token. 
+
+required: false
+
+.. _action-ssh-private-signing-key:
+
+``ssh_private_signing_key``
+----------
+
+The private key used to verify a commit. If customized, it must be associated with the same account as the provided token. 
+
+required: false
+
+Additional Options
+========
+.. _action-directory:
+
+``directory``
+----------
+
+Sub-directory to cd into before running semantic-release
+required: false
+
+.. _action-additional-options:
+
+``additional_options``
+----------
+
+Additional options for the publish command. Example: --noop
+
+required: false

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -302,7 +302,7 @@ Default: ``semantic-release <semantic-release>``
 .. note::
   If you are using the built-in GitHub Action, the default value is set to
   ``github-actions <actions@github.com>``. You can modify this with the
-  ``git_committer_name`` and ``git_committer_name`` inputs.
+  ``git_committer_name`` and ``git_committer_email`` inputs.
 
 Changelog
 =========


### PR DESCRIPTION
Add ability to add an SSH key for verifying commits as mentioned here: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#ssh-commit-signature-verification

Updated documentation accordingly.

Install `stable-bpo` version of `git` ([1:2.34.1-1~bpo11+1](https://packages.debian.org/source/stable-backports/git)) in docker image as the stable version ([1:2.30.2-1](https://packages.debian.org/source/stable/git)) doesn't support signing commits with SSH. 

Added documentation for the action now that there are more than a few options. 