### PR TITLE
feat(cli): correct --prerelease use and add --as-prerelease

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -173,38 +173,109 @@ number (``1.0.0``).
 
 .. _cmd-version-option-force-level:
 
-``--major/--minor/--patch``
-***************************
+``--major/--minor/--patch/--prerelease``
+****************************************
 
-Force the next version to increment the major, minor or patch digit, respectively.
-These flags are optional but mutually exclusive, so only one may be supplied, or none at all.
-Using these flags overrides the usual calculation for the next version; this can be useful, say,
-when a project wants to release its initial 1.0.0 version.
+Force the next version to increment the major, minor or patch digits, or the prerelease revision,
+respectively. These flags are optional but mutually exclusive, so only one may be supplied, or
+none at all. Using these flags overrides the usual calculation for the next version; this can
+be useful, say, when a project wants to release its initial 1.0.0 version.
 
 .. warning::
-    Using these flags will override the value of prerelease, **regardless of your configuration or the
-    current version**. To produce a prerelease with the appropriate digit incremented you should also
-    supply the :ref:`cmd-version-option-prerelease` flag. If you do not, using these flags will force
+
+    Using these flags will override the configured value of ``prerelease`` (configured
+    in your :ref:`Release Group<multibranch-releases-configuring>`),
+    **regardless of your configuration or the current version**.
+
+    To produce a prerelease with the appropriate digit incremented you should also
+    supply the :ref:`cmd-version-option-as-prerelease` flag. If you do not, using these flags will force
     a full (non-prerelease) version to be created.
+
+For example, suppose your project's current version is ``0.2.1-rc.1``. The following
+shows how these options can be combined with ``--as-prerelease`` to force different
+versions:
+
+.. code-block:: bash
+
+   semantic-release version --prerelease --print
+   # 0.2.1-rc.2
+
+   semantic-release version --patch --print
+   # 0.2.2
+
+   semantic-release version --minor --print
+   # 0.3.0
+
+   semantic-release version --major --print
+   # 1.0.0
+
+   semantic-release version --minor --as-prerelease --print
+   # 0.3.0-rc.1
+
+   semantic-release version --prerelease --as-prerelease --print
+   # 0.2.1-rc.2
 
 These options are forceful overrides, but there is no action required for subsequent releases
 performed using the usual calculation algorithm.
+
+Supplying ``--prerelease`` will cause Python Semantic Release to scan your project history
+for any previous prereleases with the same major, minor and patch versions as the latest
+version and the same :ref:`prerelease token<cmd-version-option-prerelease-token>` as the
+one passed by command-line or configuration. If one is not found, ``--prerelease`` will
+produce the next version according to the following format:
+
+.. code-block:: python
+
+    f"{latest_version.major}.{latest_version.minor}.{latest_version.patch}-{prerelease_token}.1"
+
+However, if Python Semantic Release identifies a previous *prerelease* version with the same
+major, minor and patch digits as the latest version, *and* the same prerelease token as the
+one supplied by command-line or configuration, then Python Semantic Release will increment
+the revision found on that previous prerelease version in its new version.
+
+For example, if ``"0.2.1-rc.1"`` and already exists as a previous version, and the latest version
+is ``"0.2.1"``, invoking the following command will produce ``"0.2.1-rc.2"``:
+
+.. code-block:: bash
+
+   semantic-release version --prerelease --prerelease-token "rc" --print
+
+.. warning::
+
+   This is true irrespective of the branch from which ``"0.2.1-rc.1"`` was released from.
+   The check for previous prereleases "leading up to" this normal version is intended to
+   help prevent collisions in git tags to an extent, but isn't foolproof. As the example
+   shows it is possible to release a prerelease for a normal version that's already been
+   released when using this flag, which would in turn be ignored by tools selecting
+   versions by `SemVer precedence rules`_.
+
+
+.. _SemVer precedence rules: https://semver.org/#spec-item-11
+
 
 .. seealso::
     - :ref:`configuration`
     - :ref:`config-branches`
 
-.. _cmd-version-option-prerelease:
+.. _cmd-version-option-as-prerelease:
 
-``--prerelease``
-****************
+``--as-prerelease``
+*******************
 
-Force the next version to be a prerelease. As with :ref:`cmd-version-option-force-level`, this option
+After performing the normal calculation of the next version, convert the resulting next version
+to a prerelease before applying it. As with :ref:`cmd-version-option-force-level`, this option
 is a forceful override, but no action is required to resume calculating versions as normal on the
