### PR TITLE
Update Gitmojis according to official node module and make utf-8 symbols available

### DIFF
--- a/semantic_release/defaults.cfg
+++ b/semantic_release/defaults.cfg
@@ -25,11 +25,11 @@ gitea_token_var=GITEA_TOKEN
 
 hvcs=github
 ignore_token_for_push=false
-major_emoji=:boom:
+major_emoji=💥,:boom:
 major_on_zero=true
-minor_emoji=:sparkles:,:children_crossing:,:lipstick:,:iphone:,:egg:,:chart_with_upwards_trend:
+minor_emoji=✨,:sparkles:
 minor_tag=:sparkles:
-patch_emoji=:ambulance:,:lock:,:bug:,:zap:,:goal_net:,:alien:,:wheelchair:,:speech_balloon:,:mag:,:apple:,:penguin:,:checkered_flag:,:robot:,:green_apple:
+patch_emoji=⚡️,🐛,🚑️,💄,🔒️,⬇️,⬆️,📌,📈,➕,➖,🔧,🌐,✏️,⏪️,📦️,👽️,🍱,♿️,💬,🗃️ ,🚸,📱,🥚,⚗️,🔍️,🏷️ ,🚩,🥅,💫,🗑️ ,🛂,🩹,👔,:zap:,:bug:,:ambulance:,:lipstick:,:lock:,:arrow_down:,:arrow_up:,:pushpin:,:chart_with_upwards_trend:,:heavy_plus_sign:,:heavy_minus_sign:,:wrench:,:globe_with_meridians:,:pencil2:,:rewind:,:package:,:alien:,:bento:,:wheelchair:,:speech_balloon:,:card_file_box:,:children_crossing:,:iphone:,:egg:,:alembic:,:mag:,:label:,:triangular_flag_on_post:,:goal_net:,:dizzy:,:wastebasket:,:passport_control:,:adhesive_bandage:,:necktie:
 patch_without_tag=false
 pre_commit_command=
 pypi_pass_var=PYPI_PASSWORD


### PR DESCRIPTION
According to the "official" [node module](https://github.com/carloscuesta/gitmoji/blob/master/packages/gitmojis/src/gitmojis.json) the Gitmojis have changed. This PR updates the default emojis for patch and minor versions.

In addition, it allows the usage of utf-8 symbols. So one can either use `:sparkles` or `✨` in their commit messages.