### PR TITLE
fix: generate markdown linter compliant changelog headers & lists

### DIFF
--- a/semantic_release/changelog/__init__.py
+++ b/semantic_release/changelog/__init__.py
@@ -31,7 +31,7 @@ def markdown_changelog(
     :param header: A boolean that decides whether a version number header should be included.
     :return: The markdown formatted changelog.
     """
-    output = f"## v{version}\n" if header else ""
+    output = f"## v{version}\n\n" if header else ""
 
     # Add the output of each component separated by a blank line
     output += "\n\n".join(

--- a/semantic_release/changelog/changelog.py
+++ b/semantic_release/changelog/changelog.py
@@ -56,7 +56,7 @@ def changelog_headers(
 
     for section in get_changelog_sections(changelog, changelog_sections):
         # Add a header for this section
-        output += f"\n### {section.capitalize()}\n"
+        output += f"\n### {section.capitalize()}\n\n"
 
         # Add each commit from the section in an unordered list
         for item in changelog[section]:

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -32,23 +32,42 @@ def test_markdown_changelog():
         },
     ) == (
         # Expected output with the default configuration
-        "### Feature\n"
+        "### Feature\n\n"
         "* Add non-breaking super-feature ([`145`](https://github.com/owner/repo_name/"
         "commit/145))\n"
         "* Add super-feature ([`134`](https://github.com/owner/repo_name/commit/134))\n"
         "\n"
-        "### Fix\n"
+        "### Fix\n\n"
         "* Fix bug in super-feature ([#15](https://github.com/owner/repo_name/issues/15))"
         " ([`234`](https://github.com/owner/repo_name/"
         "commit/234))\n"
         "\n"
-        "### Breaking\n"
+        "### Breaking\n\n"
         "* Uses super-feature as default instead of dull-feature."
         " ([`21`](https://github.com/owner/repo_name/commit/21))\n"
         "\n"
-        "### Documentation\n"
+        "### Documentation\n\n"
         "* Document super-feature ([#189](https://github.com/owner/repo_name/issues/189))"
         " ([`0`](https://github.com/owner/repo_name/commit/0))"
+    )
+
+
+def test_markdown_changelog_with_header():    
+    assert markdown_changelog(
+        "owner",
+        "repo_name",
+        "1.0.1",
+        {
+            "fix": [("234", "Fix bug in super-feature (#15)")],
+        },
+        header=True,
+    ) == (
+        # Expected output with the default configuration
+        "## v1.0.1\n\n"
+        "### Fix\n\n"
+        "* Fix bug in super-feature ([#15](https://github.com/owner/repo_name/issues/15))"
+        " ([`234`](https://github.com/owner/repo_name/"
+        "commit/234))"
     )
 
 
@@ -71,14 +90,14 @@ def test_markdown_changelog_gitlab():
             },
         ) == (
             # Expected output with the default configuration
-            "### Feature\n"
+            "### Feature\n\n"
             "* Add non-breaking super-feature ([#1](https://gitlab.com/owner/"
             "repo_name/-/issues/1)) ([`145`](https://gitlab.com/owner/"
             "repo_name/-/commit/145))\n"
             "* Add super-feature ([`134`](https://gitlab.com/owner/repo_name/-/"
             "commit/134))\n"
             "\n"
-            "### Documentation\n"
+            "### Documentation\n\n"
             "* Document super-feature ([#189](https://gitlab.com/owner/repo_name/"
             "-/issues/189)) ([`0`](https://gitlab.com/owner/repo_name/"
             "-/commit/0))"


### PR DESCRIPTION
Adding an extra new line after each header and between sections fixes the following 2 `markdownlint` ([VS Code](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint), [GitHub](https://github.com/DavidAnson/markdownlint)) errors for changelogs generated by this package:  
* [`MD022` - Headings should be surrounded by blank lines](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md022---headings-should-be-surrounded-by-blank-lines)
* [`MD032` - Lists should be surrounded by blank lines](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md032---lists-should-be-surrounded-by-blank-lines)