### PR TITLE
fix: configure repo as safe in workflow action

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -13,6 +13,9 @@ export GIT_COMMITTER_EMAIL="${INPUT_GIT_COMMITTER_EMAIL:="github-actions@github.
 export SSH_PRIVATE_SIGNING_KEY="${INPUT_SSH_PRIVATE_SIGNING_KEY}"
 export SSH_PUBLIC_SIGNING_KEY="${INPUT_SSH_PUBLIC_SIGNING_KEY}"
 
+# Fix unsafe
+git config --global --add safe.directory $(pwd)
+
 # Change to configured directory
 cd "${INPUT_DIRECTORY}"
 


### PR DESCRIPTION
The new git version introduced in
31ad5eb5a25f0ea703afc295351104aefd66cac1 causes failure to read from git repository, due to "detected dubious ownership". This is a quick fix that just marks the repo as safe so it will work again.