### PR TITLE
docs: update project urls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,11 @@ semantic-release = "semantic_release.cli:main"
 psr = "semantic_release.cli:main"
 
 [project.urls]
-"Project Url" = "http://github.com/python-semantic-release/python-semantic-release"
-Homepage = "https://python-semantic-release.readthedocs.io"
+changelog = "https://github.com/python-semantic-release/python-semantic-release/blob/master/CHANGELOG.md"
+documentation = "https://python-semantic-release.readthedocs.io"
+homepage = "https://python-semantic-release.readthedocs.io"
+issues = "https://github.com/python-semantic-release/python-semantic-release/issues"
+repository = "http://github.com/python-semantic-release/python-semantic-release.git"
 
 [project.optional-dependencies]
 docs = [


### PR DESCRIPTION
## Proposed Changes

This PR proposed the following changes:

- add changelog url
- add issues url
- use lowercase for project urls

Your current homepage url points to the documentation. I added a documentation url, but left the hompeage url as well. Should I remove one of those?

These new urls will render with a nice icon on PyPI.

Refs: https://daniel.feldroy.com/posts/2023-08-pypi-project-urls-cheatsheet