### PR TITLE
fix: Error when running build command on windows systems

### DIFF
--- a/semantic_release/cli/commands/version.py
+++ b/semantic_release/cli/commands/version.py
@@ -102,7 +102,7 @@ def shell(cmd: str, *, check: bool = True) -> subprocess.CompletedProcess:
     if not shell:
         raise TypeError("'shell' is None")
 
-    return subprocess.run([shell, "-c", cmd], check=check)  # noqa: S603
+    return subprocess.run([shell, "-c" if shell != "cmd" else "/c", cmd], check=check)  # noqa: S603
 
 
 @click.command(


### PR DESCRIPTION
On Windows systems, if the shell you get is cmd instead of executing the command it opens a shell
This is because instead of telling it cmd /c COMMAND it is sent cmd -c COMMAND