### PR TITLE
chore: fix implement --no-verify git commit option and fix gitlab hvc…

### DIFF
--- a/semantic_release/cli/commands/version.py
+++ b/semantic_release/cli/commands/version.py
@@ -285,6 +285,7 @@ def version(  # noqa: C901
     commit_author = runtime.commit_author
     commit_message = runtime.commit_message
     major_on_zero = runtime.major_on_zero
+    no_verify = runtime.no_verify
     build_command = runtime.build_command
     opts = runtime.global_cli_options
     gha_output = VersionGitHubActionsOutput()
@@ -529,6 +530,7 @@ def version(  # noqa: C901
         )
 
         command += f"git commit -m '{indented_commit_message}'"
+        command += "--no-verify" if no_verify else ""
 
         noop_report(
             indented(
@@ -544,6 +546,7 @@ def version(  # noqa: C901
             repo.git.commit(
                 m=commit_message.format(version=new_version),
                 date=int(commit_date.timestamp()),
+                no_verify=no_verify,
             )
 
     # Run the tagging after potentially creating a new HEAD commit.

--- a/semantic_release/cli/config.py
+++ b/semantic_release/cli/config.py
@@ -210,6 +210,7 @@ class RawConfig(BaseModel):
     major_on_zero: bool = True
     allow_zero_version: bool = True
     remote: RemoteConfig = RemoteConfig()
+    no_verify: bool = False
     tag_format: str = "v{version}"
     publish: PublishConfig = PublishConfig()
     version_toml: Optional[Tuple[str, ...]] = None
@@ -295,6 +296,7 @@ class RuntimeContext:
     major_on_zero: bool
     allow_zero_version: bool
     prerelease: bool
+    no_verify: bool
     assets: List[str]
     commit_author: Actor
     commit_message: str
@@ -488,6 +490,7 @@ class RuntimeContext:
             upload_to_vcs_release=raw.publish.upload_to_vcs_release,
             global_cli_options=global_cli_options,
             masker=masker,
+            no_verify=raw.no_verify,
         )
         # credential masker
         self.apply_log_masking(self.masker)

--- a/semantic_release/hvcs/github.py
+++ b/semantic_release/hvcs/github.py
@@ -238,7 +238,7 @@ class Github(HvcsBase):
         """
         Edit a release with updated change notes
         https://docs.github.com/rest/reference/repos#update-a-release
-        :param id: ID of release to update
+        :param release_id: ID of release to update
         :param release_notes: The release notes for this version
         :return: The ID of the release that was edited
         """
@@ -263,8 +263,9 @@ class Github(HvcsBase):
     ) -> int:
         """
         Post release changelog
-        :param version: The version number
+        :param tag: The version number
         :param release_notes: The release notes for this version
+        :param prerelease: Whether or not this release should be created as a prerelease
         :return: The status of the request
         """
         log.info("Creating release for %s", tag)
@@ -361,8 +362,8 @@ class Github(HvcsBase):
     def upload_dists(self, tag: str, dist_glob: str) -> int:
         """
         Upload distributions to a release
-        :param version: Version to upload for
-        :param path: Path to the dist directory
+        :param tag: Version to upload for
+        :param dist_glob: Path to the dist directory
         :return: The number of distributions successfully uploaded
         """
         # Find the release corresponding to this version

--- a/semantic_release/hvcs/gitlab.py
+++ b/semantic_release/hvcs/gitlab.py
@@ -113,6 +113,7 @@ class Gitlab(HvcsBase):
             {
                 "name": "Release " + tag,
                 "tag_name": tag,
+                "tag_message": release_notes[0:72],
                 "description": release_notes,
             }
         )

--- a/semantic_release/hvcs/gitlab.py
+++ b/semantic_release/hvcs/gitlab.py
@@ -46,7 +46,6 @@ class Gitlab(HvcsBase):
         **kwargs: Any,
     ) -> None:
         super().__init__(remote_url)
-        self._remote_url = remote_url
         self.token = token
 
         domain_url = parse_url(


### PR DESCRIPTION
Implement --no-verify git commit option to enable configuring pre-commit local hook to create semantic release version. Update TokenAuth to support setting Gitlab REST API private access token authorization header.
Implemented get_release_id_by_tag method in Gitlab hvcs and updated edit_release_notes try catch logic to align with Github hvcs logic.
Changed pre-commit-config.yaml default_language_version from python3.8 to python3 to resolve:
- RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.8'
Updated github documentation comment args to match method signatures.