### PR TITLE
fix: unset mypy version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
         ],
         "docs": ["Sphinx==1.3.6", "Jinja2==3.0.3"],
         "dev": ["tox", "isort", "black"],
-        "mypy": ["mypy", "types-requests"],
+        "mypy": ["mypy==0.982", "types-requests"],
     },
     entry_points="""
         [console_scripts]


### PR DESCRIPTION
When I forked this repo and run my own github action, the test failed because numpy reported many errors. While looking back at this original project, the CI tests build are working well with the version of `mypy-0.982` but on my side but I got the latest on my side, which reports more errors and make tests to fail.

As the test has been written for a version of `mypy-0.982`, I propose to fix the version in the attendances.