### PR TITLE
Always strip url scheme from domain

### DIFF
--- a/semantic_release/hvcs/gitea.py
+++ b/semantic_release/hvcs/gitea.py
@@ -37,7 +37,6 @@ class Gitea(HvcsBase):
 
     DEFAULT_DOMAIN = "gitea.com"
     DEFAULT_API_PATH = "/api/v1"
-    DEFAULT_API_DOMAIN = f"{DEFAULT_DOMAIN}{DEFAULT_API_PATH}"
     DEFAULT_ENV_TOKEN_NAME = "GITEA_TOKEN"  # noqa: S105
 
     # pylint: disable=super-init-not-called
@@ -74,10 +73,14 @@ class Gitea(HvcsBase):
         self.hvcs_api_domain = Url(
             host=api_domain_parts.host,
             port=api_domain_parts.port,
-            path=api_domain_parts.path,
+            path=str.replace(api_domain_parts.path or "", self.DEFAULT_API_PATH, ""),
         ).url.rstrip("/")
 
-        self.api_url = f"https://{self.hvcs_api_domain}"
+        self.api_url = Url(
+            scheme=api_domain_parts.scheme or "https",
+            host=self.hvcs_api_domain,
+            path=self.DEFAULT_API_PATH,
+        ).url.rstrip("/")
 
         self.token = token
         auth = None if not self.token else TokenAuth(self.token)

--- a/semantic_release/hvcs/github.py
+++ b/semantic_release/hvcs/github.py
@@ -50,15 +50,15 @@ class Github(HvcsBase):
         self._remote_url = remote_url
 
         # ref: https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables
