### PR TITLE
feat(utils): expand parsable valid git remote url formats

### DIFF
--- a/tests/unit/semantic_release/test_helpers.py
+++ b/tests/unit/semantic_release/test_helpers.py
@@ -1,0 +1,82 @@
+import pytest
+
+from semantic_release.helpers import ParsedGitUrl, parse_git_url
+
+
+@pytest.mark.parametrize(('url', 'expected'), [
+    (
+        "http://git.mycompany.com/username/myproject.git",
+        ParsedGitUrl("http", "git.mycompany.com", "username", "myproject")
+    ),
+    (
+        "https://github.com/username/myproject.git",
+        ParsedGitUrl("https", "github.com", "username", "myproject")
+    ),
+    (
+        "https://gitlab.com/group/subgroup/myproject.git",
+        ParsedGitUrl("https", "gitlab.com", "group/subgroup", "myproject")
+    ),
+    (
+        "https://git.mycompany.com:4443/username/myproject.git",
+        ParsedGitUrl("https", "git.mycompany.com:4443", "username", "myproject")
+    ),
+    (
+        "git://host.xz/path/to/repo.git/",
+        ParsedGitUrl("git", "host.xz", "path/to", "repo")
+    ),
+    (
+        "git://host.xz:9418/path/to/repo.git/",
+        ParsedGitUrl("git", "host.xz:9418", "path/to", "repo")
+    ),
+    (
+        "git@github.com:username/myproject.git",
+        ParsedGitUrl("ssh", "git@github.com", "username", "myproject")
+    ),
+    (
+        "ssh://git@github.com:3759/myproject.git",
+        ParsedGitUrl("ssh", "git@github.com", "3759", "myproject")
+    ),
+    (
+        "ssh://git@github.com:username/myproject.git",
+        ParsedGitUrl("ssh", "git@github.com", "username", "myproject")
+    ),
+    (
+        "ssh://git@bitbucket.org:7999/username/myproject.git",
+        ParsedGitUrl("ssh", "git@bitbucket.org:7999", "username", "myproject")
+    ),
+    (
+        "git+ssh://git@github.com:username/myproject.git",
+        ParsedGitUrl("ssh", "git@github.com", "username", "myproject")
+    ),
+    (
+        "/Users/username/dev/remote/myproject.git",
+        ParsedGitUrl("file", "", "Users/username/dev/remote", "myproject")
+    ),
+    (
+        "file:///Users/username/dev/remote/myproject.git",
+        ParsedGitUrl("file", "", "Users/username/dev/remote", "myproject")
+    ),
+    (
+        "C:/Users/username/dev/remote/myproject.git",
+        ParsedGitUrl("file", "", "C:/Users/username/dev/remote", "myproject")
+    ),
+    (
+        "file:///C:/Users/username/dev/remote/myproject.git",
+        ParsedGitUrl("file", "", "C:/Users/username/dev/remote", "myproject")
+    ),
+])
+def test_parse_valid_git_urls(url: str, expected: ParsedGitUrl):
+    """Test that a valid given git remote url is parsed correctly."""
+    assert expected == parse_git_url(url)
+
+
+@pytest.mark.parametrize('url', [
+    "icmp://git",
+    "abcdefghijklmnop.git",
+    "../relative/path/to/repo.git",
+    "http://domain/project.git"
+])
+def test_parse_invalid_git_urls(url: str):
+    """Test that an invalid git remote url throws a ValueError."""
+    with pytest.raises(ValueError):
+        parse_git_url(url)


### PR DESCRIPTION
## Purpose

Expand the compatibility to as many variants of valid git remote urls as git allows

## Rationale

In preparation to facilitate the request of #734, first we need to properly parse all valid git urls.  I found a stackoverflow reference that listed many of the possible urls and I built a unit test to match a set of them.  During implementation, I opted to coerce each input into an URL-parse compatible format which then could be easily broken up into the valid parts.

## How I tested

Build a paramaterized unit test with all the expected valid tests.

## How to verify

```sh
git fetch origin pull/771/head:pr-771

# checkout the PR as a detached HEAD state with only the unit tests
git checkout pr-771~1 --detach

# execute tests, 10 should fail with valid urls
pytest tests/unit/semantic_release/test_helpers.py

# update to the HEAD of the PR (with fixes)
git merge --ff-only pr-771

# run pytest again
pytest tests/unit/semantic_release/test_helpers.py
```
