### PR TITLE
fix(changelog): use base version without tag format by default

### DIFF
--- a/semantic_release/data/templates/CHANGELOG.md.j2
+++ b/semantic_release/data/templates/CHANGELOG.md.j2
@@ -11,7 +11,7 @@
 {% endif %}{% endfor %}{% endfor %}{% endif %}
 {% for version, release in context.history.released.items() %}
 {# RELEASED #}
-## {{ version.as_base_version() }} ({{ release.tagged_date.strftime("%Y-%m-%d") }})
+## {{ version.as_semver_tag() }} ({{ release.tagged_date.strftime("%Y-%m-%d") }})
 {% for type_, commits in release["elements"] | dictsort %}
 ### {{ type_ | capitalize }}
 {% for commit in commits %}{% if type_ != "unknown" %}

--- a/semantic_release/data/templates/CHANGELOG.md.j2
+++ b/semantic_release/data/templates/CHANGELOG.md.j2
@@ -11,7 +11,7 @@
 {% endif %}{% endfor %}{% endfor %}{% endif %}
 {% for version, release in context.history.released.items() %}
 {# RELEASED #}
-## {{ version.as_tag() }} ({{ release.tagged_date.strftime("%Y-%m-%d") }})
+## {{ version.as_base_version() }} ({{ release.tagged_date.strftime("%Y-%m-%d") }})
 {% for type_, commits in release["elements"] | dictsort %}
 ### {{ type_ | capitalize }}
 {% for commit in commits %}{% if type_ != "unknown" %}

--- a/semantic_release/version/version.py
+++ b/semantic_release/version/version.py
@@ -205,6 +205,9 @@ class Version:
     def as_tag(self) -> str:
         return self.tag_format.format(version=str(self))
 
+    def as_base_version(self) -> str:
+        return "v{version}".format(version=str(self))
+
     def bump(self, level: LevelBump) -> Version:
         """
         Return a new Version instance according to the level specified to bump.

--- a/semantic_release/version/version.py
+++ b/semantic_release/version/version.py
@@ -205,7 +205,7 @@ class Version:
     def as_tag(self) -> str:
         return self.tag_format.format(version=str(self))
 
-    def as_base_version(self) -> str:
+    def as_semver_tag(self) -> str:
         return "v{version}".format(version=str(self))
 
     def bump(self, level: LevelBump) -> Version:

--- a/tests/fixtures/git_repo.py
+++ b/tests/fixtures/git_repo.py
@@ -942,6 +942,89 @@ def repo_with_git_flow_and_release_channels_angular_commits(
 
 
 @pytest.fixture
+def repo_with_git_flow_and_release_channels_angular_commits_using_tag_format(
+    git_repo_factory, file_in_repo
+):
+    git_repo = git_repo_factory()
+
+    add_text_to_file(git_repo, file_in_repo)
+    git_repo.git.commit(m="Initial commit")
+
+    add_text_to_file(git_repo, file_in_repo)
+    git_repo.git.commit(m=COMMIT_MESSAGE.format(version="0.1.0"))
+    git_repo.git.tag("vpy0.1.0", m="vpy0.1.0")
+
+    # Do a prerelease
+    add_text_to_file(git_repo, file_in_repo)
+    git_repo.git.commit(m="fix: add some more text")
+    add_text_to_file(git_repo, file_in_repo)
+    git_repo.git.commit(m=COMMIT_MESSAGE.format(version="0.1.1-rc.1"))
+    git_repo.git.tag("vpy0.1.1-rc.1", m="vpy0.1.1-rc.1")
+
+    # Do a prerelease
+    add_text_to_file(git_repo, file_in_repo)
+    git_repo.git.commit(m="feat!: add some more text")
+    add_text_to_file(git_repo, file_in_repo)
+    git_repo.git.commit(m=COMMIT_MESSAGE.format(version="1.0.0-rc.1"))
+    git_repo.git.tag("vpy1.0.0-rc.1", m="vpy1.0.0-rc.1")
+
+    # Do a full release
+    add_text_to_file(git_repo, file_in_repo)
+    git_repo.git.commit(m="feat: add some more text")
+    add_text_to_file(git_repo, file_in_repo)
+    git_repo.git.commit(m=COMMIT_MESSAGE.format(version="1.0.0"))
+    git_repo.git.tag("vpy1.0.0", m="vpy1.0.0")
+
+    assert git_repo.commit("vpy1.0.0").hexsha == git_repo.head.commit.hexsha
+
+    # Suppose branch "dev" has prerelease suffix of "rc"
+    git_repo.create_head("dev")
+    git_repo.heads.dev.checkout()
+
+    add_text_to_file(git_repo, file_in_repo)
+    git_repo.git.commit(m="feat: (dev) add some more text")
+    add_text_to_file(git_repo, file_in_repo)
+    git_repo.git.commit(m=COMMIT_MESSAGE.format(version="1.1.0-rc.1"))
+    git_repo.git.tag("vpy1.1.0-rc.1", m="vpy1.1.0-rc.1")
+
+    add_text_to_file(git_repo, file_in_repo)
+    git_repo.git.commit(m="fix: (dev) add some more text")
+    add_text_to_file(git_repo, file_in_repo)
+    git_repo.git.commit(m=COMMIT_MESSAGE.format(version="1.1.0-rc.2"))
+    git_repo.git.tag("vpy1.1.0-rc.2", m="vpy1.1.0-rc.2")
+
+    assert git_repo.commit("vpy1.1.0-rc.2").hexsha == git_repo.head.commit.hexsha
+
+    # Suppose branch "feature" has prerelease suffix of "alpha"
+    git_repo.create_head("feature")
+    git_repo.heads.feature.checkout()
+
+    # Do a prerelease on the branch
+    add_text_to_file(git_repo, file_in_repo)
+    git_repo.git.commit(m="feat: (feature) add some more text")
+    add_text_to_file(git_repo, file_in_repo)
+    git_repo.git.commit(m=COMMIT_MESSAGE.format(version="1.1.0-alpha.1"))
+    git_repo.git.tag("vpy1.1.0-alpha.1", m="vpy1.1.0-alpha.1")
+
+    add_text_to_file(git_repo, file_in_repo)
+    git_repo.git.commit(m="feat: (feature) add some more text")
+    add_text_to_file(git_repo, file_in_repo)
+    git_repo.git.commit(m=COMMIT_MESSAGE.format(version="1.1.0-alpha.2"))
+    git_repo.git.tag("vpy1.1.0-alpha.2", m="vpy1.1.0-alpha.2")
+
+    add_text_to_file(git_repo, file_in_repo)
+    git_repo.git.commit(m="fix: (feature) add some more text")
+    add_text_to_file(git_repo, file_in_repo)
+    git_repo.git.commit(m=COMMIT_MESSAGE.format(version="1.1.0-alpha.3"))
+    git_repo.git.tag("vpy1.1.0-alpha.3", m="vpy1.1.0-alpha.3")
+
+    assert git_repo.commit("vpy1.1.0-alpha.3").hexsha == git_repo.head.commit.hexsha
+    assert git_repo.active_branch.name == "feature"
+    yield git_repo
+    git_repo.close()
+
+
+@pytest.fixture
 def repo_with_git_flow_and_release_channels_emoji_commits(
     git_repo_factory, file_in_repo
 ):

--- a/tests/unit/semantic_release/changelog/TEST_CHANGELOG.md.j2
+++ b/tests/unit/semantic_release/changelog/TEST_CHANGELOG.md.j2
@@ -13,7 +13,7 @@
 {% endif %}{% endfor %}
 {% endfor %}{% endif %}
 {% for version, release in context.history.released.items() %}
-## {{ version.as_tag() }} ({{ release.tagged_date.strftime("%Y-%m-%d") }})
+## {{ version.as_base_version() }} ({{ release.tagged_date.strftime("%Y-%m-%d") }})
 {% for type_, commits in release["elements"] | dictsort %}
 ### {{ type_ | capitalize }}
 {% for commit in commits %}{% if type_ != "unknown" %}

--- a/tests/unit/semantic_release/changelog/TEST_CHANGELOG.md.j2
+++ b/tests/unit/semantic_release/changelog/TEST_CHANGELOG.md.j2
@@ -13,7 +13,7 @@
 {% endif %}{% endfor %}
 {% endfor %}{% endif %}
 {% for version, release in context.history.released.items() %}
-## {{ version.as_base_version() }} ({{ release.tagged_date.strftime("%Y-%m-%d") }})
+## {{ version.as_semver_tag() }} ({{ release.tagged_date.strftime("%Y-%m-%d") }})
 {% for type_, commits in release["elements"] | dictsort %}
 ### {{ type_ | capitalize }}
 {% for commit in commits %}{% if type_ != "unknown" %}

--- a/tests/unit/semantic_release/changelog/test_default_changelog.py
+++ b/tests/unit/semantic_release/changelog/test_default_changelog.py
@@ -87,3 +87,19 @@ def test_default_changelog_template(
     context.bind_to_environment(env)
     actual_content = env.from_string(default_changelog_template).render()
     assert actual_content == EXPECTED_CONTENT
+
+def test_default_changelog_template_using_tag_format(
+    repo_with_git_flow_and_release_channels_angular_commits_using_tag_format, default_angular_parser
+):
+    repo = repo_with_git_flow_and_release_channels_angular_commits_using_tag_format
+    env = environment(trim_blocks=True, lstrip_blocks=True, keep_trailing_newline=True)
+    rh = ReleaseHistory.from_git_history(
+        repo=repo, translator=VersionTranslator(tag_format="vpy{version}"), commit_parser=default_angular_parser
+    )
+    context = make_changelog_context(
+        hvcs_client=Github(remote_url=repo.remote().url), release_history=rh
+    )
+    context.bind_to_environment(env)
+
+    actual_content = env.from_string(default_changelog_template).render()
+    assert actual_content == EXPECTED_CONTENT


### PR DESCRIPTION
when release notes are generated, tag version is set instead of baser version. Before breaking change we were having base version format "v{version}" that reflects the actual published version. I think tag formatting is used for avoiding multi packages conflicts in the same repo.