### PR TITLE
build(deps-dev): bump importlib-resources from 5.7 to 5.12.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "python-gitlab>=2,<4",
   "tomlkit~=0.10",
   "dotty-dict>=1.3.0,<2",
-  "importlib-resources==5.12.0",
+  "importlib-resources>=5.7,<6",
   "pydantic>=1.10.2,<2",
   "rich>=12.5.1",
   "shellingham>=1.5.0.post1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "python-gitlab>=2,<4",
   "tomlkit~=0.10",
   "dotty-dict>=1.3.0,<2",
-  "importlib-resources==5.7",
+  "importlib-resources==5.12.0",
   "pydantic>=1.10.2,<2",
   "rich>=12.5.1",
   "shellingham>=1.5.0.post1",


### PR DESCRIPTION
I'm trying to use python-semantic-release in Airflow. With version 2.6.3 of airflow, version 5.12.0 of importlib-resources is forced.
I'd like to bump this dependency since it presents no impact on the project.

Thanks