### PR TITLE
refactor(config): enable default environment token per hvcs

### DIFF
--- a/semantic_release/hvcs/__init__.py
+++ b/semantic_release/hvcs/__init__.py
@@ -3,3 +3,5 @@ from semantic_release.hvcs.gitea import Gitea
 from semantic_release.hvcs.github import Github
 from semantic_release.hvcs.gitlab import Gitlab
 from semantic_release.hvcs.token_auth import TokenAuth
+
+__all__ = ["Gitea", "Github", "Gitlab", "HvcsBase", "TokenAuth"]

--- a/semantic_release/hvcs/_base.py
+++ b/semantic_release/hvcs/_base.py
@@ -33,6 +33,8 @@ class HvcsBase:
     checking for NotImplemented around every method call.
     """
 
+    DEFAULT_ENV_TOKEN_NAME = "HVCS_TOKEN"
+
     def __init__(
         self,
         remote_url: str,

--- a/semantic_release/hvcs/gitea.py
+++ b/semantic_release/hvcs/gitea.py
@@ -36,6 +36,7 @@ class Gitea(HvcsBase):
     DEFAULT_DOMAIN = "gitea.com"
     DEFAULT_API_PATH = "/api/v1"
     DEFAULT_API_DOMAIN = f"{DEFAULT_DOMAIN}{DEFAULT_API_PATH}"
+    DEFAULT_ENV_TOKEN_NAME = "GITEA_TOKEN"
 
     # pylint: disable=super-init-not-called
     def __init__(

--- a/semantic_release/hvcs/github.py
+++ b/semantic_release/hvcs/github.py
@@ -37,6 +37,7 @@ class Github(HvcsBase):
     DEFAULT_DOMAIN = "github.com"
     DEFAULT_API_DOMAIN = "api.github.com"
     DEFAULT_UPLOAD_DOMAIN = "uploads.github.com"
+    DEFAULT_ENV_TOKEN_NAME = "GH_TOKEN"
 
     def __init__(
         self,

--- a/semantic_release/hvcs/gitlab.py
+++ b/semantic_release/hvcs/gitlab.py
@@ -38,6 +38,10 @@ class Gitlab(HvcsBase):
     API domain
     """
 
+    DEFAULT_ENV_TOKEN_NAME = "GITLAB_TOKEN"
+    # purposefully not CI_JOB_TOKEN as it is not a personal access token,
+    # It is missing the permission to push to the repository, but has all others (releases, packages, etc.)
+
     DEFAULT_DOMAIN = "gitlab.com"
 
     def __init__(


### PR DESCRIPTION
## Purpose

Update the configuration parser to optionally default to the VCS specific token

## Rationale

In preparation to facilitate the request of #734, I need to find a way to solve the missing token when the `remote.type` is `none`.  This led me to determining that it would be helpful if we looked for the default token names for each of the VCS. This refactor enables the configuration to be aware of each VCS's default.  

Current downside is that `Gitea` does not provide a pre-authed CI-like token based on [this discussion](https://github.com/go-gitea/gitea/issues/20394).  I just guessed to use `GITEA_TOKEN`. I could potentially have it be empty instead, which would force the user to provide it.

Consideration also should be made for `GitLab` as GitLab's default token `CI_JOB_TOKEN` has permissions problems with `python-semantic-release`.  The fact that `python-semantic-release` uses `git push` both commits and tags are both unauthorized actions by a `CI_JOB_TOKEN`.  This means users are forced to provide a PAT as that is how we mark versions. What the users define as that token name is up to them. My guess would be to use `GITLAB_TOKEN` but maybe we need to force them to be specific here also. Curious on your thoughts.

Separately, there is still some investigation that I'm doing here to hopefully find a better implementation for GitLab.

One of the other issues (besides for `none`) that I have with the current implementation is that if the user does not know to specify a token value or forgets, we default to `GH_TOKEN` when I have specified `remote.type = 'gitlab'`.

## How I tested

Build a paramaterized unit test with all the expected valid & invalid tests.

## How to verify

```sh
git fetch origin pull/774/head:pr-774

# checkout the PR as a detached HEAD state with only the unit tests
git checkout pr-774~1 --detach

# execute tests, 2 should fail (non-github)
pytest tests/unit/semantic_release/cli/test_config.py

# update to the HEAD of the PR (with fixes)
git merge --ff-only pr-774

# run pytest again to see success
pytest tests/unit/semantic_release/cli/test_config.py
```