-subsequent releases.
+subsequent releases. The main distinction between ``--prerelease`` and ``--as-prerelease`` is that
+the latter will not *force* a new version if one would not have been released without supplying
+the flag.
+
+This can be useful when making a single prerelease on a branch that would typically release
+normal versions.
 
 If not specified in :ref:`cmd-version-option-prerelease-token`, the prerelease token is idenitified using the
 :ref:`Multibranch Release Configuration <multibranch-releases-configuring>`
+
+See the examples alongside :ref:`cmd-version-option-force-level` for how to use this flag.
 
 .. _cmd-version-option-prerelease-token:
 

--- a/docs/multibranch_releases.rst
+++ b/docs/multibranch_releases.rst
@@ -163,5 +163,5 @@ This would lead to versions such as ``1.1.1+main.20221127`` or ``2.0.0-rc.4+2.x.
 
 .. note::
    Remember that is always possible to override the release rules configured by using
-   the :ref:`cmd-version-option-force-level` and :ref:`cmd-version-option-prerelease`
+   the :ref:`cmd-version-option-force-level` and :ref:`cmd-version-option-as-prerelease`
    flags.

--- a/tests/command_line/test_version.py
+++ b/tests/command_line/test_version.py
@@ -102,14 +102,16 @@ def test_version_noop_is_noop(
             for cli_args, expected_stdout in (
                 ([], "0.1.0"),
                 (["--build-metadata", "build.12345"], "0.1.0+build.12345"),
+                (["--prerelease"], "0.0.0-rc.1"),
                 (["--patch"], "0.0.1"),
                 (["--minor"], "0.1.0"),
                 (["--major"], "1.0.0"),
-                (["--patch", "--prerelease"], "0.0.1-rc.1"),
-                (["--minor", "--prerelease"], "0.1.0-rc.1"),
-                (["--major", "--prerelease"], "1.0.0-rc.1"),
+                (["--prerelease", "--as-prerelease"], "0.0.0-rc.1"),
+                (["--patch", "--as-prerelease"], "0.0.1-rc.1"),
+                (["--minor", "--as-prerelease"], "0.1.0-rc.1"),
+                (["--major", "--as-prerelease"], "1.0.0-rc.1"),
                 (
-                    ["--patch", "--prerelease", "--prerelease-token", "beta"],
+                    ["--patch", "--as-prerelease", "--prerelease-token", "beta"],
                     "0.0.1-beta.1",
                 ),
             )
@@ -123,14 +125,16 @@ def test_version_noop_is_noop(
             for cli_args, expected_stdout in (
                 ([], "0.1.2"),
                 (["--build-metadata", "build.12345"], "0.1.2+build.12345"),
+                (["--prerelease"], "0.1.1-rc.1"),
                 (["--patch"], "0.1.2"),
                 (["--minor"], "0.2.0"),
                 (["--major"], "1.0.0"),
-                (["--patch", "--prerelease"], "0.1.2-rc.1"),
-                (["--minor", "--prerelease"], "0.2.0-rc.1"),
-                (["--major", "--prerelease"], "1.0.0-rc.1"),
+                (["--prerelease", "--as-prerelease"], "0.1.1-rc.1"),
+                (["--patch", "--as-prerelease"], "0.1.2-rc.1"),
+                (["--minor", "--as-prerelease"], "0.2.0-rc.1"),
+                (["--major", "--as-prerelease"], "1.0.0-rc.1"),
                 (
-                    ["--patch", "--prerelease", "--prerelease-token", "beta"],
+                    ["--patch", "--as-prerelease", "--prerelease-token", "beta"],
                     "0.1.2-beta.1",
                 ),
             )
@@ -144,14 +148,17 @@ def test_version_noop_is_noop(
             for cli_args, expected_stdout in (
                 ([], "0.2.1"),
                 (["--build-metadata", "build.12345"], "0.2.1+build.12345"),
+                # There is already a 0.2.0-rc.1
+                (["--prerelease"], "0.2.0-rc.2"),
                 (["--patch"], "0.2.1"),
                 (["--minor"], "0.3.0"),
                 (["--major"], "1.0.0"),
-                (["--patch", "--prerelease"], "0.2.1-rc.1"),
-                (["--minor", "--prerelease"], "0.3.0-rc.1"),
-                (["--major", "--prerelease"], "1.0.0-rc.1"),
+                (["--prerelease", "--as-prerelease"], "0.2.0-rc.2"),
+                (["--patch", "--as-prerelease"], "0.2.1-rc.1"),
+                (["--minor", "--as-prerelease"], "0.3.0-rc.1"),
+                (["--major", "--as-prerelease"], "1.0.0-rc.1"),
                 (
-                    ["--patch", "--prerelease", "--prerelease-token", "beta"],
+                    ["--patch", "--as-prerelease", "--prerelease-token", "beta"],
                     "0.2.1-beta.1",
                 ),
             )
@@ -167,15 +174,17 @@ def test_version_noop_is_noop(
             for cli_args, expected_stdout in (
                 ([], "0.3.0-beta.2"),
                 (["--build-metadata", "build.12345"], "0.3.0-beta.2+build.12345"),
+                (["--prerelease"], "0.3.0-beta.2"),
                 (["--patch"], "0.3.1"),
                 (["--minor"], "0.4.0"),
                 (["--major"], "1.0.0"),
-                (["--patch", "--prerelease"], "0.3.1-beta.1"),
-                (["--minor", "--prerelease"], "0.4.0-beta.1"),
-                (["--major", "--prerelease"], "1.0.0-beta.1"),
+                (["--prerelease", "--as-prerelease"], "0.3.0-beta.2"),
+                (["--patch", "--as-prerelease"], "0.3.1-beta.1"),
+                (["--minor", "--as-prerelease"], "0.4.0-beta.1"),
+                (["--major", "--as-prerelease"], "1.0.0-beta.1"),
                 (
-                    ["--patch", "--prerelease", "--prerelease-token", "beta"],
-                    "0.3.1-beta.1",
+                    ["--patch", "--as-prerelease", "--prerelease-token", "rc"],
+                    "0.3.1-rc.1",
                 ),
             )
         ],
@@ -188,14 +197,16 @@ def test_version_noop_is_noop(
             for cli_args, expected_stdout in (
                 ([], "1.2.0-alpha.3"),
                 (["--build-metadata", "build.12345"], "1.2.0-alpha.3+build.12345"),
+                (["--prerelease"], "1.2.0-alpha.3"),
                 (["--patch"], "1.2.1"),
                 (["--minor"], "1.3.0"),
                 (["--major"], "2.0.0"),
-                (["--patch", "--prerelease"], "1.2.1-alpha.1"),
-                (["--minor", "--prerelease"], "1.3.0-alpha.1"),
-                (["--major", "--prerelease"], "2.0.0-alpha.1"),
+                (["--prerelease", "--as-prerelease"], "1.2.0-alpha.3"),
+                (["--patch", "--as-prerelease"], "1.2.1-alpha.1"),
+                (["--minor", "--as-prerelease"], "1.3.0-alpha.1"),
+                (["--major", "--as-prerelease"], "2.0.0-alpha.1"),
                 (
-                    ["--patch", "--prerelease", "--prerelease-token", "beta"],
+                    ["--patch", "--as-prerelease", "--prerelease-token", "beta"],
                     "1.2.1-beta.1",
                 ),
             )
@@ -209,14 +220,16 @@ def test_version_noop_is_noop(
             for cli_args, expected_stdout in (
                 ([], "1.1.0-alpha.4"),
                 (["--build-metadata", "build.12345"], "1.1.0-alpha.4+build.12345"),
+                (["--prerelease"], "1.1.0-alpha.4"),
                 (["--patch"], "1.1.1"),
                 (["--minor"], "1.2.0"),
                 (["--major"], "2.0.0"),
-                (["--patch", "--prerelease"], "1.1.1-alpha.1"),
-                (["--minor", "--prerelease"], "1.2.0-alpha.1"),
-                (["--major", "--prerelease"], "2.0.0-alpha.1"),
+                (["--prerelease", "--as-prerelease"], "1.1.0-alpha.4"),
+                (["--patch", "--as-prerelease"], "1.1.1-alpha.1"),
+                (["--minor", "--as-prerelease"], "1.2.0-alpha.1"),
+                (["--major", "--as-prerelease"], "2.0.0-alpha.1"),
                 (
-                    ["--patch", "--prerelease", "--prerelease-token", "beta"],
+                    ["--patch", "--as-prerelease", "--prerelease-token", "beta"],
                     "1.1.1-beta.1",
                 ),
             )
@@ -291,14 +304,16 @@ def test_version_already_released_no_push(repo: Repo, cli_runner: CliRunner):
             )
             for cli_args, expected_stdout in (
                 (["--build-metadata", "build.12345"], "0.1.0+build.12345"),
+                (["--prerelease"], "0.0.0-rc.1"),
                 (["--patch"], "0.0.1"),
                 (["--minor"], "0.1.0"),
                 (["--major"], "1.0.0"),
-                (["--patch", "--prerelease"], "0.0.1-rc.1"),
-                (["--minor", "--prerelease"], "0.1.0-rc.1"),
-                (["--major", "--prerelease"], "1.0.0-rc.1"),
+                (["--prerelease", "--as-prerelease"], "0.0.0-rc.1"),
+                (["--patch", "--as-prerelease"], "0.0.1-rc.1"),
+                (["--minor", "--as-prerelease"], "0.1.0-rc.1"),
+                (["--major", "--as-prerelease"], "1.0.0-rc.1"),
                 (
-                    ["--patch", "--prerelease", "--prerelease-token", "beta"],
+                    ["--patch", "--as-prerelease", "--prerelease-token", "beta"],
                     "0.0.1-beta.1",
                 ),
             )
@@ -311,14 +326,16 @@ def test_version_already_released_no_push(repo: Repo, cli_runner: CliRunner):
             )
             for cli_args, expected_stdout in (
                 (["--build-metadata", "build.12345"], "0.1.1+build.12345"),
+                (["--prerelease"], "0.1.1-rc.1"),
                 (["--patch"], "0.1.2"),
                 (["--minor"], "0.2.0"),
                 (["--major"], "1.0.0"),
-                (["--patch", "--prerelease"], "0.1.2-rc.1"),
-                (["--minor", "--prerelease"], "0.2.0-rc.1"),
-                (["--major", "--prerelease"], "1.0.0-rc.1"),
+                (["--prerelease", "--as-prerelease"], "0.1.1-rc.1"),
+                (["--patch", "--as-prerelease"], "0.1.2-rc.1"),
+                (["--minor", "--as-prerelease"], "0.2.0-rc.1"),
+                (["--major", "--as-prerelease"], "1.0.0-rc.1"),
                 (
-                    ["--patch", "--prerelease", "--prerelease-token", "beta"],
+                    ["--patch", "--as-prerelease", "--prerelease-token", "beta"],
                     "0.1.2-beta.1",
                 ),
             )
@@ -331,14 +348,17 @@ def test_version_already_released_no_push(repo: Repo, cli_runner: CliRunner):
             )
             for cli_args, expected_stdout in (
                 (["--build-metadata", "build.12345"], "0.2.0+build.12345"),
+                # There is already a 0.2.0-rc.1
+                (["--prerelease"], "0.2.0-rc.2"),
                 (["--patch"], "0.2.1"),
                 (["--minor"], "0.3.0"),
                 (["--major"], "1.0.0"),
-                (["--patch", "--prerelease"], "0.2.1-rc.1"),
-                (["--minor", "--prerelease"], "0.3.0-rc.1"),
-                (["--major", "--prerelease"], "1.0.0-rc.1"),
+                (["--prerelease", "--as-prerelease"], "0.2.0-rc.2"),
+                (["--patch", "--as-prerelease"], "0.2.1-rc.1"),
+                (["--minor", "--as-prerelease"], "0.3.0-rc.1"),
+                (["--major", "--as-prerelease"], "1.0.0-rc.1"),
                 (
-                    ["--patch", "--prerelease", "--prerelease-token", "beta"],
+                    ["--patch", "--as-prerelease", "--prerelease-token", "beta"],
                     "0.2.1-beta.1",
                 ),
             )
@@ -353,15 +373,17 @@ def test_version_already_released_no_push(repo: Repo, cli_runner: CliRunner):
             )
             for cli_args, expected_stdout in (
                 (["--build-metadata", "build.12345"], "0.3.0-beta.1+build.12345"),
+                (["--prerelease"], "0.3.0-beta.2"),
                 (["--patch"], "0.3.1"),
                 (["--minor"], "0.4.0"),
                 (["--major"], "1.0.0"),
-                (["--patch", "--prerelease"], "0.3.1-beta.1"),
-                (["--minor", "--prerelease"], "0.4.0-beta.1"),
-                (["--major", "--prerelease"], "1.0.0-beta.1"),
+                (["--prerelease", "--as-prerelease"], "0.3.0-beta.2"),
+                (["--patch", "--as-prerelease"], "0.3.1-beta.1"),
+                (["--minor", "--as-prerelease"], "0.4.0-beta.1"),
+                (["--major", "--as-prerelease"], "1.0.0-beta.1"),
                 (
-                    ["--patch", "--prerelease", "--prerelease-token", "beta"],
-                    "0.3.1-beta.1",
+                    ["--patch", "--as-prerelease", "--prerelease-token", "rc"],
+                    "0.3.1-rc.1",
                 ),
             )
         ],
