### PR TITLE
docs: add Python 3.11 to classifiers in metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
 ]
 readme = "README.rst"
 authors = [{ name = "Rolf Erik Lekang", email = "me@rolflekang.com" }]


### PR DESCRIPTION
Hi there, my first PR to the project.

The tests in GitHub Actions run on Python 3.11 as well. I guess you should add it to the project metadata then.