### PR TITLE
Update minimum version pin of GitPython to fix vulnerability.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ readme = "README.rst"
 authors = [{ name = "Rolf Erik Lekang", email = "me@rolflekang.com" }]
 dependencies = [
   "click>=8,<9",
-  "gitpython>=3.0.8,<4",
+  "gitpython>=3.1.34,<4",
   "requests>=2.25,<3",
   "jinja2>=3.1.2,<4",
   "python-gitlab>=2,<4",


### PR DESCRIPTION
Update minimum version of GitPython to 3.1.34 to fix resource leak issue introduced via a path traversal vulnerability in versions prior to 3.1.34.