@@ -373,14 +395,16 @@ def test_version_already_released_no_push(repo: Repo, cli_runner: CliRunner):
             )
             for cli_args, expected_stdout in (
                 (["--build-metadata", "build.12345"], "1.2.0-alpha.2+build.12345"),
+                (["--prerelease"], "1.2.0-alpha.3"),
                 (["--patch"], "1.2.1"),
                 (["--minor"], "1.3.0"),
                 (["--major"], "2.0.0"),
-                (["--patch", "--prerelease"], "1.2.1-alpha.1"),
-                (["--minor", "--prerelease"], "1.3.0-alpha.1"),
-                (["--major", "--prerelease"], "2.0.0-alpha.1"),
+                (["--prerelease", "--as-prerelease"], "1.2.0-alpha.3"),
+                (["--patch", "--as-prerelease"], "1.2.1-alpha.1"),
+                (["--minor", "--as-prerelease"], "1.3.0-alpha.1"),
+                (["--major", "--as-prerelease"], "2.0.0-alpha.1"),
                 (
-                    ["--patch", "--prerelease", "--prerelease-token", "beta"],
+                    ["--patch", "--as-prerelease", "--prerelease-token", "beta"],
                     "1.2.1-beta.1",
                 ),
             )
@@ -393,14 +417,16 @@ def test_version_already_released_no_push(repo: Repo, cli_runner: CliRunner):
             )
             for cli_args, expected_stdout in (
                 (["--build-metadata", "build.12345"], "1.1.0-alpha.3+build.12345"),
+                (["--prerelease"], "1.1.0-alpha.4"),
                 (["--patch"], "1.1.1"),
                 (["--minor"], "1.2.0"),
                 (["--major"], "2.0.0"),
-                (["--patch", "--prerelease"], "1.1.1-alpha.1"),
-                (["--minor", "--prerelease"], "1.2.0-alpha.1"),
-                (["--major", "--prerelease"], "2.0.0-alpha.1"),
+                (["--prerelease", "--as-prerelease"], "1.1.0-alpha.4"),
+                (["--patch", "--as-prerelease"], "1.1.1-alpha.1"),
+                (["--minor", "--as-prerelease"], "1.2.0-alpha.1"),
+                (["--major", "--as-prerelease"], "2.0.0-alpha.1"),
                 (
-                    ["--patch", "--prerelease", "--prerelease-token", "beta"],
+                    ["--patch", "--as-prerelease", "--prerelease-token", "beta"],
                     "1.1.1-beta.1",
                 ),
             )

