### PR TITLE
docs: clarify v8 breaking changes in GitHub action inputs

### DIFF
--- a/docs/migrating_from_v7.rst
+++ b/docs/migrating_from_v7.rst
@@ -113,24 +113,24 @@ GitHub Action:
 
 .. _breaking-github-action-removed-pypi-token:
 
-Removal of ``pypi_token`` input
-"""""""""""""""""""""""""""""""
-The ``pypi_token`` input of the GitHub action has been removed. You should
-supply the token as the value of the ``repository_username`` instead,
-and if using only the token for authentication, remember to set the
-``repository_username`` input equal to ``__token__``.
+Removal of ``pypi_token``, ``repository_username`` and ``repository_password`` inputs
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+Since the library no longer supports publishing to PyPI, the ``pypi_token``,
+``repository_username`` and ``repository_password`` inputs of the GitHub action have
+all been removed. See the above section for how to publish to PyPI using the official
+GitHub Action from the Python Packaging Authority (PyPA).
 
 .. _breaking-options-inputs:
 
-``additional_options``, ``version_options`` and ``publish_options``
-"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+Rename ``additional_options`` to ``root_options``
+"""""""""""""""""""""""""""""""""""""""""""""""""
 
 Because the purposes of the :ref:`cmd-version` and :ref:`cmd-publish` commands
 have changed, the GitHub action now performs both commands in sequence. For this
-reason, and because the usage of the CLI has changed, ``additional_options`` can
-now only supply flags to the main :ref:`cmd-main` command group, and two new inputs,
-``version_options`` and ``publish_options``, have been added to supply the
-required command-line options to the relevant commands in the GitHub Action.
+reason, and because the usage of the CLI has changed, ``additional_options`` has
+been renamed to ``root_options`` to reflect the fact that the options are for the
+main :ref:`cmd-main` command group.
 
 .. _breaking-commands:
 


### PR DESCRIPTION
Fix #642
