### PR TITLE
fix: handle missing configuration

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -6,7 +6,7 @@ Configuration
 Configuration is read from a file which can be specified using the
 :ref:`--config <cmd-main-option-config>` option to :ref:`cmd-main`. Python Semantic
 Release currently supports either TOML- or JSON-formatted configuration, and will
-attempt to detect and parse the configuration based on the file extension.
+attempt to detect the configuration format and parse it.
 
 When using a JSON-format configuration file, Python Semantic Release looks for its
 settings beneath a top-level ``semantic_release`` key; when using a TOML-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 readme = "README.rst"
 authors = [{ name = "Rolf Erik Lekang", email = "me@rolflekang.com" }]
 dependencies = [
-  "click>=7,<9",
+  "click>=8,<9",
   "gitpython>=3.0.8,<4",
   "requests>=2.25,<3",
   "jinja2>=3.1.2,<4",
@@ -62,7 +62,7 @@ test = [
   "types-pytest-lazy-fixture>=0.6.3.3",
 ]
 dev = ["tox", "isort", "black"]
-mypy = ["mypy", "types-requests", "types-click"]
+mypy = ["mypy", "types-requests"]
 
 [tool.pytest.ini_options]
 addopts = [
@@ -124,7 +124,7 @@ commands =
 [testenv:mypy]
 deps = .[mypy]
 commands =
-    mypy --ignore-missing-imports semantic_release
+    mypy semantic_release
 
 [testenv:coverage]
 deps = coverage[toml]

--- a/semantic_release/cli/config.py
+++ b/semantic_release/cli/config.py
@@ -8,7 +8,6 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, ClassVar, Dict, List, Optional, Tuple, Union
 
-import tomlkit
 from git import Actor
 from git.repo.base import Repo
 from jinja2 import Environment
@@ -39,27 +38,6 @@ from semantic_release.version.declaration import (
 )
 
 log = logging.getLogger(__name__)
-
-
-def read_toml(path: str) -> dict[str, Any]:
-    raw_text = (Path() / path).resolve().read_text(encoding="utf-8")
-    try:
-        toml_text = tomlkit.loads(raw_text)
-    except tomlkit.exceptions.TOMLKitError as exc:
-        raise InvalidConfiguration(f"File {path!r} contains invalid TOML") from exc
-
-    # Look for [tool.semantic_release]
-    cfg_text = toml_text.get("tool", {}).get("semantic_release")
-    if cfg_text is not None:
-        return cfg_text
-    # Look for [semantic_release]
-    cfg_text = toml_text.get("semantic_release")
-    if cfg_text is not None:
-        return cfg_text
-
-    raise InvalidConfiguration(
-        f"Missing keys 'tool.semantic_release' or 'semantic_release' in {path}"
-    )
 
 
 class HvcsClient(str, Enum):

--- a/semantic_release/cli/util.py
+++ b/semantic_release/cli/util.py
@@ -1,10 +1,22 @@
 """
 Utilities for command-line functionality
 """
+from __future__ import annotations
+
+import json
+import logging
 import sys
+from pathlib import Path
 from textwrap import dedent, indent
+from typing import Any
 
 import rich
+import tomlkit
+from tomlkit.exceptions import TOMLKitError
+
+from semantic_release.errors import InvalidConfiguration
+
+log = logging.getLogger(__name__)
 
 
 def rprint(msg: str) -> None:
@@ -32,3 +44,69 @@ def indented(msg: str, prefix: str = " " * 4) -> str:
     indentation in the Python source code
     """
     return indent(dedent(msg), prefix=prefix)
+
+
+def parse_toml(raw_text: str) -> dict[Any, Any]:
+    """
+    Attempts to parse raw configuration for semantic_release
+    using tomlkit.loads, raising InvalidConfiguration if the
+    TOML is invalid or there's no top level "semantic_release"
+    or "tool.semantic_release" keys
+    """
+    try:
+        toml_text = tomlkit.loads(raw_text)
+    except TOMLKitError as exc:
+        raise InvalidConfiguration(str(exc)) from exc
+
+    # Look for [tool.semantic_release]
+    cfg_text = toml_text.get("tool", {}).get("semantic_release")
+    if cfg_text is not None:
+        return cfg_text
+    # Look for [semantic_release] or return {} if not
+    # found
+    return toml_text.get("semantic_release", {})
+
+
+def load_raw_config_file(config_file: Path | str) -> dict[Any, Any]:
+    """
+    Load raw configuration as a dict from the filename specified
+    by config_filename, trying the following parsing methods:
+
+    1. try to parse with tomlkit.load (guessing it's a TOML file)
+    2. try to parse with json.load (guessing it's a JSON file)
+    3. raise InvalidConfiguration if none of the above parsing
+       methods work
+
+    This function will also raise FileNotFoundError if it is raised
+    while trying to read the specified configuration file
+    """
+
+    log.info("Loading configuration from %s", config_file)
+    raw_text = (Path() / config_file).resolve().read_text(encoding="utf-8")
+    try:
+        log.debug("Trying to parse configuration %s in TOML format", config_file)
+        return parse_toml(raw_text)
+    except InvalidConfiguration as e:
+        log.debug("Configuration %s is invalid TOML: %s", config_file, str(e))
+        log.debug("trying to parse %s as JSON", config_file)
+        try:
+            # could be a "parse_json" function but it's a one-liner here
+            return json.loads(raw_text)["semantic_release"]
+        except KeyError:
+            # valid configuration, but no "semantic_release" or "tool.semantic_release" top
+            # level key
+            log.debug(
+                "configuration has no 'semantic_release' or 'tool.semantic_release' top-level key"
+            )
+            return {}
+        except json.JSONDecodeError as jde:
+            raise InvalidConfiguration(
+                dedent(
+                    f"""
+                    None of the supported configuration parsers were able to parse
+                    the configuration file {config_file}:
+                    * TOML: {str(e)}
+                    * JSON: {str(jde)}
+                    """
+                )
+            ) from jde

--- a/tests/command_line/test_main.py
+++ b/tests/command_line/test_main.py
@@ -1,3 +1,8 @@
+import json
+import os
+from textwrap import dedent
+
+import git
 import pytest
 
 from semantic_release import __version__
@@ -30,3 +35,92 @@ def test_not_a_release_branch_exit_code_with_strict(
     repo_with_git_flow_angular_commits.git.checkout("-b", "branch-does-not-exist")
     result = cli_runner.invoke(main, ["--strict", "version", "--no-commit"])
     assert result.exit_code != 0
+
+
+@pytest.fixture
+def toml_file_with_no_configuration_for_psr(tmp_path):
+    path = tmp_path / "config.toml"
+    path.write_text(
+        dedent(
+            r"""
+            [project]
+            name = "foo"
+            version = "1.2.0"
+            """
+        )
+    )
+
+    yield path
+
+
+@pytest.fixture
+def json_file_with_no_configuration_for_psr(tmp_path):
+    path = tmp_path / "config.json"
+    path.write_text(json.dumps({"foo": [1, 2, 3]}))
+
+    yield path
+
+
+@pytest.mark.usefixtures("repo_with_git_flow_angular_commits")
+def test_default_config_is_used_when_none_in_toml_config_file(
+    cli_runner,
+    toml_file_with_no_configuration_for_psr,
+):
+    result = cli_runner.invoke(
+        main,
+        ["--noop", "--config", str(toml_file_with_no_configuration_for_psr), "version"],
+    )
+
+    assert result.exit_code == 0
+
+
+@pytest.mark.usefixtures("repo_with_git_flow_angular_commits")
+def test_default_config_is_used_when_none_in_json_config_file(
+    cli_runner,
+    json_file_with_no_configuration_for_psr,
+):
+    result = cli_runner.invoke(
+        main,
+        ["--noop", "--config", str(json_file_with_no_configuration_for_psr), "version"],
+    )
+
+    assert result.exit_code == 0
+
+
+@pytest.mark.usefixtures("repo_with_git_flow_angular_commits")
+def test_errors_when_config_file_does_not_exist_and_passed_explicitly(
+    cli_runner,
+):
+    result = cli_runner.invoke(
+        main,
+        ["--noop", "--config", "somenonexistantfile.123.txt", "version"],
+    )
+
+    assert result.exit_code == 2
+    assert "does not exist" in result.stderr
+
+
+def test_uses_default_config_when_no_config_file_found(
+    tmp_path,
+    cli_runner,
+):
+    # We have to initialise an empty git repository, as the example projects
+    # all have pyproject.toml configs which would be used by default
+    repo = git.Repo.init(tmp_path)
+    repo.git.branch("-M", "main")
+    with repo.config_writer("repository") as config:
+        config.set_value("user", "name", "semantic release testing")
+        config.set_value("user", "email", "not_a_real@email.com")
+    repo.create_remote(name="origin", url="foo@barvcs.com:user/repo.git")
+    repo.git.commit("-m", "feat: initial commit", "--allow-empty")
+
+    try:
+        os.chdir(tmp_path)
+        result = cli_runner.invoke(
+            main,
+            ["--noop", "version"],
+        )
+
+        assert result.exit_code == 0
+    finally:
+        repo.close()

--- a/tests/unit/semantic_release/cli/test_util.py
+++ b/tests/unit/semantic_release/cli/test_util.py
@@ -1,0 +1,202 @@
+import json
+from textwrap import dedent
+
+import pytest
+from pytest import lazy_fixture
+
+from semantic_release.cli.util import load_raw_config_file, parse_toml
+from semantic_release.errors import InvalidConfiguration
+
+
+@pytest.mark.parametrize(
+    "toml_text, expected",
+    [
+        (
+            dedent(
+                r"""
+                [not_the_right_key]
+                foo = "bar"
+                """
+            ),
+            {},
+        ),
+        (
+            dedent(
+                r"""
+                [semantic_release]
+                foo = "bar"
+                """
+            ),
+            {"foo": "bar"},
+        ),
+        (
+            dedent(
+                r"""
+                [tool.semantic_release]
+                abc = 123
+
+                [tool.semantic_release.foo]
+                def = 456
+                """
+            ),
+            {"abc": 123, "foo": {"def": 456}},
+        ),
+    ],
+)
+def test_parse_toml(toml_text, expected):
+    assert parse_toml(toml_text) == expected
+
+
+def test_parse_toml_raises_invalid_configuration_with_invalid_toml():
+    invalid_toml = dedent(
+        r"""
+        [semantic_release]
+        foo = bar  # this is not a valid TOML string
+        """
+    )
+
+    with pytest.raises(InvalidConfiguration):
+        parse_toml(invalid_toml)
+
+
+@pytest.fixture
+def raw_toml_config_file(tmp_path):
+    path = tmp_path / "config.toml"
+
+    path.write_text(
+        dedent(
+            r"""
+            [semantic_release]
+            foo = "bar"
+
+            [semantic_release.abc]
+            bar = "baz"
+            """
+        )
+    )
+
+    yield path
+
+
+@pytest.fixture
+def raw_pyproject_toml_config_file(tmp_path):
+    tmp_path.mkdir(exist_ok=True)
+
+    path = tmp_path / "pyproject.toml"
+
+    path.write_text(
+        dedent(
+            r"""
+            [tool.semantic_release]
+            foo = "bar"
+
+            [tool.semantic_release.abc]
+            bar = "baz"
+            """
+        )
+    )
+
+    yield path
+
+
+@pytest.fixture
+def raw_json_config_file(tmp_path):
+    tmp_path.mkdir(exist_ok=True)
+
+    path = tmp_path / ".releaserc"
+
+    path.write_text(
+        json.dumps(
+            {"semantic_release": {"foo": "bar", "abc": {"bar": "baz"}}}, indent=4
+        )
+    )
+
+    yield path
+
+
+@pytest.fixture
+def invalid_toml_config_file(tmp_path):
+    path = tmp_path / "config.toml"
+
+    path.write_text(
+        dedent(
+            r"""
+            [semantic_release]
+            foo = bar  # no quotes == invalid
+
+            [semantic_release.abc]
+            bar = "baz"
+            """
+        )
+    )
+
+    yield path
+
+
+@pytest.fixture
+def invalid_json_config_file(tmp_path):
+    tmp_path.mkdir(exist_ok=True)
+
+    path = tmp_path / "releaserc.json"
+
+    path.write_text(
+        dedent(
+            r"""
+            {"semantic_release": {foo: "bar", "abc": {bar: "baz"}}}
+            """
+        )
+    )
+
+    yield path
+
+
+@pytest.fixture
+def invalid_other_config_file(tmp_path):
+    # e.g. XML
+    path = tmp_path / "config.xml"
+
+    path.write_text(
+        dedent(
+            r"""
+            <semantic_release>
+                <foo>bar</foo>
+                <abc>
+                    <bar>baz</bar>
+                </abc>
+            </semantic_release>
+            """
+        )
+    )
+
+    yield path
+
+
+@pytest.mark.parametrize(
+    "raw_config_file, expected",
+    [
+        (lazy_fixture("raw_toml_config_file"), {"foo": "bar", "abc": {"bar": "baz"}}),
+        (
+            lazy_fixture("raw_pyproject_toml_config_file"),
+            {"foo": "bar", "abc": {"bar": "baz"}},
+        ),
+        (
+            lazy_fixture("raw_json_config_file"),
+            {"semantic_release": {"foo": "bar", "abc": {"bar": "baz"}}},
+        ),
+    ],
+)
+def test_load_raw_config_file_loads_config(raw_config_file, expected):
+    assert load_raw_config_file(raw_config_file) == expected
+
+
+@pytest.mark.parametrize(
+    "raw_config_file",
+    [
+        lazy_fixture("invalid_toml_config_file"),
+        lazy_fixture("invalid_json_config_file"),
+        lazy_fixture("invalid_other_config_file"),
+    ],
+)
+def test_load_raw_config_file_loads_config(raw_config_file):
+    with pytest.raises(InvalidConfiguration):
+        load_raw_config_file(raw_config_file)


### PR DESCRIPTION
With this change, PSR will no longer error if it cannot find appropriate configuration in the default
pyproject.toml file, or in the file specified by -c/ --config when that option is given. Instead it will use the default configuration values