--- a/tests/command_line/test_version.py
+++ b/tests/command_line/test_version.py
@@ -793,7 +793,7 @@ def test_version_only_update_files_no_git_actions(
 def test_version_print_last_released_prints_version(
     repo_with_single_branch_tag_commits: Repo, cli_runner: CliRunner
 ):
-    result = cli_runner.invoke(main, [version.name, "--print-last-released"])
+    result = cli_runner.invoke(main, [version_subcmd, "--print-last-released"])
     assert result.exit_code == 0
     assert result.stdout == "0.1.1\n"
 
@@ -809,7 +809,7 @@ def test_version_print_last_released_prints_released_if_commits(
     repo_with_single_branch_tag_commits.git.add(str(new_file.resolve()))
     repo_with_single_branch_tag_commits.git.commit(m="fix: temp new file")
 
-    result = cli_runner.invoke(main, [version.name, "--print-last-released"])
+    result = cli_runner.invoke(main, [version_subcmd, "--print-last-released"])
     assert result.exit_code == 0
     assert result.stdout == "0.1.1\n"
 
@@ -817,7 +817,7 @@ def test_version_print_last_released_prints_released_if_commits(
 def test_version_print_last_released_prints_nothing_if_no_tags(
     caplog, repo_with_no_tags_angular_commits: Repo, cli_runner: CliRunner
 ):
-    result = cli_runner.invoke(main, [version.name, "--print-last-released"])
+    result = cli_runner.invoke(main, [version_subcmd, "--print-last-released"])
     assert result.exit_code == 0
     assert result.stdout == ""
     assert "No release tags found." in caplog.text


### PR DESCRIPTION
Prior to this change, --prerelease performed the role that --as-prerelease now does, which was an unintentional breaking change to the CLI compared to v7.

--prerelease now forces the next version to increment the prerelease revision, which makes it consistent with --patch, --minor and --major, while --as-prerelease allows for the usual next version to be converted to a prerelease befoer it is applied to the project

Resolves: #639 