### PR TITLE
chore: modernize ruff configuration to work with ruff >= 0.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,9 +163,17 @@ allow_incomplete_defs = true
 allow_untyped_calls = true
 
 [tool.ruff]
+line-length = 88
+target-version = "py38"
+force-exclude = true
+output-format = "grouped"
+show-fixes = true
+src = ["semantic_release", "tests"]
+
+[tool.ruff.lint]
 select = ["ALL"]
 
-# See https://beta.ruff.rs/docs/rules
+# See https://docs.astral.sh/ruff/rules/
 # for any of these codes you can also run `ruff rule [CODE]`
 # which explains it in the terminal
 ignore = [
@@ -257,14 +265,7 @@ ignore = [
 ]
 
 external = ["V"]
-target-version = "py38"
-force-exclude = true
-line-length = 88
-output-format = "grouped"
 ignore-init-module-imports = true
-show-source = true
-show-fixes = true
-src = ["semantic_release", "tests"]
 task-tags = ["NOTE", "TODO", "FIXME", "XXX"]
 
 [tool.ruff.format]
@@ -272,7 +273,7 @@ quote-style = "double"
 indent-style = "space"
 line-ending = "lf"
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 # Imported but unused
 "__init__.py" = ["F401"]
 # pydantic 1 can't handle __future__ annotations-enabled syntax on < 3.10
@@ -306,28 +307,28 @@ line-ending = "lf"
   "ANN",
 ]
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 max-complexity = 10
 
-[tool.ruff.flake8-implicit-str-concat]
+[tool.ruff.lint.flake8-implicit-str-concat]
 allow-multiline = true
 
-[tool.ruff.flake8-quotes]
+[tool.ruff.lint.flake8-quotes]
 inline-quotes = "double"
 multiline-quotes = "double"
 
-[tool.ruff.flake8-tidy-imports]
+[tool.ruff.lint.flake8-tidy-imports]
 ban-relative-imports = "all"
 
-[tool.ruff.flake8-type-checking]
+[tool.ruff.lint.flake8-type-checking]
 strict = true
 
-[tool.ruff.flake8-pytest-style]
+[tool.ruff.lint.flake8-pytest-style]
 fixture-parentheses = false
 mark-parentheses = false
 parametrize-names-type = "csv"
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 # required-imports = ["from __future__ import annotations"]
 combine-as-imports = true
 known-first-party = ["semantic_release"]


### PR DESCRIPTION
This PR proposes the following changes:

- update the ruff configuration to use e.g. `[tool.ruff.lint]` and `[tool.ruff.lint.flake8-quotes]`

Refs:
- https://docs.astral.sh/ruff/configuration/