### PR TITLE
fix(cmd-version): handle committing of git-ignored file gracefully

### DIFF
--- a/tests/command_line/test_version.py
+++ b/tests/command_line/test_version.py
@@ -389,7 +389,7 @@ def test_version_no_push_force_level(
     expected_new_version,
     example_project,
     example_pyproject_toml,
-    tmp_path_factory,
+    tmp_path_factory: pytest.TempPathFactory,
     cli_runner,
 ):
     tempdir = tmp_path_factory.mktemp("test_version")
@@ -415,7 +415,7 @@ def test_version_no_push_force_level(
     # Changelog already reflects changes this should introduce
     assert differing_files == [
         "pyproject.toml",
-        f"src/{EXAMPLE_PROJECT_NAME}/__init__.py",
+        f"src/{EXAMPLE_PROJECT_NAME}/_version.py",
     ]
 
     # Compare pyproject.toml
@@ -434,14 +434,14 @@ def test_version_no_push_force_level(
     assert old_pyproject_toml == new_pyproject_toml
     assert new_version == expected_new_version
 
-    # Compare __init__.py
+    # Compare _version.py
     new_init_py = (
-        (example_project / "src" / EXAMPLE_PROJECT_NAME / "__init__.py")
+        (example_project / "src" / EXAMPLE_PROJECT_NAME / "_version.py")
         .read_text(encoding="utf-8")
         .splitlines(keepends=True)
     )
     old_init_py = (
-        (tempdir / "src" / EXAMPLE_PROJECT_NAME / "__init__.py")
+        (tempdir / "src" / EXAMPLE_PROJECT_NAME / "_version.py")
         .read_text(encoding="utf-8")
         .splitlines(keepends=True)
     )
@@ -662,7 +662,7 @@ def test_version_only_update_files_no_git_actions(
     # Files that should receive version change
     assert differing_files == [
         "pyproject.toml",
-        f"src/{EXAMPLE_PROJECT_NAME}/__init__.py",
+        f"src/{EXAMPLE_PROJECT_NAME}/_version.py",
     ]
 
     # Compare pyproject.toml
@@ -681,20 +681,20 @@ def test_version_only_update_files_no_git_actions(
     assert old_pyproject_toml == new_pyproject_toml
     assert new_version == expected_new_version
 
-    # Compare __init__.py
-    new_init_py = (
-        (example_project / "src" / EXAMPLE_PROJECT_NAME / "__init__.py")
+    # Compare _version.py
+    new_version_py = (
+        (example_project / "src" / EXAMPLE_PROJECT_NAME / "_version.py")
         .read_text(encoding="utf-8")
         .splitlines(keepends=True)
     )
-    old_init_py = (
-        (tempdir / "src" / EXAMPLE_PROJECT_NAME / "__init__.py")
+    old_version_py = (
+        (tempdir / "src" / EXAMPLE_PROJECT_NAME / "_version.py")
         .read_text(encoding="utf-8")
         .splitlines(keepends=True)
     )
 
     d = difflib.Differ()
-    diff = list(d.compare(old_init_py, new_init_py))
+    diff = list(d.compare(old_version_py, new_version_py))
     added = [line[2:] for line in diff if line.startswith("+ ")]
     removed = [line[2:] for line in diff if line.startswith("- ")]
 

--- a/tests/const.py
+++ b/tests/const.py
@@ -180,7 +180,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.semantic_release]
 version_variables = [
-    "src/{EXAMPLE_PROJECT_NAME}/__init__.py:__version__",
+    "src/{EXAMPLE_PROJECT_NAME}/_version.py:__version__",
 ]
 version_toml = ["pyproject.toml:tool.poetry.version"]
 build_command = "bash -c \"echo 'Hello World'\""
@@ -375,7 +375,7 @@ def _read_long_description():
         return None
 
 
-with open("{EXAMPLE_PROJECT_NAME}/__init__.py", "r") as fd:
+with open("{EXAMPLE_PROJECT_NAME}/_version.py", "r") as fd:
     version = re.search(
         r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]', fd.read(), re.MULTILINE
     ).group(1)

--- a/tests/fixtures/example_project.py
+++ b/tests/fixtures/example_project.py
@@ -26,7 +26,7 @@ def cd(path: Path) -> Generator[Path, None, None]:
 
 
 @pytest.fixture
-def example_project(tmp_path):
+def example_project(tmp_path: "Path") -> "Generator[Path, None, None]":
     with cd(tmp_path):
         src_dir = tmp_path / "src"
         src_dir.mkdir()
@@ -35,16 +35,33 @@ def example_project(tmp_path):
         init_py = example_dir / "__init__.py"
         init_py.write_text(
             dedent(
-                f'''
+                '''
                 """
                 An example package with a very informative docstring
                 """
-                __version__ = "{EXAMPLE_PROJECT_VERSION}"
+                from ._version import __version__
 
 
                 def hello_world() -> None:
                     print("Hello World")
                 '''
+            )
+        )
+        version_py = example_dir / "_version.py"
+        version_py.write_text(
+            dedent(
+                f'''
+                __version__ = "{EXAMPLE_PROJECT_VERSION}"
+                '''
+            )
+        )
+        gitignore = tmp_path / ".gitignore"
+        gitignore.write_text(
+            dedent(
+                f"""
+                *.pyc
+                /src/**/{version_py.name}
+                """
             )
         )
         pyproject_toml = tmp_path / "pyproject.toml"


### PR DESCRIPTION
## Purpose

Fix a TypeError when one of the modified files during `version` command adds a file that matches a `.gitignore` pattern.

<!--
- Handle any resulting error from where all detected changes are actually ignored, leading to a failure of git commit on an empty index. This failure should be deliberate from the developer in my opinion which is the reason for the error message about `--no-commit`. Their alternative is to use `--tag` now that #752 is merged.
-->

## Rationale

I personally don't commit a change to the version number in my files when building my distribution. To enable my software to know its version number I write it to a file that is imported `_version.py`. This file is generated by the build system `setuptools_scm` and it makes it easy to have this file git-ignored.  When semantic-release executed the update to the version file, it tried to add it to the index and git rejects with an exit code unless the `--force` command is provided.  My recommendation (this implementation) is to catch this error gracefully and print a warning to the developer in case they did not desire it to be ignored.

## How I tested

I modified the current testing infrastructure to instead of using `__init__.py` as the version holder to instead use `_version.py` that can be our concept for an ignored file. I figured this helps the tests evenly hit more failure possibilities as we already have a file `pyproject.toml` that is being committed with a version number change.  This way we have one ignored and one committed for all tests.