### PR TITLE
ci: add grouped github-actions section to dependabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -14,3 +14,18 @@ updates:
       - dependencies
     open-pull-requests-limit: 10
     rebase-strategy: auto
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "18:00"
+    commit-message:
+      prefix: "ci"
+    labels:
+      - dependencies
+    rebase-strategy: auto
+    groups:
+      github-actions:
+        patterns:
+        - "*"


### PR DESCRIPTION
This PR proposes the following changes:

- add a grouped github-actions section to the dependabot config

This will generate a single pull request containing all updates to GitHub Actions in the project.

What do you think?

Refs:
- https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/

Example PR:
- https://github.com/afuetterer/python-semantic-release/pull/10