### PR TITLE
fix: changelog release commit search logic

### DIFF
--- a/semantic_release/history/logs.py
+++ b/semantic_release/history/logs.py
@@ -118,10 +118,7 @@ def generate_changelog(
                 )
                 found_the_release = True
 
-        if (
-            from_version_commit
-            and commit_message.strip() == from_version_commit.strip()
-        ):
+        if (from_version_commit and commit_message == from_version_commit):
             # We reached the previous release
             logger.debug(f"{from_version} reached, ending changelog generation")
             break

--- a/semantic_release/history/logs.py
+++ b/semantic_release/history/logs.py
@@ -101,9 +101,12 @@ def generate_changelog(
     changes: dict = {"breaking": []}
 
     found_the_release = to_version is None
-    to_version_commit = to_version and get_formatted_commit(to_version)
-    from_version_commit = from_version and get_formatted_commit(from_version)
+    to_version_commit = to_version and get_formatted_commit(to_version).strip()
+    from_version_commit = from_version and get_formatted_commit(from_version).strip()
     for _hash, commit_message in get_commit_log(from_version, to_version):
+        # See https://github.com/relekang/python-semantic-release/issues/490 -
+        # commit messages (which we compare with ==) have a trailing newline
+        commit_message = commit_message.strip()
         if not found_the_release:
             # Skip until we find the last commit in this release
             # (we are looping in the order of newest -> oldest)
@@ -115,8 +118,6 @@ def generate_changelog(
                 )
                 found_the_release = True
 
-        # See https://github.com/relekang/python-semantic-release/issues/490 -
-        # commit messages (which we compare with ==) have a trailing newline
         if (
             from_version_commit
             and commit_message.strip() == from_version_commit.strip()


### PR DESCRIPTION
Running `semantic-release changelog` currently fails to identify "the last commit in [a] release" because the compared commit messages have superfluous whitespace. (Likely related to the issue causing https://github.com/relekang/python-semantic-release/issues/490)

The logic to iterate through the commits, to identify the boundary between the two versions, fails to identify the release commit message generated by semantic-release, and skips all the commits.
This ultimately results in no commits being printed as part of the changelog.

## Fixes:

I have a log looking like this:
```
$ git log --oneline
a501da0 (HEAD -> main, tag: 0.2.0-dev.4, origin/main) 0.2.0-dev.4
812e796 Merge pull request #41 from [...]
8ccc600 (origin/todo) refactor: [...]
e06c3b4 Merge pull request #40 from [...]
94a4d35 (origin/v) refactor: Remove verbose.
302254d [...]
07846a6 ci(semrel): [...]
0b9560c 0.2.0-dev.3
ac25e8d (tag: 0.2.0-dev.3) Merge pull request #39 from ...
```

But running changelog fails to find the three changes labelled with 'ci' and 'refactor':
```
$ semantic-release changelog -D changelog_sections="refactor,ci"
[nothing here]
```

After the PR I get the expected output:
```
$ semantic-release changelog -D changelog_sections="refactor,ci"
### Refactor
* [...] ([`8ccc600`](https://github.com/...))
* [...] ([`94a4d35`](https://github.com/...))

### Ci
* **semrel:** [...] ([`07846a6`](https://github.com/...))
```