### PR TITLE
chore: add tests for python 3.12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ legacy_tox_ini = """
 [tox]
 envlist =
     mypy,
-    py{37,38,39,310,311},
+    py{37,38,39,310,311,312},
     coverage
     ruff
 skipsdist = True


### PR DESCRIPTION
## Proposed changes

Python 3.12 was released on 2023-10-02 and is now available for GitHub actions runners as well.

This PR proposes the following changes:
- replace Python version 3.12-dev with 3.12 to the CI test runs
- add Python 3.12 to tox envlist

The tests are still passing. So I guess your library is now really ready for Python 3.12.