### PR TITLE
docs: correct version_toml example in migrating_from_v7.rst

### DIFF
--- a/docs/migrating_from_v7.rst
+++ b/docs/migrating_from_v7.rst
@@ -579,11 +579,11 @@ simply wrap the value in ``[]``:
 
    # Python Semantic Release v7 configuration
    [tool.semantic_release]
-   version_toml = "tool.poetry.version:{version}"
+   version_toml = "pyproject.toml:tool.poetry.version"
 
    # Python Semantic Release v8 configuration
    [tool.semantic_release]
-   version_toml = ["tool.poetry.version:{version}"]
+   version_toml = ["pyproject.toml:tool.poetry.version"]
 
 
 .. _breaking-tag-format-validation:


### PR DESCRIPTION
Fixes #637 