### PR TITLE
fix: docker build fails installing git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # This Dockerfile is only for GitHub Actions
-FROM python:3.10
+FROM python:3.10-bullseye
 
 RUN set -ex; \
     apt-get update; \


### PR DESCRIPTION
git was installed from bullseye-backports,
but base image is referencing latest python:3.10
since bookworm was recently released,
this now points at bookworm and installing the backport of git
is actually trying to downgrade, resulting in this error:

> E: Packages were downgraded and -y was used without --allow-downgrades.

> ERROR: failed to solve: process "/bin/sh -c echo \"deb http://deb.debian.org/debian bullseye-backports main\" >> /etc/apt/sources.list;     apt-get update;    apt-get install -y git/bullseye-backports" did not complete successfully: exit code: 100