### PR TITLE
Trim emojis from config

### DIFF
--- a/semantic_release/helpers.py
+++ b/semantic_release/helpers.py
@@ -1,5 +1,5 @@
 import functools
-from typing import Union
+from typing import Union, List
 
 from requests import Session
 from requests.adapters import HTTPAdapter
@@ -37,6 +37,16 @@ def build_requests_session(
         session.mount("http://", adapter)
         session.mount("https://", adapter)
     return session
+
+
+def trim_csv_str(csv_str: str) -> List[str]:
+    """
+    Trim whitespace from each value in a comma-separated string.
+
+    :param csv_str: Comma-separated string of values.
+    :return List of values with leading and trailing whitespace removed.
+    """
+    return [value.strip() for value in csv_str.split(",")]
 
 
 class LoggedFunction:

--- a/semantic_release/history/parser_emoji.py
+++ b/semantic_release/history/parser_emoji.py
@@ -3,7 +3,7 @@ import logging
 import re
 from typing import Optional
 
-from ..helpers import LoggedFunction
+from ..helpers import LoggedFunction, trim_csv_str
 from ..settings import config
 from .parser_helpers import ParsedCommit, parse_paragraphs
 
@@ -34,9 +34,9 @@ def parse_commit_message(
 
     subject = message.split("\n")[0]
 
-    major = config.get("major_emoji").split(",")
-    minor = config.get("minor_emoji").split(",")
-    patch = config.get("patch_emoji").split(",")
+    major = trim_csv_str(config.get("major_emoji"))
+    minor = trim_csv_str(config.get("minor_emoji"))
+    patch = trim_csv_str(config.get("patch_emoji"))
     all_emojis = major + minor + patch
 
     use_textual_changelog_sections = config.get("use_textual_changelog_sections")

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,6 @@
+from semantic_release.helpers import trim_csv_str
+
+
+def test_trim_csv_str():
+    csv_str = "Apple,banana, mango, pineapple"
+    assert trim_csv_str(csv_str) == ["Apple", "banana", "mango", "pineapple"]


### PR DESCRIPTION
Emojis (`patch_emoji`, `minor_emoji` and `major_emoji`) are given as comma-separated values. Since they are not trimmed, one can easily get into headaches. This PR adds striping to the config values.