-        self.hvcs_domain = hvcs_domain or os.getenv(
-            "GITHUB_SERVER_URL", self.DEFAULT_DOMAIN
+        self.hvcs_domain = (
+            hvcs_domain or os.getenv("GITHUB_SERVER_URL", self.DEFAULT_DOMAIN)
         ).replace("https://", "")
 
         # not necessarily prefixed with "api." in the case of a custom domain, so
         # can't just default to "api.github.com"
         # ref: https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables
-        self.hvcs_api_domain = hvcs_api_domain or os.getenv(
-            "GITHUB_API_URL", self.DEFAULT_API_DOMAIN
+        self.hvcs_api_domain = (
+            hvcs_api_domain or os.getenv("GITHUB_API_URL", self.DEFAULT_API_DOMAIN)
         ).replace("https://", "")
 
         self.api_url = f"https://{self.hvcs_api_domain}"

--- a/semantic_release/hvcs/gitlab.py
+++ b/semantic_release/hvcs/gitlab.py
@@ -56,7 +56,7 @@ class Gitlab(HvcsBase):
         self.hvcs_domain = (
             hvcs_domain or self._domain_from_environment() or self.DEFAULT_DOMAIN
         )
-        self.hvcs_api_domain = hvcs_api_domain or self.hvcs_domain.replace(
+        self.hvcs_api_domain = (hvcs_api_domain or self.hvcs_domain).replace(
             "https://", ""
         )
         self.api_url = os.getenv("CI_SERVER_URL", f"https://{self.hvcs_api_domain}")

--- a/semantic_release/hvcs/gitlab.py
+++ b/semantic_release/hvcs/gitlab.py
@@ -6,9 +6,9 @@ import logging
 import mimetypes
 import os
 from functools import lru_cache
-from urllib.parse import urlsplit
 
 import gitlab
+from urllib3.util.url import Url, parse_url
 
 from semantic_release.helpers import logged_function
 from semantic_release.hvcs._base import HvcsBase
@@ -44,6 +44,7 @@ class Gitlab(HvcsBase):
     # It is missing the permission to push to the repository, but has all others (releases, packages, etc.)
 
     DEFAULT_DOMAIN = "gitlab.com"
+    DEFAULT_API_PATH = "/api/v4"
 
     def __init__(
         self,
@@ -53,25 +54,43 @@ class Gitlab(HvcsBase):
         token: str | None = None,
     ) -> None:
         self._remote_url = remote_url
-        self.hvcs_domain = (
-            hvcs_domain or self._domain_from_environment() or self.DEFAULT_DOMAIN
+
+        domain_url = parse_url(
+            hvcs_domain or os.getenv("CI_SERVER_URL", "") or self.DEFAULT_DOMAIN
         )
-        self.hvcs_api_domain = (hvcs_api_domain or self.hvcs_domain).replace(
-            "https://", ""
+
+        # Strip any scheme, query or fragment from the domain
+        self.hvcs_domain = Url(
+            host=domain_url.host, port=domain_url.port, path=domain_url.path
+        ).url.rstrip("/")
+
+        api_domain_parts = parse_url(
+            hvcs_api_domain
+            or os.getenv("CI_API_V4_URL", "")
+            or Url(
+                # infer from Domain url and append the default api path
+                scheme=domain_url.scheme,
+                host=self.hvcs_domain,
+                path=self.DEFAULT_API_PATH,
+            ).url
         )
-        self.api_url = os.getenv("CI_SERVER_URL", f"https://{self.hvcs_api_domain}")
+
+        # Strip any scheme, query or fragment from the api domain
+        self.hvcs_api_domain = Url(
+            host=api_domain_parts.host,
+            port=api_domain_parts.port,
+            path=str.replace(api_domain_parts.path or "", self.DEFAULT_API_PATH, ""),
+        ).url.rstrip("/")
+
+        self.api_url = Url(
+            scheme=api_domain_parts.scheme or "https",
+            host=self.hvcs_api_domain,
+            path=self.DEFAULT_API_PATH,
+        ).url.rstrip("/")
 
         self.token = token
         auth = None if not self.token else TokenAuth(self.token)
         self.session = build_requests_session(auth=auth)
-
-    @staticmethod
-    def _domain_from_environment() -> str | None:
-        """Use Gitlab-CI environment variable to get the server domain, if available"""
-        if "CI_SERVER_URL" in os.environ:
-            url = urlsplit(os.environ["CI_SERVER_URL"])
-            return f"{url.netloc}{url.path}".rstrip("/")
-        return os.getenv("CI_SERVER_HOST")
 
     @lru_cache(maxsize=1)
     def _get_repository_owner_and_name(self) -> tuple[str, str]:

--- a/tests/unit/semantic_release/hvcs/test_github.py
+++ b/tests/unit/semantic_release/hvcs/test_github.py
@@ -54,7 +54,7 @@ def default_gh_client():
             {"GITHUB_SERVER_URL": "https://special.custom.server/vcs/"},
             "https://example.com",
             None,
-            "https://example.com",
+            "example.com",
             Github.DEFAULT_API_DOMAIN,
         ),
         (
@@ -62,7 +62,7 @@ def default_gh_client():
             None,
             "https://api.example.com",
             Github.DEFAULT_DOMAIN,
-            "https://api.example.com",
+            "api.example.com",
         ),
     ],
 )

--- a/tests/unit/semantic_release/hvcs/test_github.py
+++ b/tests/unit/semantic_release/hvcs/test_github.py
@@ -16,7 +16,12 @@ from requests import HTTPError, Response, Session
 from semantic_release.hvcs.github import Github
 from semantic_release.hvcs.token_auth import TokenAuth
 
-from tests.const import EXAMPLE_REPO_NAME, EXAMPLE_REPO_OWNER, RELEASE_NOTES
+from tests.const import (
+    EXAMPLE_HVCS_DOMAIN,
+    EXAMPLE_REPO_NAME,
+    EXAMPLE_REPO_OWNER,
+    RELEASE_NOTES,
+)
 from tests.util import netrc_file
 
 if TYPE_CHECKING:
@@ -30,39 +35,54 @@ def default_gh_client():
 
 
 @pytest.mark.parametrize(
-    (
-        "patched_os_environ, hvcs_domain, hvcs_api_domain, "
-        "expected_hvcs_domain, expected_hvcs_api_domain"
+    str.join(
+        ", ",
+        [
+            "patched_os_environ",
+            "hvcs_domain",
+            "hvcs_api_domain",
+            "expected_hvcs_domain",
+            "expected_hvcs_api_domain",
+        ],
     ),
     [
+        # Default values
         ({}, None, None, Github.DEFAULT_DOMAIN, Github.DEFAULT_API_DOMAIN),
         (
+            # Imply api domain from server domain of environment
+            {"GITHUB_SERVER_URL": "https://special.custom.server/"},
+            None,
+            None,
+            "special.custom.server",
+            "api.special.custom.server",
+        ),
+        (
+            # Pull server locations from environment
+            {
+                "GITHUB_SERVER_URL": "https://special.custom.server/",
+                "GITHUB_API_URL": "https://api2.special.custom.server/"
+            },
+            None,
+            None,
+            "special.custom.server",
+            "api2.special.custom.server",
+        ),
+        (
+            # Ignore environment & use provided parameter value (ie from user config)
+            # then infer api domain from the parameter value based on default GitHub configurations
             {"GITHUB_SERVER_URL": "https://special.custom.server/vcs/"},
+            f"https://{EXAMPLE_HVCS_DOMAIN}",
             None,
-            None,
-            "special.custom.server/vcs/",
-            Github.DEFAULT_API_DOMAIN,
+            EXAMPLE_HVCS_DOMAIN,
+            f"api.{EXAMPLE_HVCS_DOMAIN}",
         ),
         (
+            # Ignore environment & use provided parameter value (ie from user config)
             {"GITHUB_API_URL": "https://api.special.custom.server/"},
-            None,
-            None,
-            Github.DEFAULT_DOMAIN,
-            "api.special.custom.server/",
-        ),
-        (
-            {"GITHUB_SERVER_URL": "https://special.custom.server/vcs/"},
-            "https://example.com",
-            None,
-            "example.com",
-            Github.DEFAULT_API_DOMAIN,
-        ),
-        (
-            {"GITHUB_API_URL": "https://api.special.custom.server/"},
-            None,
-            "https://api.example.com",
-            Github.DEFAULT_DOMAIN,
-            "api.example.com",
+            f"https://{EXAMPLE_HVCS_DOMAIN}",
+            f"https://api.{EXAMPLE_HVCS_DOMAIN}",
+            EXAMPLE_HVCS_DOMAIN,
+            f"api.{EXAMPLE_HVCS_DOMAIN}",
         ),
     ],
 )
@@ -91,11 +111,11 @@ def test_github_client_init(
             token=token,
         )
 
-        assert client.hvcs_domain == expected_hvcs_domain
-        assert client.hvcs_api_domain == expected_hvcs_api_domain
-        assert client.api_url == f"https://{client.hvcs_api_domain}"
-        assert client.token == token
-        assert client._remote_url == remote_url
+        assert expected_hvcs_domain == client.hvcs_domain
+        assert expected_hvcs_api_domain == client.hvcs_api_domain
+        assert f"https://{expected_hvcs_api_domain}" == client.api_url
+        assert token == client.token
+        assert remote_url == client._remote_url
         assert hasattr(client, "session")
         assert isinstance(getattr(client, "session", None), Session)
 
@@ -223,10 +243,10 @@ def test_pull_request_url(default_gh_client, pr_number):
 # Tests which need http response mocking
 ############
 
-
+github_upload_url = f"https://uploads.{Github.DEFAULT_DOMAIN}"
 github_matcher = re.compile(rf"^https://{Github.DEFAULT_DOMAIN}")
 github_api_matcher = re.compile(rf"^https://{Github.DEFAULT_API_DOMAIN}")
-github_upload_matcher = re.compile(rf"^https://{Github.DEFAULT_UPLOAD_DOMAIN}")
+github_upload_matcher = re.compile(rf"^{github_upload_url}")
 
 
 @pytest.mark.parametrize("status_code", (200, 201))
@@ -535,7 +555,7 @@ def test_asset_upload_url(default_gh_client):
     # https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#get-a-release
     resp_payload = {
         "upload_url": (
-            f"{default_gh_client.upload_url}/repos/"
+            f"{github_upload_url}/repos/"
             f"{default_gh_client.owner}/{default_gh_client.repo_name}/"
             f"releases/{release_id}/"
             "assets{?name,label}"
@@ -546,8 +566,8 @@ def test_asset_upload_url(default_gh_client):
         m.register_uri("GET", github_api_matcher, json=resp_payload, status_code=200)
         assert (
             default_gh_client.asset_upload_url(release_id)
-            == "https://{domain}/repos/{owner}/{repo}/releases/{release_id}/assets".format(
-                domain=default_gh_client.DEFAULT_UPLOAD_DOMAIN,
+            == "{upload_domain}/repos/{owner}/{repo}/releases/{release_id}/assets".format(
+                upload_domain=github_upload_url,
                 owner=default_gh_client.owner,
                 repo=default_gh_client.repo_name,
                 release_id=release_id,
@@ -579,7 +599,7 @@ def test_upload_asset_succeeds(
     label = "abc123"
     urlparams = {"name": example_changelog_md.name, "label": label}
     expected_upload_url = (
-        f"{default_gh_client.upload_url}/repos/{default_gh_client.owner}/"
+        f"{github_upload_url}/repos/{default_gh_client.owner}/"
         f"{default_gh_client.repo_name}/releases/{mock_release_id}/"
         r"assets{?name,label}"
     )
@@ -639,7 +659,7 @@ def test_upload_asset_fails(
     json_get_up_url = {
         "status": "ok",
         "upload_url": "{up_url}/repos/{owner}/{repo_name}/releases/{release_id}".format(
-            up_url=default_gh_client.upload_url,
+            up_url=github_upload_url,
             owner=default_gh_client.owner,
             repo_name=default_gh_client.repo_name,
             release_id=mock_release_id,


### PR DESCRIPTION
Hi

Whilst fixing the tests for #675 I noticed something with `hvcs_api_domain` and `api_url`.

`hvcs_api_domain` only has `https://` stripped if read from the environment. As a result `api_url` can end up as `https://https://...` if `hvcs_api_domain` is explicitly passed with the url scheme (which the tests do). I'm not sure if it's intentional given the test case,  but it's surely not for `api_url` 😀

Maybe this is better as an issue rather than PR, but in case it really is trivial here's a mod normalising `hvcs_api_domain` across github/gitea/gitlab by always stripping `https://` (and `hvcs_domain`, too).

Thanks
