### PR TITLE
docs(migration): fix comments about publish command

### DIFF
--- a/docs/migrating_from_v7.rst
+++ b/docs/migrating_from_v7.rst
@@ -176,7 +176,8 @@ To achieve a similar flow of logic such as
     4. Push the changes to the metadata and changelog to the remote repository
     5. Create a release in the remote version control system
     6. Build a wheel
-    7. Publish the wheel to PyPI and to the release in the remote VCS
+    7. Publish the wheel to PyPI
+    8. Publish the distribution artifacts to the release in the remote VCS
 
 You should run::
 
@@ -184,8 +185,9 @@ You should run::
     twine upload dist/*  # or whichever path your distributions are placed in
     semantic-release publish
 
-With steps 1-5 being handled by the :ref:`cmd-version` command, and steps 6 and 7
-handled by the :ref:`cmd-publish` command.
+With steps 1-6 being handled by the :ref:`cmd-version` command, step 7 being left
+to the developer to handle, and lastly step 8 to be handled by the
+:ref:`cmd-publish` command.
 
 .. _breaking-removed-define-option:
 


### PR DESCRIPTION
## Purpose

Update the migration documentation for clarity of what `publish` command does now as opposed to before.

## Rationale

This section was a great write up to explain how I can go about migrating from `v7` to `v8`, however I was very confused about the order of operations when I reviewed the version and publish code.  I corrected the steps and alignment to each command in this PR after reviewing the code segments.  This adjustment lines up with how `version` can/will run a new build and the second statement about removing the wrapped `twine` functionality.