### PR TITLE
feat(cmd-version): changelog available to bundle

### DIFF
--- a/tests/command_line/test_version.py
+++ b/tests/command_line/test_version.py
@@ -672,18 +672,19 @@ def test_version_tag_only_push(
 def test_version_only_update_files_no_git_actions(
     mocked_git_push: MagicMock,
     repo_with_single_branch_and_prereleases_angular_commits: Repo,
-    use_release_notes_template: UseReleaseNotesTemplateFn,
     retrieve_runtime_context: RetrieveRuntimeContextFn,
     cli_runner: CliRunner,
     tmp_path_factory: pytest.TempPathFactory,
     example_pyproject_toml: Path,
     example_project_dir: ExProjectDir,
+    example_changelog_md: Path,
 ) -> None:
     # Setup
-    use_release_notes_template()
     runtime_context_with_tags = retrieve_runtime_context(
         repo_with_single_branch_and_prereleases_angular_commits
     )
+    # Remove the previously created changelog to allow for it to be generated
+    example_changelog_md.unlink()
 
     # Arrange
     expected_new_version = "0.3.0"
@@ -718,8 +719,7 @@ def test_version_only_update_files_no_git_actions(
     # Files that should receive version change
     expected_changed_files = sorted(
         [
-            # CHANGELOG.md is not included as no modification to Git History
-            # (no commit or tag) has been made
+            "CHANGELOG.md",
             "pyproject.toml",
             f"src/{EXAMPLE_PROJECT_NAME}/_version.py",
         ]

--- a/tests/util.py
+++ b/tests/util.py
@@ -106,7 +106,7 @@ def netrc_file(machine: str) -> NamedTemporaryFile:
 
 
 def flatten_dircmp(dcmp: filecmp.dircmp) -> list[str]:
-    return dcmp.diff_files + [
+    return dcmp.diff_files + dcmp.left_only + dcmp.right_only + [
         os.sep.join((directory, file))
         for directory, cmp in dcmp.subdirs.items()
         for file in flatten_dircmp(cmp)


### PR DESCRIPTION
## Purpose

Adjust order of operations during `semantic-release version` command to build changelog prior to `build_command` execution. 

## Rationale

I desire to have the ability to generate the changelog and mark versions without creating a commit or tag, and also the ability to bundle the changelog into the bundle. This is currently unavailable due to the order of execution.  This modification moves changelog generation up before the build command which allows the build_command to bundle it in.  The commits don't change either but instead this consolidates adding to the index into one git command prior to the commit.

## How did I test?

Successful refactor is captured by:
- `tests/command_line/test_version.py::test_version_only_update_files_no_git_actions()` - where the CHANGELOG is now a part of the commit of changed files along with the other version modifications
- `tests/command_line/test_version.py::test_version_no_push_force_level()` - where changelog is now a part of the commit of changed files along with the version modifications

## How to verify

```sh
git fetch origin pull/779/head:pr-779

# checkout the PR as a detached HEAD state with only the unit tests
git checkout pr-779~1 --detach

# execute tests, # should fail
pytest tests/command_line/test_version.py

# update to the HEAD of the PR (with fixes)
git merge --ff-only pr-779

# run pytest again to see success
pytest tests/command_line/test_version.py
```

Review entire test suite to validate no regressions occurred (see CI pipeline results)
