### PR TITLE
fix: generate markdown linter compliant changelog headers & lists

### DIFF
--- a/semantic_release/vcs_helpers.py
+++ b/semantic_release/vcs_helpers.py
@@ -208,7 +208,7 @@ def update_changelog_file(version: str, content_to_add: str):
             [
                 changelog_placeholder,
                 "",
-                f"## v{version} ({date.today():%Y-%m-%d})",
+                f"## v{version} ({date.today():%Y-%m-%d})\n",
                 content_to_add,
             ]
         ),

--- a/tests/test_vcs_helpers.py
+++ b/tests/test_vcs_helpers.py
@@ -444,7 +444,7 @@ def test_update_changelog_file_ok(mock_git, mocker):
         "\n"
         "<!--next-version-placeholder-->\n"
         "\n"
-        "## v1.0.0 (2015-08-04)\n"
+        "## v1.0.0 (2015-08-04)\n\n"
         "### Feature\n"
         "* Just a start"
     )
@@ -464,13 +464,13 @@ def test_update_changelog_file_ok(mock_git, mocker):
         "\n"
         "<!--next-version-placeholder-->\n"
         "\n"
-        f"## v2.0.0 ({date.today():%Y-%m-%d})\n"
+        f"## v2.0.0 ({date.today():%Y-%m-%d})\n\n"
         "### Fix\n"
         "* Fix a bug\n"
         "### Feature\n"
         "* Add something awesome\n"
         "\n"
-        "## v1.0.0 (2015-08-04)\n"
+        "## v1.0.0 (2015-08-04)\n\n"
         "### Feature\n"
         "* Just a start"
     )
@@ -491,7 +491,7 @@ def test_update_changelog_file_missing_file(mock_git, mocker):
         "\n"
         "<!--next-version-placeholder-->\n"
         "\n"
-        f"## v2.0.0 ({date.today():%Y-%m-%d})\n"
+        f"## v2.0.0 ({date.today():%Y-%m-%d})\n\n"
         "* Some new content\n"
     )
 
@@ -513,7 +513,7 @@ def test_update_changelog_file_missing_placeholder_but_containing_header(
         "\n"
         "<!--next-version-placeholder-->\n"
         "\n"
-        f"## v2.0.0 ({date.today():%Y-%m-%d})\n"
+        f"## v2.0.0 ({date.today():%Y-%m-%d})\n\n"
         "* Some new content\n"
     )
 
@@ -531,7 +531,7 @@ def test_update_changelog_empty_file(mock_git, mocker):
         "\n"
         "<!--next-version-placeholder-->\n"
         "\n"
-        f"## v2.0.0 ({date.today():%Y-%m-%d})\n"
+        f"## v2.0.0 ({date.today():%Y-%m-%d})\n\n"
         "* Some new content\n"
     )
 


### PR DESCRIPTION
In #594, I missed that there are 2 places where the version header is formatted, one with dates and one without.

In this PR, I add the extra newline to make the generated changelogs `markdownlint` compliant when the date is included in the header.