### PR TITLE
fix(cli-generate-config): ensure configuration types are always toml parsable

### DIFF
--- a/semantic_release/cli/commands/generate_config.py
+++ b/semantic_release/cli/commands/generate_config.py
@@ -40,7 +40,9 @@ def generate_config(fmt: str = "toml", is_pyproject_toml: bool = False) -> None:
 
         semantic-release generate-config -f toml >> pyproject.toml
     """
-    config = RawConfig().model_dump(exclude_none=True)
+    # due to possible IntEnum values (which are not supported by tomlkit.dumps, see sdispater/tomlkit#237),
+    # we must ensure the transformation of the model to a dict uses json serializable values
+    config = RawConfig().model_dump(mode="json", exclude_none=True)
 
     config_dct = {"semantic_release": config}
     if is_pyproject_toml and fmt == "toml":

--- a/tests/command_line/test_generate_config.py
+++ b/tests/command_line/test_generate_config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from typing import TYPE_CHECKING
 
 import pytest
 import tomlkit
@@ -8,37 +9,53 @@ import tomlkit
 from semantic_release.cli.commands.generate_config import generate_config
 from semantic_release.cli.config import RawConfig
 
+if TYPE_CHECKING:
+    from typing import Any
+
+    from tests.command_line.conftest import CliRunner
+
+
+@pytest.fixture
+def raw_config_dict() -> dict[str, Any]:
+    return RawConfig().model_dump(mode="json", exclude_none=True)
+
 
 @pytest.mark.parametrize("args", [(), ("--format", "toml"), ("--format", "TOML")])
-def test_generate_config_toml(cli_runner, args):
+def test_generate_config_toml(
+    cli_runner: CliRunner, args: tuple[str], raw_config_dict: dict[str, Any]
+):
+    expected_config_as_str = tomlkit.dumps(
+        {"semantic_release": raw_config_dict}
+    ).strip()
+
     result = cli_runner.invoke(generate_config, args)
+
     assert result.exit_code == 0
-    assert (
-        result.output.strip()
-        == tomlkit.dumps(
-            {"semantic_release": RawConfig().model_dump(exclude_none=True)}
-        ).strip()
-    )
+    assert expected_config_as_str == result.output.strip()
 
 
 @pytest.mark.parametrize("args", [("--format", "json"), ("--format", "JSON")])
-def test_generate_config_json(cli_runner, args):
+def test_generate_config_json(
+    cli_runner: CliRunner, args: tuple[str], raw_config_dict: dict[str, Any]
+):
+    expected_config_as_str = json.dumps(
+        {"semantic_release": raw_config_dict}, indent=4
+    ).strip()
+
     result = cli_runner.invoke(generate_config, args)
+
     assert result.exit_code == 0
-    assert (
-        result.output.strip()
-        == json.dumps(
-            {"semantic_release": RawConfig().model_dump(exclude_none=True)}, indent=4
-        ).strip()
-    )
+    assert expected_config_as_str == result.output.strip()
 
 
-def test_generate_config_pyproject_toml(cli_runner):
+def test_generate_config_pyproject_toml(
+    cli_runner: CliRunner, raw_config_dict: dict[str, Any]
+):
+    expected_config_as_str = tomlkit.dumps(
+        {"tool": {"semantic_release": raw_config_dict}}
+    ).strip()
+
     result = cli_runner.invoke(generate_config, ["--format", "toml", "--pyproject"])
+
     assert result.exit_code == 0
-    assert (
-        result.output.strip()
-        == tomlkit.dumps(
-            {"tool": {"semantic_release": RawConfig().model_dump(exclude_none=True)}}
-        ).strip()
-    )
+    assert expected_config_as_str == result.output.strip()

--- a/tests/unit/semantic_release/cli/test_config.py
+++ b/tests/unit/semantic_release/cli/test_config.py
@@ -52,7 +52,7 @@ def test_invalid_hvcs_type(remote_config: dict[str, Any]):
 def test_default_toml_config_valid(example_project):
     default_config_file = example_project / "default.toml"
     default_config_file.write_text(
-        tomlkit.dumps(RawConfig().model_dump(exclude_none=True))
+        tomlkit.dumps(RawConfig().model_dump(mode='json', exclude_none=True))
     )
 
     written = default_config_file.read_text(encoding="utf-8")


### PR DESCRIPTION
## Purpose

Ensure that when converting pydantic configuration objects into TOML, the TOML comes out parsable.

## Rationale

When working on #782, I ran into a problem where the TOML generated was unparsable due to the use of a subclass of IntEnum.  The `LevelBump(IntEnum)` caused the string produced by the `__str__()` to not be surrounded in quotations in the resulting TOML. 

This led to discovering that the Tomlkit developer refuses to attempt to address serialization of enums due to the shifting position of Python implementation of enums across versions of python (sdispater/tomlkit#237).  Since Tomlkit will not support enums, we must prevent enum objects from being passed to `tomlkit.dumps()`.  Pydantic saves the day with the parameter `mode` for the `model_dumps()` function which can be set to `json` and it will force the returning dictionary to always use types that are JSON serializable instead of Python classes which may or may not be serializable when passed to `tomlkit`. I also looked for a possible custom TOML serialize function that could be overrided but `tomlkit` does not have one. The effect on IntEnums such as `LevelBump` caused the result to be the numeric value of the enum as opposed to the string. The numeric value is effectively written out via `tomlkit.dumps()` and then through `pydantic` coercion it is parsed back into the proper enum value.

## How I tested

I was developing on #782, when the default AngularParserOptions included the `default_level_bump: LevelBump`, it would not generate a parsable toml. You can prove this by adding the `default_level_bump: LevelBump.NO_RELEASE` to the default `commit_parser_options` of `RawConfig` and then attempt to run the dump command. You will see a 
`default_level_bump = no_release` without quotes! Try to parse with `tomlkit` again and it will fail on the `n` of `no_release`.

Outside of the manual discovery above using the `default_level_bump: LevelBump` as a `commit_parser_option`, I updated the cli generate-config command testing. This particular testing isn't quite apparent of the problem as there are not any current default values which are non-json serializable, but with #782, there will be!

## How to verify

```sh
git fetch origin pull/785/head:pr-785

# checkout the PR as a detached HEAD state with only the unit tests
git checkout pr-785~1 --detach

# execute tests
pytest tests/command_line/test_generate_config.py

# update to the HEAD of the PR (with fixes)
git merge --ff-only pr-785

# run pytest again to see success
pytest tests/command_line/test_generate_config.py
```

And of course, all tests work as with the CI results below.
