### PR TITLE
fix: if prerelease, publish prerelease (python-semantic-release#544)

### DIFF
--- a/semantic_release/cli.py
+++ b/semantic_release/cli.py
@@ -299,6 +299,7 @@ def changelog(*, unreleased=False, noop=False, post=False, prerelease=False, **k
                 name,
                 current_version,
                 markdown_changelog(owner, name, current_version, log, header=False),
+                prerelease
             )
         else:
             logger.error("Missing token: cannot post changelog to HVCS")
@@ -404,7 +405,7 @@ def publish(
             # Update changelog on HVCS
             logger.info("Posting changelog to HVCS")
             try:
-                post_changelog(owner, name, new_version, changelog_md)
+                post_changelog(owner, name, new_version, changelog_md, prerelease)
             except GitError:
                 logger.error("Posting changelog failed")
         else:

--- a/semantic_release/hvcs.py
+++ b/semantic_release/hvcs.py
@@ -41,7 +41,7 @@ class Base(object):
 
     @classmethod
     def post_release_changelog(
-        cls, owner: str, repo: str, version: str, changelog: str
+        cls, owner: str, repo: str, version: str, changelog: str, prerelease: bool
     ) -> bool:
         raise NotImplementedError
 
@@ -178,7 +178,7 @@ class Github(Base):
 
     @classmethod
     @LoggedFunction(logger)
-    def create_release(cls, owner: str, repo: str, tag: str, changelog: str) -> bool:
+    def create_release(cls, owner: str, repo: str, tag: str, changelog: str, prerelease: bool) -> bool:
         """Create a new release
 
         https://docs.github.com/rest/reference/repos#create-a-release
@@ -198,7 +198,7 @@ class Github(Base):
                     "name": tag,
                     "body": changelog,
                     "draft": False,
-                    "prerelease": False,
+                    "prerelease": prerelease,
                 },
             )
             return True
@@ -256,7 +256,7 @@ class Github(Base):
     @classmethod
     @LoggedFunction(logger)
     def post_release_changelog(
-        cls, owner: str, repo: str, version: str, changelog: str
+        cls, owner: str, repo: str, version: str, changelog: str, prerelease: bool
     ) -> bool:
         """Post release changelog
 
@@ -269,7 +269,7 @@ class Github(Base):
         """
         tag = get_formatted_tag(version)
         logger.debug(f"Attempting to create release for {tag}")
-        success = Github.create_release(owner, repo, tag, changelog)
+        success = Github.create_release(owner, repo, tag, changelog, prerelease)
 
         if not success:
             logger.debug("Unsuccessful, looking for an existing release to update")
@@ -484,7 +484,7 @@ class Gitea(Base):
 
     @classmethod
     @LoggedFunction(logger)
-    def create_release(cls, owner: str, repo: str, tag: str, changelog: str) -> bool:
+    def create_release(cls, owner: str, repo: str, tag: str, changelog: str, prerelease: bool) -> bool:
         """Create a new release
 
         https://gitea.com/api/swagger#/repository/repoCreateRelease
@@ -504,7 +504,7 @@ class Gitea(Base):
                     "name": tag,
                     "body": changelog,
                     "draft": False,
-                    "prerelease": False,
+                    "prerelease": prerelease,
                 },
             )
             return True
@@ -562,7 +562,7 @@ class Gitea(Base):
     @classmethod
     @LoggedFunction(logger)
     def post_release_changelog(
-        cls, owner: str, repo: str, version: str, changelog: str
+        cls, owner: str, repo: str, version: str, changelog: str, prerelease: bool
     ) -> bool:
         """Post release changelog
 
@@ -575,7 +575,7 @@ class Gitea(Base):
         """
         tag = get_formatted_tag(version)
         logger.debug(f"Attempting to create release for {tag}")
-        success = Gitea.create_release(owner, repo, tag, changelog)
+        success = Gitea.create_release(owner, repo, tag, changelog, prerelease)
 
         if not success:
             logger.debug("Unsuccessful, looking for an existing release to update")
