### PR TITLE
fix: inconsistent versioning between print-version and publish

### DIFF
--- a/semantic_release/cli.py
+++ b/semantic_release/cli.py
@@ -127,7 +127,7 @@ def print_version(
         return True
 
     # Find what the new version number should be
-    level_bump = evaluate_version_bump(current_version, force_level)
+    level_bump = evaluate_version_bump(current_release_version, force_level)
     new_version = get_new_version(
         current_version,
         current_release_version,


### PR DESCRIPTION
## The problem

Reported version by `publish` and `print-version` does not match

## Expected behavior

I expected to have both to return the same next version for a same set of arguments.

## Additional context

While using:
```
python-semantic-release 7.32.2
Python 3.9.12
```

And for this given git history containing patches only:
```
* 40187c5 (HEAD -> develop) patch: change 2 (mrjk, 45 seconds ago)
* 969375d patch: change 1 (mrjk, 45 seconds ago)
* 6f01669 patch: change 0 (mrjk, 45 seconds ago)
* 17fcb7d (tag: v0.1.3-beta.2, origin/develop) bump: version v0.1.3-beta.2 (semantic-release, 83 seconds ago)
```

If I try to get the next version, I have:
```
$ semantic-release print-version --noop --prerelease
0.1.3-beta.3
```
Which is fine,  but if I publish next version, I have:
```
$ semantic-release publish --noop --prerelease
Current version: 0.1.3-beta.2, Current release version: 0.1.2
warning: No operation mode. Should have bumped from 0.1.3-beta.2 to 0.2.0-beta.1
```
So we have an inconsistency on the generated version, I expected `0.1.3-beta.3` but I realeased  `0.2.0-beta.1`

