### PR TITLE
refactor(changelog): update the release-compare link

### DIFF
--- a/semantic_release/changelog/compare.py
+++ b/semantic_release/changelog/compare.py
@@ -24,6 +24,6 @@ def compare_url(
 ) -> Optional[str]:
     if config.get("hvcs").lower() == "github" and previous_version:
         compare_url = get_github_compare_url(previous_version, version)
-        return f"**[See all commits in this version]({compare_url})**"
+        return f"**Full Changelog**: [`{get_formatted_tag(from_version)}...{get_formatted_tag(to_version)}`]({compare_url})"
 
     return None

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -205,6 +205,6 @@ def test_compare_url():
         return_value=["owner", "name"],
     ):
         assert compare_url(previous_version="1.0.0", version="2.0.0") == (
-            "**[See all commits in this version]"
-            "(https://github.com/owner/name/compare/v1.0.0...v2.0.0)**"
+            "**Full Changelog**: [`v1.0.0...v2.0.0`]"
+            "(https://github.com/owner/name/compare/v1.0.0...v2.0.0)"
         )


### PR DESCRIPTION
This updates the body of release comparison link. In the updated form, it's more informative and looks the same as in one generated by "Generate release notes" tool of GitHub.