@@ -730,7 +730,7 @@ class Gitlab(Base):
     @classmethod
     @LoggedFunction(logger)
     def post_release_changelog(
-        cls, owner: str, repo: str, version: str, changelog: str
+        cls, owner: str, repo: str, version: str, changelog: str, prerelease: bool
     ) -> bool:
         """Post release changelog
 
@@ -792,7 +792,7 @@ def check_build_status(owner: str, repository: str, ref: str) -> bool:
     return get_hvcs().check_build_status(owner, repository, ref)
 
 
-def post_changelog(owner: str, repository: str, version: str, changelog: str) -> bool:
+def post_changelog(owner: str, repository: str, version: str, changelog: str, prerelease: bool) -> bool:
     """
     Posts the changelog to the current hvcs release API
 
@@ -803,7 +803,7 @@ def post_changelog(owner: str, repository: str, version: str, changelog: str) ->
     :return: a tuple with success status and payload from hvcs
     """
     logger.debug(f"Posting release changelog for {owner}/{repository} {version}")
-    return get_hvcs().post_release_changelog(owner, repository, version, changelog)
+    return get_hvcs().post_release_changelog(owner, repository, version, changelog, prerelease)
 
 
 def upload_to_release(owner: str, repository: str, version: str, path: str) -> bool:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -925,7 +925,7 @@ def test_publish_should_call_functions(mocker):
     assert mock_release.called
     assert mock_should_bump_version.called
     mock_log.assert_called_once_with(
-        "relekang", "python-semantic-release", "2.0.0", "CHANGES"
+        "relekang", "python-semantic-release", "2.0.0", "CHANGES", False
     )
     mock_checkout.assert_called_once_with("master")
 
@@ -978,7 +978,7 @@ def test_publish_should_skip_build_when_command_is_empty(mocker):
     assert mock_release.called
     assert mock_should_bump_version.called
     mock_log.assert_called_once_with(
-        "relekang", "python-semantic-release", "2.0.0", "CHANGES"
+        "relekang", "python-semantic-release", "2.0.0", "CHANGES", False
     )
     mock_checkout.assert_called_once_with("master")
 
@@ -1180,7 +1180,7 @@ def test_publish_giterror_when_posting(mocker):
         header=False,
         previous_version="1.2.3",
     )
-    mock_post.assert_called_once_with("owner", "name", "new", "super md changelog")
+    mock_post.assert_called_once_with("owner", "name", "new", "super md changelog", False)
 
 
 def test_changelog_should_call_functions(mocker, runner):
@@ -1302,7 +1302,7 @@ def test_changelog_post_complete(mocker):
     mock_check_token.assert_called_once_with()
     mock_get_owner_name.assert_called_once_with()
     mock_post_changelog.assert_called_once_with(
-        "owner", "name", "current", "super md changelog"
+        "owner", "name", "current", "super md changelog", False
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -373,6 +373,22 @@ def test_cli_print_version_prerelease(mocker, runner):
     assert result.exit_code == 0
 
 
+def test_cli_print_version_prerelease(mocker, runner):
+    mock_publish = mocker.patch("semantic_release.cli.publish")
+    result = runner.invoke(main, ["publish", "--prerelease"])
+    mock_publish.assert_called_once_with(
+        prerelease=True,
+        force_level=None,
+        prerelease_patch=True,
+        post=False,
+        retry=False,
+        noop=False,
+        define=(),
+    )
+
+    assert result.exit_code == 0
+
+
 def test_cli_print_version_current(mocker, runner):
     mock_print_version = mocker.patch("semantic_release.cli.print_version")
     result = runner.invoke(main, ["print-version", "--current"])
@@ -1180,7 +1196,9 @@ def test_publish_giterror_when_posting(mocker):
         header=False,
         previous_version="1.2.3",
     )
-    mock_post.assert_called_once_with("owner", "name", "new", "super md changelog", False)
+    mock_post.assert_called_once_with(
+        "owner", "name", "new", "super md changelog", False
+    )
 
 
 def test_changelog_should_call_functions(mocker, runner):

--- a/tests/test_hvcs.py
+++ b/tests/test_hvcs.py
@@ -408,7 +408,7 @@ class GithubReleaseTests(TestCase):
 
             with mock.patch.dict(os.environ, {"NETRC": netrc_file.name}):
                 status = Github.post_release_changelog(
-                    "relekang", "rmoq", "1.0.0", "text"
+                    "relekang", "rmoq", "1.0.0", "text", False
                 )
                 self.assertTrue(status)
 
@@ -445,7 +445,7 @@ class GithubReleaseTests(TestCase):
 
             with mock.patch.dict(os.environ, {"NETRC": netrc_file.name}):
                 status = Github.post_release_changelog(
-                    "relekang", "rmoq", "1.0.0", "text"
+                    "relekang", "rmoq", "1.0.0", "text", False
                 )
                 self.assertTrue(status)
 
@@ -473,7 +473,7 @@ class GithubReleaseTests(TestCase):
             content_type="application/json",
         )
         self.assertFalse(
-            Github.post_release_changelog("relekang", "rmoq", "1.0.0", "text")
+            Github.post_release_changelog("relekang", "rmoq", "1.0.0", "text", False)
         )
 
     @responses.activate
@@ -651,7 +651,7 @@ class GiteaReleaseTests(TestCase):
             )
 
             with mock.patch.dict(os.environ, {"NETRC": netrc_file.name}):
-                status = Gitea.post_release_changelog("gitea", "tea", "1.0.0", "text")
+                status = Gitea.post_release_changelog("gitea", "tea", "1.0.0", "text", False)
                 self.assertTrue(status)
 
     @responses.activate
@@ -686,7 +686,7 @@ class GiteaReleaseTests(TestCase):
             )
 
             with mock.patch.dict(os.environ, {"NETRC": netrc_file.name}):
-                status = Gitea.post_release_changelog("gitea", "tea", "1.0.0", "text")
+                status = Gitea.post_release_changelog("gitea", "tea", "1.0.0", "text", False)
                 self.assertTrue(status)
 
     @responses.activate
@@ -712,7 +712,7 @@ class GiteaReleaseTests(TestCase):
             body="{}",
             content_type="application/json",
         )
-        self.assertFalse(Gitea.post_release_changelog("gitea", "tea", "1.0.0", "text"))
+        self.assertFalse(Gitea.post_release_changelog("gitea", "tea", "1.0.0", "text", False))
 
     @responses.activate
     @mock.patch("semantic_release.hvcs.Gitea.token", return_value="super-token")
@@ -812,15 +812,15 @@ class GiteaReleaseTests(TestCase):
 class GitlabReleaseTests(TestCase):
     @mock_gitlab()
     def test_should_return_true_if_success(self, mock_auth, mock_project):
-        self.assertTrue(post_changelog("owner", "repo", "my_good_tag", "changelog"))
+        self.assertTrue(post_changelog("owner", "repo", "my_good_tag", "changelog", False))
 
     @mock_gitlab()
     def test_should_return_false_if_bad_tag(self, mock_auth, mock_project):
-        self.assertFalse(post_changelog("owner", "repo", "my_bad_tag", "changelog"))
+        self.assertFalse(post_changelog("owner", "repo", "my_bad_tag", "changelog", False))
 
     @mock_gitlab()
     def test_should_return_true_for_locked_tags(self, mock_auth, mock_project):
-        self.assertTrue(post_changelog("owner", "repo", "my_locked_tag", "changelog"))
+        self.assertTrue(post_changelog("owner", "repo", "my_locked_tag", "changelog", False))
 
 
 def test_gitea_token():


### PR DESCRIPTION
* Fixes publishing process of release/prerelease

Running `semantic-release publish --prerelease` currently creates release, not prerelease.