### PR TITLE
fix(cli): gracefully output configuration validation errors

### DIFF
--- a/tests/fixtures/example_project.py
+++ b/tests/fixtures/example_project.py
@@ -1,10 +1,10 @@
 import os
-from contextlib import contextmanager
 from pathlib import Path
 from textwrap import dedent
-from typing import Generator
+from typing import TYPE_CHECKING, Generator
 
 import pytest
+import tomlkit
 
 from tests.const import (
     EXAMPLE_CHANGELOG_MD_CONTENT,
@@ -16,65 +16,76 @@ from tests.const import (
     EXAMPLE_SETUP_PY_CONTENT,
 )
 
+if TYPE_CHECKING:
+    from typing import Any, Protocol
 
-@contextmanager
-def cd(path: Path) -> Generator[Path, None, None]:
-    cwd = os.getcwd()
-    os.chdir(str(path.resolve()))
-    yield path
-    os.chdir(cwd)
+    ExProjectDir = Path
+
+    class UpdatePyprojectTomlFn(Protocol):
+        def __call__(self, setting: str, value: "Any") -> None:
+            ...
 
 
 @pytest.fixture
-def example_project(tmp_path: "Path") -> "Generator[Path, None, None]":
-    with cd(tmp_path):
-        src_dir = tmp_path / "src"
-        src_dir.mkdir()
-        example_dir = src_dir / EXAMPLE_PROJECT_NAME
-        example_dir.mkdir()
-        init_py = example_dir / "__init__.py"
-        init_py.write_text(
-            dedent(
-                '''
-                """
-                An example package with a very informative docstring
-                """
-                from ._version import __version__
+def change_to_tmp_dir(tmp_path: "Path") -> "Generator[None, None, None]":
+    cwd = os.getcwd()
+    os.chdir(str(tmp_path.resolve()))
+    try:
+        yield
+    finally:
+        os.chdir(cwd)
 
 
-                def hello_world() -> None:
-                    print("Hello World")
-                '''
-            )
+@pytest.fixture
+def example_project(change_to_tmp_dir: None) -> "ExProjectDir":
+    tmp_path = Path.cwd()
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    example_dir = src_dir / EXAMPLE_PROJECT_NAME
+    example_dir.mkdir()
+    init_py = example_dir / "__init__.py"
+    init_py.write_text(
+        dedent(
+            '''
+            """
+            An example package with a very informative docstring
+            """
+            from ._version import __version__
+
+
+            def hello_world() -> None:
+                print("Hello World")
+            '''
         )
-        version_py = example_dir / "_version.py"
-        version_py.write_text(
-            dedent(
-                f"""
-                __version__ = "{EXAMPLE_PROJECT_VERSION}"
-                """
-            )
+    )
+    version_py = example_dir / "_version.py"
+    version_py.write_text(
+        dedent(
+            f"""
+            __version__ = "{EXAMPLE_PROJECT_VERSION}"
+            """
         )
-        gitignore = tmp_path / ".gitignore"
-        gitignore.write_text(
-            dedent(
-                f"""
-                *.pyc
-                /src/**/{version_py.name}
-                """
-            )
+    )
+    gitignore = tmp_path / ".gitignore"
+    gitignore.write_text(
+        dedent(
+            f"""
+            *.pyc
+            /src/**/{version_py.name}
+            """
         )
-        pyproject_toml = tmp_path / "pyproject.toml"
-        pyproject_toml.write_text(EXAMPLE_PYPROJECT_TOML_CONTENT)
-        setup_cfg = tmp_path / "setup.cfg"
-        setup_cfg.write_text(EXAMPLE_SETUP_CFG_CONTENT)
-        setup_py = tmp_path / "setup.py"
-        setup_py.write_text(EXAMPLE_SETUP_PY_CONTENT)
-        template_dir = tmp_path / "templates"
-        template_dir.mkdir()
-        changelog_md = tmp_path / "CHANGELOG.md"
-        changelog_md.write_text(EXAMPLE_CHANGELOG_MD_CONTENT)
-        yield tmp_path
+    )
+    pyproject_toml = tmp_path / "pyproject.toml"
+    pyproject_toml.write_text(EXAMPLE_PYPROJECT_TOML_CONTENT)
+    setup_cfg = tmp_path / "setup.cfg"
+    setup_cfg.write_text(EXAMPLE_SETUP_CFG_CONTENT)
+    setup_py = tmp_path / "setup.py"
+    setup_py.write_text(EXAMPLE_SETUP_PY_CONTENT)
+    template_dir = tmp_path / "templates"
+    template_dir.mkdir()
+    changelog_md = tmp_path / "CHANGELOG.md"
+    changelog_md.write_text(EXAMPLE_CHANGELOG_MD_CONTENT)
+    return tmp_path
 
 
 @pytest.fixture
@@ -109,3 +120,30 @@ def example_changelog_md(example_project):
 @pytest.fixture
 def example_project_template_dir(example_project):
     return example_project / "templates"
+
+
+@pytest.fixture
+def update_pyproject_toml(
+    example_project: "Path", example_pyproject_toml: "Path"
+) -> "UpdatePyprojectTomlFn":
+    """Update the pyproject.toml file with the given content."""
+    def _update_pyproject_toml(setting: str, value: "Any") -> None:
+        with open(example_pyproject_toml) as rfd:
+            pyproject_toml = tomlkit.load(rfd)
+
+        new_setting = {}
+        parts = setting.split(".")
+        new_setting_key = parts.pop(-1)
+        new_setting[new_setting_key] = value
+
+        pointer = pyproject_toml
+        for part in parts:
+            if pointer.get(part, None) is None:
+                pointer.add(part, tomlkit.table())
+            pointer = pointer.get(part, {})
+        pointer.update(new_setting)
+
+        with open(example_pyproject_toml, 'w') as wfd:
+            tomlkit.dump(pyproject_toml, wfd)
+
+    return _update_pyproject_toml


### PR DESCRIPTION
## Purpose

Improve handling of exceptions to provide a useful message to user without stack trace

## Rationale

If a user puts in an invalid configuration setting, the configuration validator will throw a ValidationException that we do not catch gracefully. This causes python to dump a stack trace and hide the pretty ValidationError that pydantic provides by default.  

In order to set up the test appropriately, I found it useful to add a fixture that will modify the configuration file accordingly.  Meanwhile, I noticed that the implementation of example project was a bit fragile as exceptions are not handled well with generators or context managers unless explicitly using try/finally. With this modification I was able to align it more with the setup/teardown generator style fixtures as pytest recommends.

## How I tested

Created a command line test that modifies the configuration file to be incorrect before executing the `version` command. It evaluates the exit code and the stderr message to the user that there is a validation error and which component.

## How to verify

```sh
git fetch origin pull/772/head:pr/772

# checkout the PR as a detached HEAD state with only the unit tests
git checkout pr/772~1 --detach

# execute tests, should fail
pytest tests/ -k test_errors_when_config_file_invalid_configuration

# update to the HEAD of the PR (with fixes)
git merge --ff-only pr/772

# run pytest again (looking for success)
pytest tests/ -k test_errors_when_config_file_invalid_configuration

# run entire test suite for regression testing
PYTHONHASHSEED=123456 pytest tests/
```
