### PR TITLE
docs: Fix typo missing 's' in version_variable[s] in configuration.rst

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -304,7 +304,7 @@ specifed in ``file:variable`` format. For example:
 .. code-block:: toml
 
     [tool.semantic_release]
-    version_variable = [
+    version_variables = [
         "semantic_release/__init__.py:__version__",
         "docs/conf.py:version",
     ]


### PR DESCRIPTION
This was the reason why my versions would not get updated in `version.py` - I followed _the docs_, and _the docs_ had a typo ;)