### PR TITLE
fix: invalid version in Git history should not cause a release failure

### DIFF
--- a/semantic_release/version/algorithm.py
+++ b/semantic_release/version/algorithm.py
@@ -32,9 +32,26 @@ def tags_and_versions(
     Return a list of 2-tuples, where each element is a tuple (tag, version)
     from the tags in the Git repo and their corresponding `Version` according
     to `Version.from_tag`. The returned list is sorted according to semver
-    ordering rules
+    ordering rules.
+
+    Tags which are not matched by `translator` are ignored.
     """
-    ts_and_vs = [(t, translator.from_tag(t.name)) for t in tags]
+    ts_and_vs: list[tuple[Tag, Version]] = []
+    for tag in tags:
+        try:
+            version = translator.from_tag(tag.name)
+        except NotImplementedError as e:
+            log.warning(
+                "Couldn't parse tag %s as as Version: %s",
+                tag.name,
+                str(e),
+                exc_info=log.isEnabledFor(logging.DEBUG),
+            )
+            continue
+
+        if version:
+            ts_and_vs.append((tag, version))
+
     log.info("found %s previous tags", len(ts_and_vs))
     return sorted(ts_and_vs, reverse=True, key=lambda v: v[1])
 

--- a/semantic_release/version/translator.py
+++ b/semantic_release/version/translator.py
@@ -59,18 +59,16 @@ class VersionTranslator:
             prerelease_token=self.prerelease_token,
         )
 
-    def from_tag(self, tag: str) -> Version:
+    def from_tag(self, tag: str) -> Version | None:
         """
         Return a Version instance from a Git tag, if tag_format matches the format
-        which would have generated the tag from a version.
+        which would have generated the tag from a version. Otherwise return None.
         For example, a tag of 'v1.2.3' should be matched if `tag_format = 'v{version}`,
         but not if `tag_format = staging--v{version}`.
         """
         tag_match = self.from_tag_re.match(tag)
         if not tag_match:
-            raise ValueError(
-                f"Tag {tag!r} doesn't match tag format {self.tag_format!r}"
-            )
+            return None
         raw_version_str = tag_match.group("version")
         return self.from_string(raw_version_str)
 


### PR DESCRIPTION
Addresses #626 and #628 