### PR TITLE
test(commandline-main): prevent git gpgsign config from failing tests

### DIFF
--- a/tests/command_line/test_main.py
+++ b/tests/command_line/test_main.py
@@ -111,6 +111,7 @@ def test_uses_default_config_when_no_config_file_found(
     with repo.config_writer("repository") as config:
         config.set_value("user", "name", "semantic release testing")
         config.set_value("user", "email", "not_a_real@email.com")
+        config.set_value("commit", "gpgsign", False)
     repo.create_remote(name="origin", url="foo@barvcs.com:user/repo.git")
     repo.git.commit("-m", "feat: initial commit", "--allow-empty")
 


### PR DESCRIPTION
## Purpose

Fix issues when running command line tests when the global git configuration includes `commit.gpgsign = true`.

## Rationale

As my environment has the global configuration setting `commit.gpgsign` set to `true`, the scenario tests inherit this default setting.  When the scenario tests execute a commit, this setting applies. It was properly disabled in scenario tests but was not disabled in the fixture used by this `main` command line test.  This change replicates the scenario `git_repo.py` fixtures config modifications.
