### PR TITLE
docs: fix typos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN set -ex; \
     apt-get install -y --no-install-recommends \
     git-lfs
 
-#install backported stable vesion of git, which supports ssh signing
+# install backported stable version of git, which supports ssh signing
 RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list; \
     apt-get update;\
     apt-get install -y git/bullseye-backports

--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ inputs:
     description: "The ssh private key used to sign commits"
     required: false
 
-  # `semantic-release version` comamnd line options
+  # `semantic-release version` command line options
   prerelease:
     type: string
     required: false

--- a/docs/algorithm.rst
+++ b/docs/algorithm.rst
@@ -35,7 +35,7 @@ Implementation
 
 1. Parse all the Git tags of the repository into semantic versions, and **sort**
    in descending (most recent first) order according to `semver precedence`_.
-   Ignore any tags which do not correspond to valid semantic vesrions accroding
+   Ignore any tags which do not correspond to valid semantic vesrions according
    to ``tag_format``.
 
 

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -202,7 +202,7 @@ For example, assuming a project is currently at version 1.2.3::
     $ semantic-release version --minor --print
     1.3.0
 
-    $ semantic-release verison --minor --print --build-metadata "run.12345"
+    $ semantic-release version --minor --print --build-metadata "run.12345"
     1.3.0+run.12345
 
 .. _cmd-version-option-commit:
@@ -211,7 +211,7 @@ For example, assuming a project is currently at version 1.2.3::
 ************************
 
 Whether or not to perform a ``git commit`` on modifications to source files made by ``semantic-release`` during this
-command invokation, and to run ``git tag`` on this new commit with a tag corresponding to the new version.
+command invocation, and to run ``git tag`` on this new commit with a tag corresponding to the new version.
 
 If ``--no-commit`` is supplied, a number of other options are also disabled; please see below.
 

--- a/docs/commit-parsing.rst
+++ b/docs/commit-parsing.rst
@@ -50,7 +50,7 @@ The default parser, which uses the `Angular commit style <https://github.com/ang
   - Multiple ``BREAKING CHANGE:`` paragraphs are supported
   - ``revert`` is not currently supported
 
-The default confiugration options for
+The default configuration options for
 :py:class:`semantic_release.commit_parser.AngularCommitParser` are:
 
 .. code-block:: toml
@@ -85,7 +85,7 @@ section.
 
 The default settings are for `Gitmoji <https://gitmoji.carloscuesta.me/>`_.
 
-The default confiugration options for
+The default configuration options for
 :py:class:`semantic_release.commit_parser.EmojiCommitParser` are:
 
 .. code-block:: toml
@@ -128,7 +128,7 @@ A parser for `scipy-style commits <scipy-style>`_ with the following differences
     a breaking change. Multiple ``BREAKING CHANGE`` paragraphs are supported.
   - A scope (following the tag in parentheses) is supported
 
-The default confiugration options for
+The default configuration options for
 :py:class:`semantic_release.commit_parser.ScipyCommitParser` are:
 
 .. code-block:: toml
@@ -163,7 +163,7 @@ The default confiugration options for
 The original parser from v1.0.0 of Python Semantic Release. Similar to the
 emoji parser above, but with less features.
 
