### PR TITLE
docs(configuration): change defaults definition of token default to table

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -579,12 +579,16 @@ environment variable if you wish.
 
 
 The default value for this setting depends on what you specify as
-:ref:`remote.type <config-remote-type>`. If you set ``remote.type = "github"``,
-the default value for ``remote.token`` will be ``{ env = "GH_TOKEN" }``;
-if you set ``remote.type = "gitlab"``, the default value will be
-``{ env = "GITLAB_TOKEN" }``; and if you set ``remote.type = "gitea"``, the
-default value of ``remote.token`` will be ``{ env = "GITEA_TOKEN" }``.
+:ref:`remote.type <config-remote-type>`. Review the table below to see what the
+default token value will be for each remote type.
 
+================  ==  ============================
+``remote.type``       Default ``remote.token``
+================  ==  ============================
+``"github"``      ->  ``{ env = "GH_TOKEN" }``
+``"gitlab"``      ->  ``{ env = "GITLAB_TOKEN" }``
+``"gitea"``       ->  ``{ env = "GITEA_TOKEN" }``
+================  ==  ============================
 
 **Default:** ``{ env = "<envvar name>" }``, where ``<envvar name>`` depends on
 :ref:`remote.type <config-remote-type>` as indicated above.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -129,11 +129,11 @@ usage. This token should be stored in the ``GH_TOKEN`` environment variable
 To generate a token go to https://github.com/settings/tokens
 and click on *Personal access token*.
 
-GitLab (``GL_TOKEN``)
-"""""""""""""""""""""
+GitLab (``GITLAB_TOKEN``)
+"""""""""""""""""""""""""
 
 A personal access token from GitLab. This is used for authenticating when pushing
-tags, publishing releases etc. This token should be stored in the ``GL_TOKEN``
+tags, publishing releases etc. This token should be stored in the ``GITLAB_TOKEN``
 environment variable.
 
 Gitea (``GITEA_TOKEN``)


### PR DESCRIPTION
## Purpose

Improve readability of defaults relating to `remote.token`.

## Rationale

I forgot to update the docs with #774, and I was thinking this would be clearer than the paragraph of consecutive if-then statements in text.

## Evaluate

```sh
sphinx-autobuild --open-browser docs docs/_build/html
```

http://127.0.0.1:8000/configuration.html#token-dict-env-str
