### PR TITLE
chore(deps): remove obsolete dataclasses dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
   "python-gitlab>=2,<4",
   "tomlkit~=0.10",
   "dotty-dict>=1.3.0,<2",
-  "dataclasses==0.8; python_version < '3.7.0'",
   "importlib-resources==5.7",
   "pydantic>=1.10.2,<2",
   "rich>=12.5.1",


### PR DESCRIPTION
Hi there,

I think if python-semantic-release officially supports Python >= 3.7, you can get rid of the explicit `dataclasses` dependency (python_version < '3.7.0').  Is that right?

Feel free to close, if you still want to support older versions.