### PR TITLE
fix: format tag in changelog as given in config

### DIFF
--- a/semantic_release/changelog/__init__.py
+++ b/semantic_release/changelog/__init__.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from ..helpers import LoggedFunction
 from ..settings import config, current_changelog_components
+from ..vcs_helpers import get_formatted_tag
 
 from .changelog import changelog_headers, changelog_table  # noqa isort:skip
 from .compare import compare_url  # noqa isort:skip
@@ -31,7 +32,7 @@ def markdown_changelog(
     :param header: A boolean that decides whether a version number header should be included.
     :return: The markdown formatted changelog.
     """
-    output = f"## v{version}\n\n" if header else ""
+    output = f"## {get_formatted_tag(version)}\n\n" if header else ""
 
     # Add the output of each component separated by a blank line
     output += "\n\n".join(

--- a/semantic_release/changelog/compare.py
+++ b/semantic_release/changelog/compare.py
@@ -24,6 +24,6 @@ def compare_url(
 ) -> Optional[str]:
     if config.get("hvcs").lower() == "github" and previous_version:
         compare_url = get_github_compare_url(previous_version, version)
-        return f"**[See all commits in this version]({compare_url})**"
+        return f"**Full Changelog**: [`{get_formatted_tag(from_version)}...{get_formatted_tag(to_version)}`]({compare_url})"
 
     return None

--- a/semantic_release/vcs_helpers.py
+++ b/semantic_release/vcs_helpers.py
@@ -208,7 +208,7 @@ def update_changelog_file(version: str, content_to_add: str):
             [
                 changelog_placeholder,
                 "",
-                f"## v{version} ({date.today():%Y-%m-%d})\n",
+                f"## {get_formatted_tag(version)} ({date.today():%Y-%m-%d})\n",
                 content_to_add,
             ]
         ),

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -205,6 +205,6 @@ def test_compare_url():
         return_value=["owner", "name"],
     ):
         assert compare_url(previous_version="1.0.0", version="2.0.0") == (
-            "**[See all commits in this version]"
-            "(https://github.com/owner/name/compare/v1.0.0...v2.0.0)**"
+            "**Full Changelog**: [`v1.0.0...v2.0.0`]"
+            "(https://github.com/owner/name/compare/v1.0.0...v2.0.0)"
         )


### PR DESCRIPTION
Currently, the format of release number with prefixed "v" is always applied in changelog headers, irrespective of `tag_format`).

I believe it should be fixed to keep versioning clean and consistent. 

This updates the code generating marked-down changelog, so that the version tag displayed in the release header is formatted as specified in configuration (`tag_format` variable).