-The default confiugration options for
+The default configuration options for
 :py:class:`semantic_release.commit_parser.TagCommitParser` are:
 
 .. code-block:: toml

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -299,7 +299,7 @@ Tags which do not match this format will not be considered as versions of your p
 """""""""""""""""""""""""""""""""
 
 Each entry represents a location where the version is stored in the source code,
-specifed in ``file:variable`` format. For example:
+specified in ``file:variable`` format. For example:
 
 .. code-block:: toml
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,7 +40,7 @@ inspect the default configuration in your terminal by running
 
 ``semantic-release generate-config``
 
-You can also use the :ref:`-f/--format <cmd-generate-config-option-format>` option to specify what foramt you would like this configuration
+You can also use the :ref:`-f/--format <cmd-generate-config-option-format>` option to specify what format you would like this configuration
 to be. The default is TOML, but JSON can also be used.
 
 You can append the configuration to your existing ``pyproject.toml`` file using a standard redirect,

--- a/docs/migrating_from_v7.rst
+++ b/docs/migrating_from_v7.rst
@@ -197,7 +197,7 @@ It is no longer possible to override arbitrary configuration values using the ``
 file using :ref:`cmd-main-option-config` or via the available command-line options.
 
 This simplifies the command-line option parsing significantly and is less error-prone,
-which has resulted in previous issues (e.g. `#600`_) with overriddes on the command-line.
+which has resulted in previous issues (e.g. `#600`_) with overrides on the command-line.
 Some of the configuration values expected by Python Semantic Release use complex data
 types such as lists or nested structures, which would be tedious and error-prone to
 specify using just command-line options.

--- a/docs/multibranch_releases.rst
+++ b/docs/multibranch_releases.rst
@@ -83,7 +83,7 @@ Configuring Multibranch Releases
 --------------------------------
 
 Within your configuration file, you can create one or more groups of branches
-(*"release groups"*) that produce a certain type of release. Options are confiugred
+(*"release groups"*) that produce a certain type of release. Options are configured
 at the group level, and the group to use is chosen based on the *current branch name*
 against which Python Semantic Release is running.
 

--- a/docs/strict_mode.rst
+++ b/docs/strict_mode.rst
@@ -6,7 +6,7 @@ Strict Mode
 Strict Mode is enabled by use of the :ref:`strict <cmd-main-option-strict>` parameter
 to the main command for Python Semantic Release. Strict Mode alters the behaviour of
 Python Semantic Release when certain conditions are encountered that prevent Python
-Semantic Release from perfoming an action. Typically, this will result in a warning
+Semantic Release from performing an action. Typically, this will result in a warning
 becoming an error, or a different exit code (0 vs non-zero) being produced when Python
 Semantic Release exits early.
 

--- a/semantic_release/hvcs/_base.py
+++ b/semantic_release/hvcs/_base.py
@@ -95,7 +95,7 @@ class HvcsBase:
 
     def get_release_id_by_tag(self, tag: str) -> int | None:
         """
-        Given a Git tag, return the ID (as the remote VCS defines it) of a corrsponding
+        Given a Git tag, return the ID (as the remote VCS defines it) of a corresponding
         release in the remove VCS, if supported
         """
         _not_supported(self, "get_release_id_by_tag")

--- a/semantic_release/hvcs/gitlab.py
+++ b/semantic_release/hvcs/gitlab.py
@@ -62,7 +62,7 @@ class Gitlab(HvcsBase):
 
     @staticmethod
     def _domain_from_environment() -> str | None:
-        """Use Gitlab-CI environment varable to get the server domain, if available"""
+        """Use Gitlab-CI environment variable to get the server domain, if available"""
         if "CI_SERVER_URL" in os.environ:
             url = urlsplit(os.environ["CI_SERVER_URL"])
             return f"{url.netloc}{url.path}".rstrip("/")

--- a/tests/const.py
+++ b/tests/const.py
@@ -445,7 +445,7 @@ setup(
 EXAMPLE_CHANGELOG_MD_CONTENT = r"""
 # CHANGELOG.md
 
-## This is an example changlog
+## This is an example changelog
 
 ## v1.0.0
 * Various bugfixes, security enhancements

--- a/tests/unit/semantic_release/changelog/TEST_CHANGELOG.md.j2
+++ b/tests/unit/semantic_release/changelog/TEST_CHANGELOG.md.j2
@@ -1,5 +1,5 @@
 {#
-    NOTE: this changlog test doesn't include commit hashes from the default template as
+    NOTE: this changelog test doesn't include commit hashes from the default template as
     they always change - which makes it notoriously difficult to check exact content
 #}# CHANGELOG
 {% if context.history.unreleased | length > 0 %}


### PR DESCRIPTION
Hi, I think these might all be typos, right?

I was unsure in this line:
https://github.com/python-semantic-release/python-semantic-release/blob/3abfb7ac216b9ad439de24fda60eca84038e850e/tests/unit/semantic_release/version/test_declaration.py#L83

Is this a typo or some sort of fuzzy matching?
`r"(?P<vrsion>.*)"`