### PR TITLE
fix(config): gracefully fail when repo is in a detached HEAD state

### DIFF
--- a/semantic_release/cli/config.py
+++ b/semantic_release/cli/config.py
@@ -257,8 +257,18 @@ class RuntimeContext:
         ##
         # credentials masking for logging
         masker = MaskingFilter(_use_named_masks=raw.logging_use_named_masks)
+
+        try:
+            active_branch = repo.active_branch.name
+        except TypeError as err:
+            raise NotAReleaseBranch(
+                "Detached HEAD state cannot match any release groups; "
+                "no release will be made"
+            ) from err
+
         # branch-specific configuration
-        branch_config = cls.select_branch_options(raw.branches, repo.active_branch.name)
+        branch_config = cls.select_branch_options(raw.branches, active_branch)
+
         # commit_parser
         commit_parser_cls = (
             _known_commit_parsers[raw.commit_parser]

--- a/tests/command_line/test_main.py
+++ b/tests/command_line/test_main.py
@@ -37,6 +37,20 @@ def test_not_a_release_branch_exit_code_with_strict(
     assert result.exit_code != 0
 
 
+def test_not_a_release_branch_detached_head_exit_code(
+    repo_with_git_flow_angular_commits, cli_runner
+):
+    expected_err_msg = "Detached HEAD state cannot match any release groups; no release will be made"
+
+    # cause repo to be in detached head state without file changes
+    repo_with_git_flow_angular_commits.git.checkout("HEAD", "--detach")
+    result = cli_runner.invoke(main, ["version", "--no-commit"])
+
+    # as non-strict, this will return success exit code
+    assert result.exit_code == 0
+    assert expected_err_msg in result.stderr
+
+
 @pytest.fixture
 def toml_file_with_no_configuration_for_psr(tmp_path):
     path = tmp_path / "config.toml"


### PR DESCRIPTION
## Purpose

Gracefully handle a TypeError when repository is in a detached HEAD state as occurs naturally in GitLab CI/CD environments.

## Rationale

As I was setting up this library to run within GitLab CI/CD, I ran into an unhandled TypeError because of the detached HEAD state that GitLab's Runner Helper image sets up the environment by default.  This is problematic due to the branch detection mechanism used in `python-semantic-release`. I opted to have the code gracefully catch this error and display a rationale to the user.  

I have devised a way to manually resolve this problem in GitLab in the step before `semantic-release` is called but have not implemented an internal correction method (match the detached HEAD SHA to an equivalent branch and checkout). At the current time it will be up to the developer to ensure the state is correct.

## How I tested

Outside of the manual integration tests I performed on GitLab, I added a test that purposefully mimics a detached HEAD state like GitLab does.