### PR TITLE
feat(publish): Added Github Actions output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,12 @@ inputs:
     description: 'The ssh private key used to sign commits'
     required: false
 
+outputs:
+  released:
+    description: 'true if a release was mad, false otherwise'
+  version:
+    description: 'The current version if no release was made, otherwise the new version'
+
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/docs/automatic-releases/github-actions.rst
+++ b/docs/automatic-releases/github-actions.rst
@@ -23,6 +23,16 @@ Inputs
 | ``additional_options``   | Additional :ref:`cmd-common-options` for the ``publish`` command. Example: ``--noop``  |
 +--------------------------+----------------------------------------------------------------------------------------+
 
++--------------------------+----------------------------------------------------------------------------------------+
+| Outpput                  | Description                                                                            |
++==========================+========================================================================================+
+| ``released``             | Set to `true` if a release was made, otherwise set to `false`                          |
++--------------------------+----------------------------------------------------------------------------------------+
+| ``version``              | Set to the current version if no release was made, otherwise to the new version.       |
++--------------------------+----------------------------------------------------------------------------------------+
+
+
+
 Other options are taken from your regular configuration file.
 
 Example Workflow

--- a/semantic_release/cli.py
+++ b/semantic_release/cli.py
@@ -220,6 +220,10 @@ def should_bump_version(
     """Test whether the version should be bumped."""
     if new_version == match_version and not retry:
         logger.info("No release will be made.")
+        if os.getenv("GITHUB_ACTIONS"):
+            with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+                print(f'released=false', file=fh)
+                print(f'version={match_version}', file=fh)
         return False
 
     if noop:
@@ -227,6 +231,10 @@ def should_bump_version(
             "No operation mode. Should have bumped "
             f"from {current_version} to {new_version}"
         )
+        if os.getenv("GITHUB_ACTIONS"):
+            with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+                print(f'released=false', file=fh)
+                print(f'version={match_version}', file=fh)
         return False
 
     if config.get("check_build_status"):
@@ -237,6 +245,10 @@ def should_bump_version(
             return False
         logger.info("The build was a success, continuing the release")
 
+    if os.getenv("GITHUB_ACTIONS"):
+        with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+            print(f'released=true', file=fh)
+            print(f'version={new_version}', file=fh)
     return True
 
 


### PR DESCRIPTION
- Added output for `released` and `version` for Github Actions
`released` is either `true` if the version was bumped, or `false` otherwise
`version` is the new version if version was bumped, otherwise the current version
- Re-ordered imports with `isort`
- Added tests

Still having some issues with some of the tests.  @sp-luciano-chinke  Could you help out?


Inspired by: https://github.com/python-semantic-release/python-semantic-release/issues/401