### PR TITLE
feat: Allow user customization of release notes template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2156,12 +2156,12 @@ Any issues which are labelled as a question will be closed after two weeks of in
 
 * ci: pass SHA from beautify to release
 
-Checkout the current SHA from the end of the beautify job for releasing, 
-instead of master. This will either be the same as the commit we are 
-running for, or the SHA of a style commit. This prevents releasing of 
+Checkout the current SHA from the end of the beautify job for releasing,
+instead of master. This will either be the same as the commit we are
+running for, or the SHA of a style commit. This prevents releasing of
 untested code.
 
-See 
+See
 https://github.community/t5/GitHub-Actions/Checkout-commit-pushed-by-previous-job/m-p/55847#M9670 ([`76e34b6`](https://github.com/python-semantic-release/python-semantic-release/commit/76e34b6b52b8019e87eaddf295d0781b6aa51541))
 
 ### Documentation
@@ -2239,15 +2239,15 @@ This was missed in 213530fb0c914e274b81d1dacf38ea7322b5b91f ([`3084249`](https:/
 
 * refactor(debug): use logging and click_log instead of ndebug
 
-BREAKING CHANGE: `DEBUG=&#34;*&#34;` no longer has an effect, instead use 
+BREAKING CHANGE: `DEBUG=&#34;*&#34;` no longer has an effect, instead use
 `--verbosity DEBUG`. ([`15b1f65`](https://github.com/python-semantic-release/python-semantic-release/commit/15b1f650f29761e1ab2a91b767cbff79b2057a4c))
 
 ### Build
 
 * build(pip): store requirements in setup.py
 
-Remove the requirements directory and instead store all required 
-libraries directly inside setup.py. Development, testing and docs 
+Remove the requirements directory and instead store all required
+libraries directly inside setup.py. Development, testing and docs
 dependencies are included as extras. ([`401468f`](https://github.com/python-semantic-release/python-semantic-release/commit/401468f312cf4f3b52006c68c58c4645b5e19802))
 
 ### Chore
@@ -2260,12 +2260,12 @@ Allow mypy and coverage to run on any Python version. ([`28feba6`](https://githu
 
 * ci: always checkout most recent commit to release
 
-This should pull a beautify commit if one has been created, allowing the 
+This should pull a beautify commit if one has been created, allowing the
 new version to be pushed. ([`6c98aab`](https://github.com/python-semantic-release/python-semantic-release/commit/6c98aab932724e3aab08e68b75439bc8c31bd877))
 
 * ci: cache testing dependencies
 
-This should help improve the speed of the testing workflow by caching 
+This should help improve the speed of the testing workflow by caching
 downloaded dependencies. ([`4f53e35`](https://github.com/python-semantic-release/python-semantic-release/commit/4f53e351960a6b658f50265384c9e8f678718f68))
 
 * ci: move beautification to separate workflow
@@ -2282,7 +2282,7 @@ Run isort and Black on pushes to master. Any edits made are committed. isort and
 
 * docs: include README.rst in index.rst
 
-These files were very similar so it makes sense to simply include one 
+These files were very similar so it makes sense to simply include one
 inside the other. ([`8673a9d`](https://github.com/python-semantic-release/python-semantic-release/commit/8673a9d92a9bf348bb3409e002a830741396c8ca))
 
 * docs: rewrite README.rst ([`e049772`](https://github.com/python-semantic-release/python-semantic-release/commit/e049772cf14cdd49538cf357db467f0bf3fe9587))
@@ -2312,12 +2312,12 @@ inside the other. ([`8673a9d`](https://github.com/python-semantic-release/python
 
 * ci: fetch full history in release job
 
-I didn&#39;t realise that actions/checkout@v2 only fetches 1 commit by 
+I didn&#39;t realise that actions/checkout@v2 only fetches 1 commit by
 default. ([`a02a9b7`](https://github.com/python-semantic-release/python-semantic-release/commit/a02a9b7e34d8e7f8bb3b9c8aa1b5e1ef8bdd406c))
 
 * ci: run tests on pull_request
 
-The tests didn&#39;t run for #211 which caused a flake8 failure to be 
+The tests didn&#39;t run for #211 which caused a flake8 failure to be
 missed. ([`32fd77e`](https://github.com/python-semantic-release/python-semantic-release/commit/32fd77ed835bcfc943abeacec4e327df045b2ec9))
 
 * ci: run tests on GitHub Actions ([`39ff283`](https://github.com/python-semantic-release/python-semantic-release/commit/39ff283312a0c686bfc5be71e1da9b6456652d95))
@@ -2340,7 +2340,7 @@ Automatically create pages in the API docs section using sphinx-autodoc. This is
 
 * style: fix styling from 2997908
 
-These code style problems were introduced because tests didn&#39;t run on 
+These code style problems were introduced because tests didn&#39;t run on
 #211. ([`172391e`](https://github.com/python-semantic-release/python-semantic-release/commit/172391ec5b5e490081b9b0ea58a94dfd5be33937))
 
 
@@ -2393,7 +2393,7 @@ These code style problems were introduced because tests didn&#39;t run on
 
 * refactor(history): use a named tuple for parsed commits
 
-This improves readability as we can use attributes such as &#39;bump&#39; and 
+This improves readability as we can use attributes such as &#39;bump&#39; and
 &#39;descriptions&#39; instead of confusing numeric indices. ([`bff40d5`](https://github.com/python-semantic-release/python-semantic-release/commit/bff40d53174ffe27451d82132c31b112c7bee9fd))
 
 
@@ -2535,7 +2535,7 @@ Fixes #181 ([`0fddbe2`](https://github.com/python-semantic-release/python-semant
 
 * refactor(github): create upload_asset function
 
-Create a function to call the asset upload API. This will soon be used 
+Create a function to call the asset upload API. This will soon be used
 to upload assets specified by the user.
 
 * refactor(github): infer Content-Type from file extension
@@ -2544,13 +2544,13 @@ Infer the Content-Type header based on the file extension instead of setting it 
 
 * refactor(pypi): move building of dists to cli.py
 
-Refactor to have the building/removal of distributions in cli.py instead 
-of within the upload_to_pypi function. This makes way for uploading to 
+Refactor to have the building/removal of distributions in cli.py instead
+of within the upload_to_pypi function. This makes way for uploading to
 other locations, such as GitHub Releases, too.
 
 * feat(github): upload dists to release
 
-Upload Python wheels to the GitHub release. Configured with the option 
+Upload Python wheels to the GitHub release. Configured with the option
 upload_to_release, on by default if using GitHub.
 
 * docs: document upload_to_release config option
@@ -2592,7 +2592,7 @@ application/octet-stream is more generic, but it is better than using a non-offi
 
 * feat(history): capitalize changelog messages
 
-Capitalize the first letter of messages in the changelog regardless of 
+Capitalize the first letter of messages in the changelog regardless of
 whether they are capitalized in the commit itself. ([`1a8e306`](https://github.com/python-semantic-release/python-semantic-release/commit/1a8e3060b8f6d6362c27903dcfc69d17db5f1d36))
 
 ### Fix
@@ -2630,7 +2630,7 @@ Fix the syntax of a broken bullet-point list in README.rst. ([`7aa572b`](https:/
 
 * fix(github): send token in request header
 
-Use an Authorization header instead of deprecated query parameter 
+Use an Authorization header instead of deprecated query parameter
 authorization.
 
 Fixes relekang/python-semantic-release#167 ([`be9972a`](https://github.com/python-semantic-release/python-semantic-release/commit/be9972a7b1fb183f738fb31bd370adb30281e4d5))
@@ -2915,9 +2915,9 @@ The commands is lacking from the documentation. ([`b6fa04d`](https://github.com/
 
 ### Refactor
 
-* refactor: added debug to hvcshvcs 
+* refactor: added debug to hvcshvcs
 
- 
+
 module did not have any debug ([`0c6237b`](https://github.com/python-semantic-release/python-semantic-release/commit/0c6237bc01ec39608fb768925091c755d9bb25bd))
 
 * refactor: fix import sorting ([`01e4c5d`](https://github.com/python-semantic-release/python-semantic-release/commit/01e4c5d743f2f237d2c85481118e467d4f5fde15))

--- a/docs/changelog_templates.rst
+++ b/docs/changelog_templates.rst
@@ -253,6 +253,22 @@ generates the release notes when :ref:`creating VCS releases <index-creating-vcs
 * create a file named ``.release_notes.md.j2`` inside the project's
   :ref:`template_dir <config-changelog-template-dir>` to customize the release notes
 
+.. _changelog-templates-customizing-vcs-release-notes-release-notes-context:
+
+Release Notes Context
+"""""""""""""""""""""
+
+All of the changelog's
+:ref:`template context <changelog-templates-template-rendering-template-context>` is
+exposed to the `Jinja`_ template when rendering the release notes.
+
+Additionally, the following two globals are available to the template:
+
+* ``release`` (:class:`Release <semantic_release.changelog.release_history.Release>`):
+  contains metadata about the content of the release, as parsed from commit logs
+* ``version`` (:class:`Version <semantic_release.version.version.Version>`): contains
+  metadata about the software version to be released and its ``git`` tag
+
 .. _in-built template: https://github.com/python-semantic-release/python-semantic-release/blob/master/semantic_release/data/templates/release_notes.md.j2
 
 .. _changelog-templates-release-notes-template-example:

--- a/docs/changelog_templates.rst
+++ b/docs/changelog_templates.rst
@@ -241,6 +241,40 @@ Each ``Release`` object also has the following attributes:
 
 .. _dataclass: https://docs.python.org/3/library/dataclasses.html
 
+.. _changelog-templates-customizing-vcs-release-notes:
+
+Customizing VCS Release Notes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The same :ref:`template rendering <changelog-templates-template-rendering>` mechanism
+generates the release notes when :ref:`creating VCS releases <index-creating-vcs-releases>`:
+
+* the `in-built template`_ is used by default
+* create a file named ``.release_notes.md.j2`` inside the project's
+  :ref:`template_dir <config-changelog-template-dir>` to customize the release notes
+
+.. _in-built template: https://github.com/python-semantic-release/python-semantic-release/blob/master/semantic_release/data/templates/release_notes.md.j2
+
+.. _changelog-templates-release-notes-template-example:
+
+Release Notes Template Example
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Below is an example template that can be used to render release notes (it's similar to
+GitHub's `automatically generated release notes`_):
+
+.. code-block::
+
+    ## What's Changed
+    {% for type_, commits in release["elements"] | dictsort %}
+    ### {{ type_ | capitalize }}
+    {%- if type_ != "unknown" %}
+    {% for commit in commits %}
+    * {{ commit.descriptions[0] }} by {{commit.commit.author.name}} in [`{{ commit.short_hash }}`]({{ commit.hexsha | commit_hash_url }})
+    {%- endfor %}{% endif %}{% endfor %}
+
+.. _Automatically generated release notes: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+
 .. _changelog-templates-template-rendering-example:
 
 Changelog Template Example

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -144,6 +144,8 @@ environment variable.
 
 .. seealso::
    - :ref:`Changelog <config-changelog>` - customize your project's changelog.
+   - :ref:`Customizing VCS Release Notes <changelog-templates-customizing-vcs-release-notes>` - customize
+     the VCS release notes.
    - :ref:`upload_to_vcs_release <config-publish-upload-to-vcs-release>` -
      enable/disable uploading artefacts to VCS releases
    - :ref:`version --vcs-release/--no-vcs-release <cmd-version-option-vcs-release>` - enable/disable VCS release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 # Ref: https://packaging.python.org/en/latest/specifications/declaring-project-metadata/
 # and https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html
-
 [build-system]
 requires = ["setuptools>=61.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
@@ -77,12 +76,16 @@ addopts = [
   "-ra",
   "--cache-clear",
   "--cov=semantic_release",
+  "--cov-context=test",
   "--cov-report",
   "html:coverage-html",
   "--cov-report",
   "term",
 ]
 python_files = ["tests/test_*.py", "tests/**/test_*.py"]
+
+[tool.coverage.html]
+show_contexts = true
 
 [tool.coverage.run]
 omit = ["*/tests/*"]

--- a/semantic_release/changelog/template.py
+++ b/semantic_release/changelog/template.py
@@ -75,7 +75,9 @@ def environment(
 
 # pylint: disable=redefined-outer-name
 def recursive_render(
-    template_dir: str, environment: Environment, _root_dir: str = "."
+    template_dir: Path,
+    environment: Environment,
+    _root_dir: str | os.PathLike[str] = ".",
 ) -> list[str]:
     rendered_paths: list[str] = []
     for root, file in (

--- a/semantic_release/changelog/template.py
+++ b/semantic_release/changelog/template.py
@@ -20,7 +20,7 @@ log = logging.getLogger(__name__)
 
 # pylint: disable=too-many-arguments,too-many-locals
 def environment(
-    template_dir: str = ".",
+    template_dir: Path | str = ".",
     block_start_string: str = "{%",
     block_end_string: str = "%}",
     variable_start_string: str = "{{",

--- a/semantic_release/cli/commands/changelog.py
+++ b/semantic_release/cli/commands/changelog.py
@@ -8,8 +8,9 @@ import click
 from semantic_release.changelog import ReleaseHistory, recursive_render
 from semantic_release.changelog.context import make_changelog_context
 from semantic_release.cli.common import (
+    get_release_notes_template,
     render_default_changelog_file,
-    render_default_release_notes,
+    render_release_notes,
 )
 from semantic_release.cli.util import noop_report
 
@@ -88,8 +89,12 @@ def changelog(ctx: click.Context, release_tag: str | None = None) -> None:
         except KeyError:
             ctx.fail(f"tag {release_tag} not in release history")
 
-        release_notes = render_default_release_notes(
-            template_environment=env, version=version, release=release
+        template = get_release_notes_template(template_dir)
+        release_notes = render_release_notes(
+            release_notes_template=template,
+            template_environment=env,
+            version=version,
+            release=release,
         )
         try:
             hvcs_client.create_or_update_release(

--- a/semantic_release/cli/commands/changelog.py
+++ b/semantic_release/cli/commands/changelog.py
@@ -9,7 +9,7 @@ from semantic_release.changelog import ReleaseHistory, recursive_render
 from semantic_release.changelog.context import make_changelog_context
 from semantic_release.cli.common import (
     render_default_changelog_file,
-    render_release_notes,
+    render_default_release_notes,
 )
 from semantic_release.cli.util import noop_report
 
@@ -88,7 +88,7 @@ def changelog(ctx: click.Context, release_tag: str | None = None) -> None:
         except KeyError:
             ctx.fail(f"tag {release_tag} not in release history")
 
-        release_notes = render_release_notes(
+        release_notes = render_default_release_notes(
             template_environment=env, version=version, release=release
         )
         try:

--- a/semantic_release/cli/commands/version.py
+++ b/semantic_release/cli/commands/version.py
@@ -13,8 +13,9 @@ import shellingham  # type: ignore[import]
 from semantic_release.changelog import ReleaseHistory, environment, recursive_render
 from semantic_release.changelog.context import make_changelog_context
 from semantic_release.cli.common import (
+    get_release_notes_template,
     render_default_changelog_file,
-    render_default_release_notes,
+    render_release_notes,
 )
 from semantic_release.cli.github_actions_output import VersionGitHubActionsOutput
 from semantic_release.cli.util import indented, noop_report, rprint
@@ -527,7 +528,10 @@ def version(  # noqa: C901
         # not user-configurable at the moment
         release_note_environment = environment(template_dir=runtime.template_dir)
         changelog_context.bind_to_environment(release_note_environment)
-        release_notes = render_default_release_notes(
+
+        template = get_release_notes_template(template_dir)
+        release_notes = render_release_notes(
+            release_notes_template=template,
             template_environment=release_note_environment,
             version=new_version,
             release=release,

--- a/semantic_release/cli/commands/version.py
+++ b/semantic_release/cli/commands/version.py
@@ -14,7 +14,7 @@ from semantic_release.changelog import ReleaseHistory, environment, recursive_re
 from semantic_release.changelog.context import make_changelog_context
 from semantic_release.cli.common import (
     render_default_changelog_file,
-    render_release_notes,
+    render_default_release_notes,
 )
 from semantic_release.cli.github_actions_output import VersionGitHubActionsOutput
 from semantic_release.cli.util import indented, noop_report, rprint
@@ -527,7 +527,7 @@ def version(  # noqa: C901
         # not user-configurable at the moment
         release_note_environment = environment(template_dir=runtime.template_dir)
         changelog_context.bind_to_environment(release_note_environment)
-        release_notes = render_release_notes(
+        release_notes = render_default_release_notes(
             template_environment=release_note_environment,
             version=new_version,
             release=release,

--- a/semantic_release/cli/common.py
+++ b/semantic_release/cli/common.py
@@ -1,9 +1,30 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 # NOTE: use backport with newer API than stdlib
 from importlib_resources import files
-from jinja2 import Environment
 
-from semantic_release.changelog.release_history import Release
-from semantic_release.version import Version
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from jinja2 import Environment
+
+    from semantic_release.changelog.release_history import Release
+    from semantic_release.version import Version
+
+
+def get_release_notes_template(template_dir: Path) -> str:
+    """Read the project's template for release notes, falling back to the default."""
+    fname = template_dir / ".release_notes.md.j2"
+    try:
+        return fname.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return (
+            files("semantic_release")
+            .joinpath("data/templates/release_notes.md.j2")
+            .read_text(encoding="utf-8")
+        )
 
 
 def render_default_changelog_file(template_environment: Environment) -> str:
@@ -16,14 +37,12 @@ def render_default_changelog_file(template_environment: Environment) -> str:
     return tmpl.render()
 
 
-def render_default_release_notes(
-    template_environment: Environment, version: Version, release: Release
+def render_release_notes(
+    release_notes_template: str,
+    template_environment: Environment,
+    version: Version,
+    release: Release,
 ) -> str:
-    release_template = (
-        files("semantic_release")
-        .joinpath("data/templates/release_notes.md.j2")
-        .read_text(encoding="utf-8")
-    )
-    return template_environment.from_string(release_template).render(
+    return template_environment.from_string(release_notes_template).render(
         version=version, release=release
     )

--- a/semantic_release/cli/common.py
+++ b/semantic_release/cli/common.py
@@ -16,7 +16,7 @@ def render_default_changelog_file(template_environment: Environment) -> str:
     return tmpl.render()
 
 
-def render_release_notes(
+def render_default_release_notes(
     template_environment: Environment, version: Version, release: Release
 ) -> str:
     release_template = (

--- a/semantic_release/cli/config.py
+++ b/semantic_release/cli/config.py
@@ -204,7 +204,7 @@ class RuntimeContext:
     changelog_file: Path
     ignore_token_for_push: bool
     template_environment: Environment
-    template_dir: str
+    template_dir: Path
     build_command: Optional[str]
     dist_glob_patterns: Tuple[str, ...]
     upload_to_vcs_release: bool
@@ -377,7 +377,7 @@ class RuntimeContext:
             changelog_excluded_commit_patterns=changelog_excluded_commit_patterns,
             prerelease=branch_config.prerelease,
             ignore_token_for_push=raw.remote.ignore_token_for_push,
-            template_dir=raw.changelog.template_dir,
+            template_dir=Path(repo.working_tree_dir) / raw.changelog.template_dir,
             template_environment=template_environment,
             dist_glob_patterns=raw.publish.dist_glob_patterns,
             upload_to_vcs_release=raw.publish.upload_to_vcs_release,

--- a/semantic_release/cli/config.py
+++ b/semantic_release/cli/config.py
@@ -352,6 +352,8 @@ class RuntimeContext:
         # changelog_file
         changelog_file = Path(raw.changelog.changelog_file).resolve()
 
+        template_dir = Path(repo.working_tree_dir or ".") / raw.changelog.template_dir
+
         template_environment = environment(
             template_dir=raw.changelog.template_dir,
             **raw.changelog.environment.model_dump(),
@@ -377,7 +379,7 @@ class RuntimeContext:
             changelog_excluded_commit_patterns=changelog_excluded_commit_patterns,
             prerelease=branch_config.prerelease,
             ignore_token_for_push=raw.remote.ignore_token_for_push,
-            template_dir=Path(repo.working_tree_dir) / raw.changelog.template_dir,
+            template_dir=template_dir,
             template_environment=template_environment,
             dist_glob_patterns=raw.publish.dist_glob_patterns,
             upload_to_vcs_release=raw.publish.upload_to_vcs_release,

--- a/semantic_release/hvcs/_base.py
+++ b/semantic_release/hvcs/_base.py
@@ -125,7 +125,7 @@ class HvcsBase:
         return None
 
     def upload_asset(
-        self, release_id: int, file: str, label: str | None = None
+        self, release_id: int | str, file: str, label: str | None = None
     ) -> bool:
         """
         Upload an asset (file) to a release with the given release_id, if releases are

--- a/semantic_release/hvcs/util.py
+++ b/semantic_release/hvcs/util.py
@@ -71,7 +71,7 @@ def suppress_http_error_for_codes(
             try:
                 return func(*a, **kw)
             except HTTPError as err:
-                if err.response.status_code in codes:
+                if err.response and err.response.status_code in codes:
                     logger.warning(
                         "%s received response %s: %s",
                         func.__qualname__,

--- a/tests/command_line/conftest.py
+++ b/tests/command_line/conftest.py
@@ -1,7 +1,59 @@
+from pathlib import Path
+from typing import Any, Generator
+from unittest import mock
+from unittest.mock import MagicMock
+
 import pytest
 from click.testing import CliRunner
+from git.repo import Repo
+
+from semantic_release.changelog.context import make_changelog_context
+from semantic_release.changelog.release_history import ReleaseHistory
+from semantic_release.cli.config import (
+    GlobalCommandLineOptions,
+    RawConfig,
+    RuntimeContext,
+)
+from semantic_release.cli.const import DEFAULT_CONFIG_FILE
+from semantic_release.cli.util import load_raw_config_file
 
 
 @pytest.fixture
 def cli_runner() -> CliRunner:
     return CliRunner(mix_stderr=False)
+
+
+@pytest.fixture
+def mocked_session_post() -> Generator[MagicMock, Any, None]:
+    """Mock the `post()` method in `requests.Session`."""
+    with mock.patch("requests.sessions.Session.post") as mocked_session:
+        yield mocked_session
+
+
+@pytest.fixture
+def runtime_context(
+    example_project_with_release_notes_template: Path,
+    repo_with_single_branch_and_prereleases_angular_commits: Repo,
+) -> RuntimeContext:
+    config_path = example_project_with_release_notes_template / DEFAULT_CONFIG_FILE
+    cli_options = GlobalCommandLineOptions(
+        noop=False, verbosity=0, strict=False, config_file=config_path
+    )
+    config_text = load_raw_config_file(config_path)
+    raw_config = RawConfig.model_validate(config_text)
+    return RuntimeContext.from_raw_config(
+        raw_config, repo_with_single_branch_and_prereleases_angular_commits, cli_options
+    )
+
+
+@pytest.fixture
+def release_history(runtime_context: RuntimeContext) -> ReleaseHistory:
+    rh = ReleaseHistory.from_git_history(
+        runtime_context.repo,
+        runtime_context.version_translator,
+        runtime_context.commit_parser,
+        runtime_context.changelog_excluded_commit_patterns,
+    )
+    changelog_context = make_changelog_context(runtime_context.hvcs_client, rh)
+    changelog_context.bind_to_environment(runtime_context.template_environment)
+    return rh

--- a/tests/command_line/conftest.py
+++ b/tests/command_line/conftest.py
@@ -24,8 +24,8 @@ from tests.util import (
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from _pytest.monkeypatch import MonkeyPatch
     from git.repo import Repo
+    from pytest import MonkeyPatch
 
     from semantic_release.changelog.release_history import ReleaseHistory
 

--- a/tests/command_line/conftest.py
+++ b/tests/command_line/conftest.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Generator
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
 import pytest

--- a/tests/command_line/conftest.py
+++ b/tests/command_line/conftest.py
@@ -59,6 +59,12 @@ def config_path(example_project: Path) -> Path:
 
 @pytest.fixture
 def raw_config(config_path: Path) -> RawConfig:
+    """
+    Read the raw config file from `config_path`.
+
+    note: a `tests.fixtures.example_project` fixture must precede this one
+            otherwise, the `config_path` file will not exist, and this fixture will fail
+    """
     config_text = load_raw_config_file(config_path)
     return RawConfig.model_validate(config_text)
 
@@ -69,15 +75,13 @@ def cli_options(config_path: Path) -> GlobalCommandLineOptions:
         noop=False,
         verbosity=0,
         strict=False,
-        config_file=config_path,
+        config_file=str(config_path),
     )
 
 
 @pytest.fixture
 def runtime_context_with_tags(
-    # note (1/2): the following fixture must precede the `raw_config` fixture...
     repo_with_single_branch_and_prereleases_angular_commits: Repo,
-    # note (2/2): ... so that the config file gets updated before it is read:
     raw_config: RawConfig,
     cli_options: GlobalCommandLineOptions,
 ) -> RuntimeContext:

--- a/tests/command_line/conftest.py
+++ b/tests/command_line/conftest.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Generator
-from unittest import mock
+from typing import TYPE_CHECKING, Generator
 from unittest.mock import MagicMock
 
 import pytest
 from click.testing import CliRunner
+from requests_mock import ANY
 
 from semantic_release.cli.commands import main
 from semantic_release.cli.config import (
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
 
     from git.repo import Repo
     from pytest import MonkeyPatch
+    from requests_mock.mocker import Mocker
 
     from semantic_release.changelog.release_history import ReleaseHistory
 
@@ -36,10 +37,10 @@ def cli_runner() -> CliRunner:
 
 
 @pytest.fixture
-def mocked_session_post() -> Generator[MagicMock, Any, None]:
-    """Mock the `post()` method in `requests.Session`."""
-    with mock.patch("requests.sessions.Session.post") as mocked_session:
-        yield mocked_session
+def post_mocker(requests_mock: Mocker) -> Mocker:
+    """Patch all POST requests, mocking a response body for VCS release creation."""
+    requests_mock.register_uri("POST", ANY, json={"id": 999})
+    return requests_mock
 
 
 @pytest.fixture

--- a/tests/command_line/test_changelog.py
+++ b/tests/command_line/test_changelog.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import filecmp
 import os
 import shutil
+from typing import TYPE_CHECKING, Any, Generator
 from unittest import mock
 
 import pytest
@@ -10,11 +11,67 @@ import requests_mock
 from pytest_lazyfixture import lazy_fixture
 from requests import Session
 
+from semantic_release.changelog.context import make_changelog_context
+from semantic_release.changelog.release_history import ReleaseHistory
 from semantic_release.cli import changelog, main
+from semantic_release.cli.config import (
+    GlobalCommandLineOptions,
+    RawConfig,
+    RuntimeContext,
+)
+from semantic_release.cli.const import DEFAULT_CONFIG_FILE
+from semantic_release.cli.util import load_raw_config_file
 from semantic_release.hvcs import Github
 
-from tests.const import EXAMPLE_REPO_NAME, EXAMPLE_REPO_OWNER
+from tests.const import (
+    EXAMPLE_RELEASE_NOTES_TEMPLATE,
+    EXAMPLE_REPO_NAME,
+    EXAMPLE_REPO_OWNER,
+)
 from tests.util import flatten_dircmp
+
+if TYPE_CHECKING:
+    from pathlib import Path
+    from unittest.mock import MagicMock
+
+    from click.testing import CliRunner
+    from git.repo import Repo
+
+
+@pytest.fixture
+def mocked_session_post() -> Generator[MagicMock, Any, None]:
+    """Mock the `post()` method in `requests.Session`."""
+    with mock.patch("requests.sessions.Session.post") as mocked_session:
+        yield mocked_session
+
+
+@pytest.fixture
+def runtime_context(
+    example_project_with_release_notes_template: Path,
+    repo_with_single_branch_and_prereleases_angular_commits: Repo,
+) -> RuntimeContext:
+    config_path = example_project_with_release_notes_template / DEFAULT_CONFIG_FILE
+    cli_options = GlobalCommandLineOptions(
+        noop=False, verbosity=0, strict=False, config_file=config_path
+    )
+    config_text = load_raw_config_file(config_path)
+    raw_config = RawConfig.model_validate(config_text)
+    return RuntimeContext.from_raw_config(
+        raw_config, repo_with_single_branch_and_prereleases_angular_commits, cli_options
+    )
+
+
+@pytest.fixture
+def release_history(runtime_context: RuntimeContext) -> ReleaseHistory:
+    rh = ReleaseHistory.from_git_history(
+        runtime_context.repo,
+        runtime_context.version_translator,
+        runtime_context.commit_parser,
+        runtime_context.changelog_excluded_commit_patterns,
+    )
+    changelog_context = make_changelog_context(runtime_context.hvcs_client, rh)
+    changelog_context.bind_to_environment(runtime_context.template_environment)
+    return rh
 
 
 @pytest.mark.parametrize(
@@ -156,4 +213,34 @@ def test_changelog_post_to_release(
             owner=EXAMPLE_REPO_OWNER,
             repo_name=EXAMPLE_REPO_NAME,
         )
+    )
+
+
+def test_custom_release_notes_template(
+    release_history: ReleaseHistory,
+    runtime_context: RuntimeContext,
+    mocked_session_post: MagicMock,
+    cli_runner: CliRunner,
+) -> None:
+    """Verify the template `.release_notes.md.j2` from `template_dir` is used."""
+    # Arrange
+    tag = runtime_context.repo.tags[-1].name
+    version = runtime_context.version_translator.from_tag(tag)
+    release = release_history.released[version]
+
+    # Act
+    resp = cli_runner.invoke(main, [changelog.name, "--post-to-release-tag", tag])
+    expected_release_notes = runtime_context.template_environment.from_string(
+        EXAMPLE_RELEASE_NOTES_TEMPLATE
+    ).render(version=version, release=release)
+
+    # Assert
+    assert resp.exit_code == 0, (
+        "Unexpected failure in command "
+        f"'semantic-release {changelog.name} --post-to-release-tag {tag}': "
+        + resp.stderr
+    )
+    mocked_session_post.assert_called_once()
+    assert (
+        mocked_session_post.call_args.kwargs["json"]["body"] == expected_release_notes
     )

--- a/tests/command_line/test_changelog.py
+++ b/tests/command_line/test_changelog.py
@@ -32,20 +32,27 @@ if TYPE_CHECKING:
 
 
 @pytest.mark.parametrize(
-    "repo",
+    "repo,tag",
     [
-        lazy_fixture("repo_with_no_tags_angular_commits"),
-        lazy_fixture("repo_with_single_branch_angular_commits"),
-        lazy_fixture("repo_with_single_branch_and_prereleases_angular_commits"),
-        lazy_fixture("repo_with_main_and_feature_branches_angular_commits"),
-        lazy_fixture("repo_with_git_flow_angular_commits"),
-        lazy_fixture("repo_with_git_flow_and_release_channels_angular_commits"),
+        (lazy_fixture("repo_with_no_tags_angular_commits"), None),
+        (lazy_fixture("repo_with_single_branch_angular_commits"), "v0.1.1"),
+        (
+            lazy_fixture("repo_with_single_branch_and_prereleases_angular_commits"),
+            "v0.2.0",
+        ),
+        (lazy_fixture("repo_with_main_and_feature_branches_angular_commits"), "v0.2.0"),
+        (lazy_fixture("repo_with_git_flow_angular_commits"), "v1.0.0"),
+        (
+            lazy_fixture("repo_with_git_flow_and_release_channels_angular_commits"),
+            "v1.1.0-alpha.3",
+        ),
     ],
 )
-@pytest.mark.parametrize("args", [(), ("--post-to-release-tag", "v1.99.9191")])
+@pytest.mark.parametrize("arg0", [None, "--post-to-release-tag"])
 def test_changelog_noop_is_noop(
-    repo, args, tmp_path_factory, example_project, cli_runner
+    repo, tag, arg0, tmp_path_factory, example_project, cli_runner
 ):
+    args = [arg0, tag] if tag and arg0 else []
     tempdir = tmp_path_factory.mktemp("test_noop")
     shutil.rmtree(str(tempdir.resolve()))
     shutil.copytree(src=str(example_project.resolve()), dst=tempdir)

--- a/tests/command_line/test_changelog.py
+++ b/tests/command_line/test_changelog.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import filecmp
 import os
 import shutil
+import sys
 from typing import TYPE_CHECKING
 from unittest import mock
 
@@ -172,6 +173,10 @@ def test_changelog_post_to_release(
     )
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 8),
+    reason="MagicMock.call_args does not include kwargs before Python 3.8",
+)
 @pytest.mark.usefixtures("example_project_with_release_notes_template")
 def test_custom_release_notes_template(
     release_history: ReleaseHistory,

--- a/tests/command_line/test_changelog.py
+++ b/tests/command_line/test_changelog.py
@@ -174,19 +174,19 @@ def test_changelog_post_to_release(
 
 def test_custom_release_notes_template(
     release_history: ReleaseHistory,
-    runtime_context: RuntimeContext,
+    runtime_context_with_tags: RuntimeContext,
     mocked_session_post: MagicMock,
     cli_runner: CliRunner,
 ) -> None:
     """Verify the template `.release_notes.md.j2` from `template_dir` is used."""
     # Arrange
-    tag = runtime_context.repo.tags[-1].name
-    version = runtime_context.version_translator.from_tag(tag)
+    tag = runtime_context_with_tags.repo.tags[-1].name
+    version = runtime_context_with_tags.version_translator.from_tag(tag)
     release = release_history.released[version]
 
     # Act
     resp = cli_runner.invoke(main, [changelog.name, "--post-to-release-tag", tag])
-    expected_release_notes = runtime_context.template_environment.from_string(
+    expected_release_notes = runtime_context_with_tags.template_environment.from_string(
         EXAMPLE_RELEASE_NOTES_TEMPLATE
     ).render(version=version, release=release)
 

--- a/tests/command_line/test_changelog.py
+++ b/tests/command_line/test_changelog.py
@@ -172,6 +172,7 @@ def test_changelog_post_to_release(
     )
 
 
+@pytest.mark.usefixtures("example_project_with_release_notes_template")
 def test_custom_release_notes_template(
     release_history: ReleaseHistory,
     runtime_context_with_tags: RuntimeContext,

--- a/tests/command_line/test_version.py
+++ b/tests/command_line/test_version.py
@@ -4,6 +4,7 @@ import difflib
 import filecmp
 import re
 import shutil
+import sys
 from subprocess import CompletedProcess
 from typing import TYPE_CHECKING
 from unittest import mock
@@ -425,9 +426,7 @@ def test_version_no_push_force_level(
     )
 
     old_pyproject_toml["tool"]["poetry"].pop("version")  # type: ignore[attr-defined]
-    new_version = new_pyproject_toml["tool"][  # type: ignore[attr-defined]
-        "poetry"
-    ].pop(  # type: ignore[attr-defined]
+    new_version = new_pyproject_toml["tool"]["poetry"].pop(  # type: ignore[attr-defined]  # type: ignore[attr-defined]
         "version"
     )
 
@@ -496,9 +495,7 @@ def test_version_runs_build_command(
     repo_with_git_flow_angular_commits, cli_runner, example_pyproject_toml, shell
 ):
     config = tomlkit.loads(example_pyproject_toml.read_text(encoding="utf-8"))
-    build_command = config["tool"]["semantic_release"][  # type: ignore[attr-defined]
-        "build_command"
-    ]
+    build_command = config["tool"]["semantic_release"]["build_command"]  # type: ignore[attr-defined]
     exe = shell.split("/")[-1]
     with mock.patch(
         "subprocess.run", return_value=CompletedProcess(args=(), returncode=0)
@@ -561,6 +558,10 @@ def test_version_exit_code_when_not_strict(
     assert result.exit_code == 0
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 8),
+    reason="MagicMock.call_args does not include kwargs before Python 3.8",
+)
 @pytest.mark.usefixtures("example_project_with_release_notes_template")
 def test_custom_release_notes_template(
     mocked_git_push: MagicMock,

--- a/tests/command_line/test_version.py
+++ b/tests/command_line/test_version.py
@@ -5,6 +5,7 @@ import filecmp
 import re
 import shutil
 from subprocess import CompletedProcess
+from typing import TYPE_CHECKING
 from unittest import mock
 
 import pytest
@@ -13,8 +14,19 @@ from pytest_lazyfixture import lazy_fixture
 
 from semantic_release.cli import main, version
 
-from tests.const import EXAMPLE_PROJECT_NAME
-from tests.util import actions_output_to_dict, flatten_dircmp
+from tests.const import EXAMPLE_PROJECT_NAME, EXAMPLE_RELEASE_NOTES_TEMPLATE
+from tests.util import (
+    actions_output_to_dict,
+    flatten_dircmp,
+    get_release_history_from_context,
+)
+
+if TYPE_CHECKING:
+    from unittest.mock import MagicMock
+
+    from click.testing import CliRunner
+
+    from semantic_release.cli.config import RuntimeContext
 
 
 @pytest.mark.parametrize(
@@ -547,3 +559,38 @@ def test_version_exit_code_when_not_strict(
     # Testing "no release will be made"
     result = cli_runner.invoke(main, [version.name, "--no-push"])
     assert result.exit_code == 0
+
+
+def test_custom_release_notes_template(
+    mocked_git_push: MagicMock,
+    runtime_context_with_no_tags: RuntimeContext,
+    mocked_session_post: MagicMock,
+    cli_runner: CliRunner,
+) -> None:
+    """Verify the template `.release_notes.md.j2` from `template_dir` is used."""
+    # Arrange
+    # (see fixtures)
+
+    # Act
+    resp = cli_runner.invoke(main, [version.name, "--skip-build", "--vcs-release"])
+    release_history = get_release_history_from_context(runtime_context_with_no_tags)
+    tag = runtime_context_with_no_tags.repo.tags[-1].name
+    release_version = runtime_context_with_no_tags.version_translator.from_tag(tag)
+    release = release_history.released[release_version]
+
+    expected_release_notes = (
+        runtime_context_with_no_tags.template_environment.from_string(
+            EXAMPLE_RELEASE_NOTES_TEMPLATE
+        ).render(version=release_version, release=release)
+    )
+
+    # Assert
+    assert mocked_git_push.call_count == 2  # 1 for commit, 1 for tag
+    assert resp.exit_code == 0, (
+        "Unexpected failure in command "
+        f"'semantic-release {version.name} --skip-build --vcs-release': " + resp.stderr
+    )
+    mocked_session_post.assert_called_once()
+    assert (
+        mocked_session_post.call_args.kwargs["json"]["body"] == expected_release_notes
+    )

--- a/tests/command_line/test_version.py
+++ b/tests/command_line/test_version.py
@@ -561,6 +561,7 @@ def test_version_exit_code_when_not_strict(
     assert result.exit_code == 0
 
 
+@pytest.mark.usefixtures("example_project_with_release_notes_template")
 def test_custom_release_notes_template(
     mocked_git_push: MagicMock,
     runtime_context_with_no_tags: RuntimeContext,

--- a/tests/const.py
+++ b/tests/const.py
@@ -453,4 +453,13 @@ EXAMPLE_CHANGELOG_MD_CONTENT = r"""
 * ~Removed~ simplified cookie opt-out handling logic
 """
 
+EXAMPLE_RELEASE_NOTES_TEMPLATE = r"""## What's Changed
+{% for type_, commits in release["elements"] | dictsort %}
+### {{ type_ | capitalize }}
+{%- if type_ != "unknown" %}
+{% for commit in commits %}
+* {{ commit.commit.summary.rstrip() }} ([`{{ commit.short_hash }}`]({{ commit.hexsha | commit_hash_url }}))
+{%- endfor %}{% endif %}{% endfor %}
+"""  # noqa: E501
+
 RELEASE_NOTES = "# Release Notes"

--- a/tests/fixtures/example_project.py
+++ b/tests/fixtures/example_project.py
@@ -11,6 +11,7 @@ from tests.const import (
     EXAMPLE_PROJECT_NAME,
     EXAMPLE_PROJECT_VERSION,
     EXAMPLE_PYPROJECT_TOML_CONTENT,
+    EXAMPLE_RELEASE_NOTES_TEMPLATE,
     EXAMPLE_SETUP_CFG_CONTENT,
     EXAMPLE_SETUP_PY_CONTENT,
 )
@@ -57,6 +58,14 @@ def example_project(tmp_path):
         changelog_md = tmp_path / "CHANGELOG.md"
         changelog_md.write_text(EXAMPLE_CHANGELOG_MD_CONTENT)
         yield tmp_path
+
+
+@pytest.fixture
+def example_project_with_release_notes_template(example_project: Path) -> Path:
+    template_dir = example_project / "templates"
+    release_notes_j2 = template_dir / ".release_notes.md.j2"
+    release_notes_j2.write_text(EXAMPLE_RELEASE_NOTES_TEMPLATE)
+    return example_project
 
 
 @pytest.fixture

--- a/tests/fixtures/git_repo.py
+++ b/tests/fixtures/git_repo.py
@@ -47,6 +47,7 @@ def git_repo_factory(request, example_project):
         with repo.config_writer("repository") as config:
             config.set_value("user", "name", "semantic release testing")
             config.set_value("user", "email", "not_a_real@email.com")
+            config.set_value("commit", "gpgsign", False)
         repo.create_remote(name="origin", url=request.param)
         return repo
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -13,7 +13,12 @@ from semantic_release.cli.commands import main
 
 if TYPE_CHECKING:
     import filecmp
-    from typing import TypeAlias
+
+    try:
+        from typing import TypeAlias
+    except ImportError:
+        from typing_extensions import TypeAlias
+
     from unittest.mock import MagicMock
 
     from git import Repo


### PR DESCRIPTION
# Description

Allow end users to override the default `Jinja2` template for rendering release notes. 

If a file named `.release_notes.md.j2` exists in the configured [`template_dir`](https://python-semantic-release.readthedocs.io/en/latest/configuration.html#config-changelog-template-dir), it is used to render the release notes of a given VCS release.

Implements #660 

## Checklist

- [x] test implementation: see the following commits for this feature's two acceptance tests:
    1. c3f54c837072106e1bc470a32e2027e12fbf9ff6
    2. 476cedb135e7397e88eec6b25cb07c151ffb6559
    3. d648d79d40dba66d213bfd071a595d69d0bd8504
    4. 3565dcd178255be500ec161e3e042aae557b84f7
- [x] feature implementation: see 63d952a9de82de02ce0bd95a6fb73789f5913355 for the implementation of this feature
- [x] documentation updates:
    - 8dc1283ab19d2a148add449f28828d8ef69dd78c and 884bbf849988bc46883a5ceccb862dd2ed1dc521 update the [changelog_templates.html](https://python-semantic-release.readthedocs.io/en/latest/changelog_templates.html) Sphinx page to describe how to use this feature
    - 3f2a96adada229098b10671c9d48238f799be4e1 updates how the `--noop` argument is handled in the `version` and `changelog` commands to display the rendered release notes

## Misc. Notes

- f41fc57426afd619f5487c62b1f9bd29a2453806 was needed to fix a couple of preexisting `pre-commit` failures
- 148430562a9b39c96a81768819939ac70294bed6 was later reverted by 63d952a9de82de02ce0bd95a6fb73789f5913355
- 19a01f001c79b70b30cef4c2b7bd06f8ffb09f2a and baf050ac8d68fcd79f1aa69aba1c9b8620e1b886 cleaned up some of the type annotations and `pathlib` usage
- in addition to the acceptance tests, I also validated this change by running the following in one of my projects:
  ```sh
  # install python-semantic-release from my local clone of the project
  pip uninstall -y python-semantic-release    # remove the distribution from PyPI
  pip install -e ../python-semantic-release

  # create a release notes template
  cat <<EOF >templates/.release_notes.md.j2
  ## What's Changed
  {% for type_, commits in release["elements"] | dictsort %}
  {%- if type_ != "unknown" %}
  ### {{ type_ | capitalize }}
  {% for commit in commits %}
  * {{ commit.descriptions[0] }} by {{commit.commit.author.name}} in [`{{ commit.short_hash }}`]({{ commit.hexsha | commit_hash_url }})
  {%- endfor %}
  {% endif %}{% endfor %}
  EOF

  # simulate creating a new release
  semantic-release --noop version
  ```