### PR TITLE
fix: consider empty commits

### DIFF
--- a/semantic_release/vcs_helpers.py
+++ b/semantic_release/vcs_helpers.py
@@ -17,7 +17,7 @@ from .helpers import LoggedFunction
 from .settings import config
 
 _repo: Optional[Repo]
-_sub_directory = "."
+_sub_directory = ""
 try:
     _repo = Repo(".", search_parent_directories=True)
     if config.get("use_only_cwd_commits") and config.get("version_source") == "commit":


### PR DESCRIPTION
## The Issue

Since version `7.34.0`, empty commits are ignored when scanning commits for commit messages that should trigger releases.

## Minimal Example to Reproduce

```bash
git init
git commit -m "fix: initial commit" --allow-empty
echo "[semantic_release]" >> setup.cfg
echo "version_source = tag_only" >> setup.cfg
semantic-release version --verbosity=DEBUG
```

Output with `python-semantic-release==7.33.5` (as expected):

```
Creating new version
debug: get_current_version_by_tag()
debug: get_last_version(, pattern='(\d+\.\d+\.\d+(-beta\.\d+)?)')
debug: no version found, returning default of v0.0.0
debug: get_current_version_by_tag -> 0.0.0
debug: get_current_release_version_by_tag()
debug: get_last_version(, pattern='v?(\d+\.\d+\.\d+(?!.*-beta\.\d+))')
debug: no version found, returning default of v0.0.0
debug: get_current_release_version_by_tag -> 0.0.0
Current version: 0.0.0, Current release version: 0.0.0
debug: evaluate_version_bump('0.0.0', None)
debug: Reference v0.0.0 does not exist, considering entire history
debug: parse_commit_message('fix: initial commit')
debug: parse_commit_message -> ParsedCommit(bump=1, type='fix', scope=None, descriptions=['initial commit'], breaking_descriptions=[])
debug: Commits found since last release: 1
debug: evaluate_version_bump -> patch
debug: get_new_version('0.0.0', '0.0.0', 'patch', False, True)
debug: get_new_version -> 0.0.1
Bumping with a patch version to 0.0.1
debug: tag_new_version('0.0.1')
debug: tag_new_version ->
```

Output with `python-semantic-release==7.34.0`:

```
Creating new version
debug: get_current_version_by_tag()
debug: get_last_version(, pattern='(\d+\.\d+\.\d+(-beta\.\d+)?)')
debug: no version found, returning default of v0.0.0
debug: get_current_version_by_tag -> 0.0.0
debug: get_current_release_version_by_tag()
debug: get_last_version(, pattern='v?(\d+\.\d+\.\d+(?!.*-beta\.\d+))')
debug: no version found, returning default of v0.0.0
debug: get_current_release_version_by_tag -> 0.0.0
Current version: 0.0.0, Current release version: 0.0.0
debug: evaluate_version_bump('0.0.0', None)
debug: Reference v0.0.0 does not exist, considering entire history
debug: Commits found since last release: 0
debug: get_new_version('0.0.0', '0.0.0', None, False, True)
debug: get_new_version -> 0.0.0
No release will be made.
```

I.e. in version `7.34.0`, the empty commit with the commit message `fix: initial commit` isn't found, and the intended release isn't made.

## Reason

In `vcs_helpers.py`, the default value for `_sub_directory` (when `use_only_cwd_commits` isn't specified) is `"."`.
This is passed as the `paths` argument to `iter_commits`, which then only returns commits which have made changes in any of the files inside `"."` (the current directory). This is obviously not the case for empty commits, thus they are ignored, unlike before (until version `7.33.5`).

## Fix

By changing the default value of `_sub_directory` from `"."` to `""`, we can restore the old behaviour, since `""` is the default value for the `paths` argument of `iter_commits`. This way, no commits are ignored.
In terms of git commands, we go from using `git rev-list HEAD -- .` to using `git rev-list HEAD` to retrieve the list of commits to consider.
