### PR TITLE
feat: add a new type of hvcs for gitlab to support Gitlab Job Tokens

### DIFF
--- a/docs/automatic-releases/gitlab-ci.rst
+++ b/docs/automatic-releases/gitlab-ci.rst
@@ -1,0 +1,137 @@
+.. _github-actions:
+
+Setting up python-semantic-release on Gitlab CI
+====================================================
+
+Python Semantic Release can run on Gitlab CI using two mechanisms.
+The first one uses a personal access token and the second one uses a Job Token.
+
+Gitlab Ci `Job Token <https://docs.gitlab.com/ee/ci/jobs/ci_job_token.html>`_ are generated on the fly when a CI
+pipeline is triggered.
+The token has the same permissions to access the API as the user that caused the job to run, but with a subset of API
+routes available. While safer than a
+`Personal Access Token (PAT) <https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html>`_, it is not able
+to push new commits to the repository although discussions are ongoing on the subject (cfr `issue 389060
+<https://gitlab.com/gitlab-org/gitlab/-/issues/389060>`_).
+
+
+Using a personal access token (PAT)
+-------------------------------------
+
+Once you have `created a PAT <https://docs.gitlab.com/ee/user/profile/personal_access_tokens
+.html#create-a-personal-access-token>`_,  you can add it as a secret variable in your Gitlab CI project under the
+name GL_TOKEN.
+
+In order to use gitlab token you need to configure python semantic release by adding the following to your
+pyproject.toml file:
+
+.. code:: toml
+
+    [tool.semantic_release]
+    remote.type = "gitlab"
+
+Normally using  the following .gitlab-ci.yml should be enough to get you started:
+
+.. code:: yaml
+
+    stages:
+      - publish # Deploy new version of package to registry
+
+    # Official language image. Look for the different tagged releases at:
+    # https://hub.docker.com/r/library/python/tags/
+    image: python:latest
+
+    variables:
+      PIP_CACHE_DIR: $CI_PROJECT_DIR/.cache/pip # Set folder in working dir for cache
+
+    # Runs on commit in main branch that were not made by the semantic-release job
+    version_and_publish:
+      stage: publish
+      image: python:latest
+      variables:
+        GIT_DEPTH: 0
+      before_script:
+        - pip install python-semantic-release
+        - pip install twine
+      script:
+        - git checkout "$CI_COMMIT_REF_NAME"
+        - semantic-release version
+        - |
+          if [ "dist" ]; then
+            TWINE_PASSWORD=${CI_JOB_TOKEN} TWINE_USERNAME=gitlab-ci-token python -m twine upload --repository-url ${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/pypi dist/*
+          fi
+      cache:
+        paths:
+          - ${PIP_CACHE_DIR}
+      rules:
+        # Don't run on automatic commits
+        - if: $CI_COMMIT_AUTHOR =~ /semantic-release.*/
+          when: never
+        # Only run on main/master branch
+        - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+
+Using a Job Token
+------------------
+In order to use gitlab-ci job token you need to configure python semantic release by adding the following to your
+pyproject.toml file:
+
+.. code:: toml
+
+    [tool.semantic_release]
+    remote.type = "gitlab-ci"
+    remote.ignore_token_for_push = "true"
+
+The following workflow is proposed to the reader.
+
+A `Project Access Token <https://docs.gitlab.com/ee/user/project/settings/project_access_tokens.html>`_ is created in Gitlab and given the right to push to the main branch.
+This token is added as a secret variable in your Gitlab CI project under the name ``GL_PROJECT_TOKEN_NAME`` and
+``GL_PROJECT_TOKEN``. This token should only have write access to the repository, it does not require API access.
+If you are using Gitlab Premium or Ultimate, you can make this token a guest to further restrain the token's scope,
+and specify it as the sole person allowed to push to the master branch.
+Otherwise, you will have to grant that project access token a sufficiently high access privilege that it can push to
+the main branch.
+
+The following .gitlab-ci.yml should be enough to get you started:
+
+.. code:: yaml
+
+    stages:
+      - publish # Deploy new version of package to registry
+
+    # Official language image. Look for the different tagged releases at:
+    # https://hub.docker.com/r/library/python/tags/
+    image: python:latest
+
+    variables:
+      PIP_CACHE_DIR: $CI_PROJECT_DIR/.cache/pip # Set folder in working dir for cache
+
+    # Runs on commit in main branch that were not made by the semantic-release job
+    # Using GITLAB_USER_EMAIL in the GIT_COMMIT_AUTHOR will display the person who
+    # triggered the job either by clicking the merge button or pushing to master
+    # as the author of the commit.
+    version_and_publish:
+      stage: publish
+      image: python:latest
+      variables:
+        GIT_DEPTH: 0
+        GIT_COMMIT_AUTHOR: "$GL_PROJECT_TOKEN_NAME <$GITLAB_USER_EMAIL>"
+      before_script:
+        - pip install python-semantic-release
+        - pip install twine
+      script:
+        - git checkout "$CI_COMMIT_REF_NAME"
+        - git remote set-url origin https://${GL_PROJECT_TOKEN_NAME}:${GL_PROJECT_TOKEN}@${CI_REPOSITORY_URL#*@}
+        - semantic-release version
+        - |
+          if [ "dist" ]; then
+            TWINE_PASSWORD=${CI_JOB_TOKEN} TWINE_USERNAME=gitlab-ci-token python -m twine upload --repository-url ${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/pypi dist/*
+          fi
+      cache:
+        paths:
+          - ${PIP_CACHE_DIR}
+      rules:
+        # Don't run on automatic commits
+        - if: $CI_COMMIT_AUTHOR =~ /$GL_PROJECT_TOKEN_NAME.*/
+          when: never
+        # Only run on main/master branch
+        - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH

--- a/docs/automatic-releases/index.rst
+++ b/docs/automatic-releases/index.rst
@@ -15,6 +15,7 @@ Guides
 .. toctree::
     travis
     github-actions
+    gitlab-ci
     cronjobs
 
 .. _automatic-github:

--- a/semantic_release/cli/config.py
+++ b/semantic_release/cli/config.py
@@ -43,6 +43,7 @@ log = logging.getLogger(__name__)
 class HvcsClient(str, Enum):
     GITHUB = "github"
     GITLAB = "gitlab"
+    GITLABCI = "gitlab-ci"
     GITEA = "gitea"
 
 
@@ -57,6 +58,7 @@ _known_commit_parsers = {
 _known_hvcs: Dict[HvcsClient, Type[hvcs.HvcsBase]] = {
     HvcsClient.GITHUB: hvcs.Github,
     HvcsClient.GITLAB: hvcs.Gitlab,
+    HvcsClient.GITLABCI: hvcs.GitlabCi,
     HvcsClient.GITEA: hvcs.Gitea,
 }
 

--- a/semantic_release/hvcs/__init__.py
+++ b/semantic_release/hvcs/__init__.py
@@ -2,6 +2,7 @@ from semantic_release.hvcs._base import HvcsBase
 from semantic_release.hvcs.gitea import Gitea
 from semantic_release.hvcs.github import Github
 from semantic_release.hvcs.gitlab import Gitlab
+from semantic_release.hvcs.gitlab_ci import GitlabCi
 from semantic_release.hvcs.token_auth import TokenAuth
 
-__all__ = ["Gitea", "Github", "Gitlab", "HvcsBase", "TokenAuth"]
+__all__ = ["Gitea", "Github", "Gitlab", "GitlabCi", "HvcsBase", "TokenAuth"]

--- a/semantic_release/hvcs/gitlab_ci.py
+++ b/semantic_release/hvcs/gitlab_ci.py
@@ -1,0 +1,174 @@
+"""Helper code for interacting with a Gitlab remote VCS"""
+from __future__ import annotations
+
+import logging
+import mimetypes
+import os
+from functools import lru_cache
+
+from requests import PreparedRequest
+from requests.auth import AuthBase
+from requests.exceptions import HTTPError
+
+from semantic_release.helpers import logged_function
+from semantic_release.hvcs._base import HvcsBase, _not_supported
+from semantic_release.hvcs.util import build_requests_session
+
+log = logging.getLogger(__name__)
+
+# Add a mime type for wheels
+# Fix incorrect entries in the `mimetypes` registry.
+# On Windows, the Python standard library's `mimetypes` reads in
+# mappings from file extension to MIME type from the Windows
+# registry. Other applications can and do write incorrect values
+# to this registry, which causes `mimetypes.guess_type` to return
+# incorrect values, which causes TensorBoard to fail to render on
+# the frontend.
+# This method hard-codes the correct mappings for certain MIME
+# types that are known to be either used by python-semantic-release or
+# problematic in general.
+mimetypes.add_type("application/octet-stream", ".whl")
+mimetypes.add_type("text/markdown", ".md")
+
+
+class GitlabJobTokenAuth(AuthBase):
+    """
+    requests Authentication for gitlab job token based authorization.
+    This allows us to attach the Authorization header with a token to a session.
+    """
+
+    def __init__(self, token: str) -> None:
+        self.token = token
+
+    def __eq__(self, other: object) -> bool:
+        return self.token == getattr(other, "token", None)
+
+    def __ne__(self, other: object) -> bool:
+        return not self == other
+
+    def __call__(self, req: PreparedRequest) -> PreparedRequest:
+        req.headers["JOB-TOKEN"] = f"{self.token}"
+        return req
+
+
+class GitlabCi(HvcsBase):
+    """
+    Gitlab helper class
+    Note Gitlab doesn't really have the concept of a separate
+    API domain
+    """
+
+    DEFAULT_ENV_TOKEN_NAME = "CI_JOB_TOKEN"  # noqa: S105
+
+    def __init__(
+        self,
+        remote_url: str,
+        hvcs_domain: str | None = None,  # noqa: ARG002
+        hvcs_api_domain: str | None = None,  # noqa: ARG002
+        token: str | None = None,  # noqa: ARG002
+    ) -> None:
+        self._remote_url = remote_url
+        try:
+            self.api_url = os.environ["CI_API_V4_URL"]
+            self.hvcs_api_domain = os.environ['CI_SERVER_HOST']
+            self.hvcs_domain = os.environ['CI_SERVER_HOST']
+            self.project_id = os.environ["CI_PROJECT_ID"]
+            self.token = os.environ["CI_JOB_TOKEN"]
+            self._get_repository_owner_and_name()
+        except KeyError as err:
+            raise ValueError("this hvcs type can only run in Gitlab-CI, "
+                             "for use outside gitlab-CI please use the gitlab type.") from err
+
+        auth = GitlabJobTokenAuth(self.token)
+        self.session = build_requests_session(auth=auth)
+
+
+    @lru_cache(maxsize=1)
+    def _get_repository_owner_and_name(self) -> tuple[str, str]:
+        """
+        Get the repository owner and name from GitLab CI environment variables, if
+        available, otherwise from parsing the remote url
+        """
+        return os.environ["CI_PROJECT_NAMESPACE"], os.environ["CI_PROJECT_NAME"]
+
+    @logged_function(log)
+    def create_release(
+        self,
+        tag: str,
+        release_notes: str,
+        prerelease: bool = False,  # noqa: ARG002
+    ) -> str:
+        """
+        Create a new release
+        https://docs.gitlab.com/ee/api/releases/index.html#create-a-release
+        :param tag: Tag to create release for
+        :param release_notes: The release notes for this version
+        :param prerelease: This parameter has no effect
+        :return: the tag (N.B. the tag is the unique ID of a release for Gitlab)
+        """
+        log.info("Creating release for tag %s", tag)
+        self.session.post(
+            f"{self.api_url}/projects/{self.project_id}/releases",
+            json={
+                "name": "Release " + tag,
+                "tag_name": tag,
+                "description": release_notes,
+            }
+        )
+        log.info("Successfully created release for: %s", tag)
+        return tag
+
+    # TODO: make str types accepted here
+    @logged_function(log)
+    def edit_release_notes(  # type: ignore[override]
+        self,
+        release_id: str,
+        release_notes: str,
+    ) -> str:
+        """
+        Edit a release with updated change notes
+        https://docs.github.com/rest/reference/repos#update-a-release
+        :param release_id: tag of the release
+        :param release_notes: The release notes for this version
+        :return: The tag of the release that was edited.
+        """
+        log.info("Updating release %s", release_id)
+        self.session.put(
+            f"{self.api_url}/projects/{self.project_id}/releases/{release_id}",
+            json={"description": release_notes},
+        )
+        return release_id
+
+    @logged_function(log)
+    def create_or_update_release(
+        self, tag: str, release_notes: str, prerelease: bool = False
+    ) -> str:
+        try:
+            return self.create_release(
+                tag=tag, release_notes=release_notes, prerelease=prerelease
+            )
+        except HTTPError:
+            # POSSIBLE IMPROVEMENT: Could check that it is indeed because the tag existed.
+            log.info(
+                "Release %s could not be created for project %s/%s",
+                tag,
+                self.owner,
+                self.repo_name,
+            )
+            return self.edit_release_notes(release_id=tag, release_notes=release_notes)
+
+    def compare_url(self, from_rev: str, to_rev: str) -> str:
+        return f"https://{self.hvcs_domain}/{self.owner}/{self.repo_name}/-/compare/{from_rev}...{to_rev}"
+
+    def remote_url(self, use_token: bool = True) -> str:
+        """Get the remote url including the token for authentication if requested"""
+        if not (self.token and use_token):
+            return self._remote_url
+        _not_supported(self, "remote_url with use_token set to True")
+        return self._remote_url
+
+    def commit_hash_url(self, commit_hash: str) -> str:
+        return f"https://{self.hvcs_domain}/{self.owner}/{self.repo_name}/-/commit/{commit_hash}"
+
+    def pull_request_url(self, pr_number: str | int) -> str:
+        return f"https://{self.hvcs_domain}/{self.owner}/{self.repo_name}/-/issues/{pr_number}"

--- a/tests/unit/semantic_release/cli/test_config.py
+++ b/tests/unit/semantic_release/cli/test_config.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     [
         ({"type": HvcsClient.GITHUB.value}, EnvConfigVar(env="GH_TOKEN")),
         ({"type": HvcsClient.GITLAB.value}, EnvConfigVar(env="GITLAB_TOKEN")),
+        ({"type": HvcsClient.GITLABCI.value}, EnvConfigVar(env="CI_JOB_TOKEN")),
         ({"type": HvcsClient.GITEA.value}, EnvConfigVar(env="GITEA_TOKEN")),
         ({}, EnvConfigVar(env="GH_TOKEN")),  # default not provided -> means Github
     ],

--- a/tests/unit/semantic_release/hvcs/test_gitlab_ci.py
+++ b/tests/unit/semantic_release/hvcs/test_gitlab_ci.py
@@ -215,6 +215,7 @@ def test_create_release_succeeds(default_gl_client, status_code, prerelease, tag
         assert m.called
         assert len(m.request_history) == 1
         assert m.last_request.method == "POST"
+        assert m.last_request.headers["JOB-TOKEN"] == MINIMUM_ENV_EXPECTED["CI_JOB_TOKEN"]
         assert (
                 m.last_request.url
                 == "{api_url}/projects/{project_id}/releases".format(
@@ -243,6 +244,7 @@ def test_create_release_fails(default_gl_client, prerelease, status_code):
             assert m.called
             assert len(m.request_history) == 1
             assert m.last_request.method == "POST"
+            assert m.last_request.headers["JOB-TOKEN"] == MINIMUM_ENV_EXPECTED["CI_JOB_TOKEN"]
             assert (
                     m.last_request.url
                     == "{api_url}/projects/{project_id}/releases".format(
@@ -279,6 +281,7 @@ def test_edit_release_notes_succeeds(default_gl_client, status_code, mock_tag):
         assert m.called
         assert len(m.request_history) == 1
         assert m.last_request.method == "PUT"
+        assert m.last_request.headers["JOB-TOKEN"] == MINIMUM_ENV_EXPECTED["CI_JOB_TOKEN"]
         assert (
                 m.last_request.url
                 == "{api_url}/projects/{project_id}/releases/{mock_tag}".format(
@@ -303,6 +306,7 @@ def test_edit_release_notes_fails(default_gl_client, status_code):
         assert m.called
         assert len(m.request_history) == 1
         assert m.last_request.method == "PUT"
+        assert m.last_request.headers["JOB-TOKEN"] == MINIMUM_ENV_EXPECTED["CI_JOB_TOKEN"]
         assert (
                 m.last_request.url
                 == "{api_url}/projects/{project_id}/releases/{mock_tag}".format(

--- a/tests/unit/semantic_release/hvcs/test_gitlab_ci.py
+++ b/tests/unit/semantic_release/hvcs/test_gitlab_ci.py
@@ -1,0 +1,377 @@
+import os
+import re
+from contextlib import contextmanager
+from unittest import mock
+
+import gitlab
+import pytest
+import requests_mock
+from requests import Session, HTTPError
+
+from semantic_release.hvcs.gitlab_ci import GitlabCi
+
+from tests.const import EXAMPLE_REPO_NAME, EXAMPLE_REPO_OWNER, RELEASE_NOTES
+
+# Note: there's nothing special about the value of these variables,
+# they're just constants for easier consistency with the faked objects
+A_GOOD_TAG = "v1.2.3"
+A_BAD_TAG = "v2.1.1-rc.1"
+A_LOCKED_TAG = "v0.9.0"
+A_MISSING_TAG = "v1.0.0+missing"
+AN_EXISTING_TAG = "v2.3.4+existing"
+# But note this is the only ref we're making a "fake" commit for, so
+# tests which need to query the remote for "a" ref, the exact sha for
+# which doesn't matter, all use this constant
+REF = "hashashash"
+
+MINIMUM_ENV_EXPECTED = {
+    "CI_API_V4_URL": "https://gitlab.example.com/api/v4",
+    "CI_SERVER_URL": "https://gitlab.example.com",
+    "CI_SERVER_HOST": "gitlab.example.com",
+    "CI_PROJECT_ID": "42",
+    "CI_JOB_TOKEN": "NOT_A_REAL_TOKEN",
+    "CI_PROJECT_NAMESPACE": EXAMPLE_REPO_OWNER,
+    "CI_PROJECT_NAME": EXAMPLE_REPO_NAME,
+}
+
+
+@pytest.fixture
+def default_gl_client():
+    with mock.patch.dict(os.environ, MINIMUM_ENV_EXPECTED, clear=True):
+        remote_url = f"git@gitlab.com:{EXAMPLE_REPO_OWNER}/{EXAMPLE_REPO_NAME}.git"
+        return GitlabCi(remote_url=remote_url)
+
+
+@pytest.mark.parametrize(
+    (
+            "patched_os_environ, hvcs_domain, hvcs_api_domain, "
+            "expected_hvcs_domain, expected_hvcs_api_domain"
+    ),
+    [
+        (
+                {**MINIMUM_ENV_EXPECTED},
+                None,
+                None,
+                "gitlab.example.com",
+                "gitlab.example.com",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "remote_url",
+    [
+        f"git@gitlab.com:{EXAMPLE_REPO_OWNER}/{EXAMPLE_REPO_NAME}.git",
+        f"https://gitlab.com/{EXAMPLE_REPO_OWNER}/{EXAMPLE_REPO_NAME}.git",
+    ],
+)
+@pytest.mark.parametrize("token", ("abc123", None))
+def test_gitlab_client_init(
+        patched_os_environ,
+        hvcs_domain,
+        hvcs_api_domain,
+        expected_hvcs_domain,
+        expected_hvcs_api_domain,
+        remote_url,
+        token,
+):
+    with mock.patch.dict(os.environ, patched_os_environ, clear=True):
+        client = GitlabCi(
+            remote_url=remote_url,
+            hvcs_domain=hvcs_domain,
+            hvcs_api_domain=hvcs_api_domain,
+            token=token,
+        )
+
+        assert client.hvcs_domain == expected_hvcs_domain
+        assert client.hvcs_api_domain == expected_hvcs_api_domain
+        assert client.api_url == patched_os_environ.get("CI_API_V4_URL")
+        assert client.token == patched_os_environ.get("CI_JOB_TOKEN")
+        assert client._remote_url == remote_url
+        assert hasattr(client, "session")
+        assert isinstance(getattr(client, "session", None), Session)
+
+
+@pytest.mark.parametrize(
+    "patched_os_environ, expected_owner, expected_name",
+    [
+        (MINIMUM_ENV_EXPECTED, EXAMPLE_REPO_OWNER, EXAMPLE_REPO_NAME),
+        (
+                {**MINIMUM_ENV_EXPECTED, "CI_PROJECT_NAMESPACE": "path/to/repo", "CI_PROJECT_NAME": "foo"},
+                "path/to/repo",
+                "foo",
+        ),
+    ],
+)
+def test_gitlab_get_repository_owner_and_name(
+    patched_os_environ, expected_owner, expected_name
+):
+    with mock.patch.dict(os.environ, patched_os_environ, clear=True):
+        gl_client = GitlabCi(remote_url="doesn't matter it's not used")
+        if expected_owner is None and expected_name is None:
+            assert (
+                    gl_client._get_repository_owner_and_name()
+                    == super(GitlabCi, gl_client)._get_repository_owner_and_name()
+            )
+        else:
+            assert gl_client._get_repository_owner_and_name() == (
+                expected_owner,
+                expected_name,
+            )
+
+
+def test_compare_url(default_gl_client):
+    assert default_gl_client.compare_url(
+        from_rev="revA", to_rev="revB"
+    ) == "https://{domain}/{owner}/{repo}/-/compare/revA...revB".format(
+        domain=default_gl_client.hvcs_domain,
+        owner=default_gl_client.owner,
+        repo=default_gl_client.repo_name,
+    )
+
+
+@pytest.mark.parametrize(
+    "use_token, token, _remote_url, expected",
+    [
+        (
+                False,
+                "",
+                "git@gitlab.com:custom/example.git",
+                "git@gitlab.com:custom/example.git",
+        ),
+        (
+                True,
+                "",
+                "git@gitlab.com:custom/example.git",
+                "git@gitlab.com:custom/example.git",
+        ),
+        (
+                False,
+                "aabbcc",
+                "git@gitlab.com:custom/example.git",
+                "git@gitlab.com:custom/example.git",
+        ),
+        (
+                True,
+                "aabbcc",
+                "git@gitlab.com:custom/example.git",
+                "git@gitlab.com:custom/example.git",
+        ),
+    ],
+)
+def test_remote_url(
+        default_gl_client,
+        use_token,
+        token,
+        # TODO: linter thinks this is a fixture not a param - why?
+        _remote_url,  # noqa: PT019
+        expected,
+):
+    default_gl_client._remote_url = _remote_url
+    default_gl_client.token = token
+    assert default_gl_client.remote_url(use_token=use_token) == expected
+
+
+def test_commit_hash_url(default_gl_client):
+    assert default_gl_client.commit_hash_url(
+        REF
+    ) == "https://{domain}/{owner}/{repo}/-/commit/{sha}".format(
+        domain=default_gl_client.hvcs_domain,
+        owner=default_gl_client.owner,
+        repo=default_gl_client.repo_name,
+        sha=REF,
+    )
+
+
+@pytest.mark.parametrize("pr_number", (420, "420"))
+def test_pull_request_url(default_gl_client, pr_number):
+    assert default_gl_client.pull_request_url(
+        pr_number=pr_number
+    ) == "https://{domain}/{owner}/{repo}/-/issues/{pr_number}".format(
+        domain=default_gl_client.hvcs_domain,
+        owner=default_gl_client.owner,
+        repo=default_gl_client.repo_name,
+        pr_number=pr_number,
+    )
+
+
+GITLAB_API_MATCHER = re.compile(rf"^https://gitlab.example.com")
+
+
+@pytest.mark.parametrize("status_code", (200, 201))
+@pytest.mark.parametrize("tag", ("v0.1.0", "v1.0.0"))
+@pytest.mark.parametrize("prerelease", (True, False))
+def test_create_release_succeeds(default_gl_client, status_code, prerelease, tag):
+    with requests_mock.Mocker(session=default_gl_client.session) as m:
+        m.register_uri(
+            "POST",
+            GITLAB_API_MATCHER,
+            json={"tag": tag},
+            status_code=status_code,
+        )
+        assert (
+                default_gl_client.create_release(tag, RELEASE_NOTES, prerelease)
+                == tag
+        )
+        assert m.called
+        assert len(m.request_history) == 1
+        assert m.last_request.method == "POST"
+        assert (
+                m.last_request.url
+                == "{api_url}/projects/{project_id}/releases".format(
+            api_url=default_gl_client.api_url,
+            project_id=default_gl_client.project_id, )
+        )
+        assert m.last_request.json() == {
+            "tag_name": tag,
+            "name": f"Release {tag}",
+            "description": RELEASE_NOTES,
+        }
+
+
+@pytest.mark.parametrize("status_code", (400, 404, 429, 500, 503))
+@pytest.mark.parametrize("prerelease", (True, False))
+def test_create_release_fails(default_gl_client, prerelease, status_code):
+    tag = "v1.0.0"
+    with requests_mock.Mocker(session=default_gl_client.session) as m:
+        m.register_uri(
+            "POST", GITLAB_API_MATCHER, status_code=status_code
+        )
+
+        with pytest.raises(HTTPError):
+            default_gl_client.create_release(tag, RELEASE_NOTES, prerelease)
+
+            assert m.called
+            assert len(m.request_history) == 1
+            assert m.last_request.method == "POST"
+            assert (
+                    m.last_request.url
+                    == "{api_url}/projects/{project_id}/releases".format(
+                api_url=default_gl_client.api_url,
+                project_id=default_gl_client.project_id, )
+            )
+            assert m.last_request.json() == {
+                "tag_name": tag,
+                "name": f"Release {tag}",
+                "description": RELEASE_NOTES,
+            }
+
+
+def test_not_running_in_gitlab_ci():
+    with mock.patch.dict(os.environ, {}, clear=True):
+        with pytest.raises(ValueError):
+            GitlabCi(remote_url="git@github.com:something/somewhere.git")
+
+
+@pytest.mark.parametrize("status_code", [201])
+@pytest.mark.parametrize("mock_tag", ("v0.1.0", "v1.0.0"))
+def test_edit_release_notes_succeeds(default_gl_client, status_code, mock_tag):
+    with requests_mock.Mocker(session=default_gl_client.session) as m:
+        m.register_uri(
+            "PUT",
+            GITLAB_API_MATCHER,
+            json={"tag": mock_tag},
+            status_code=status_code,
+        )
+        assert (
+                default_gl_client.edit_release_notes(mock_tag, RELEASE_NOTES)
+                == mock_tag
+        )
+        assert m.called
+        assert len(m.request_history) == 1
+        assert m.last_request.method == "PUT"
+        assert (
+                m.last_request.url
+                == "{api_url}/projects/{project_id}/releases/{mock_tag}".format(
+            api_url=default_gl_client.api_url,
+            project_id=default_gl_client.project_id,
+            mock_tag=mock_tag
+            )
+        )
+
+
+@pytest.mark.parametrize("status_code", (400, 404, 429, 500, 503))
+def test_edit_release_notes_fails(default_gl_client, status_code):
+    mock_tag = "v1.0.0"
+    with requests_mock.Mocker(session=default_gl_client.session) as m:
+        m.register_uri(
+            "PUT", GITLAB_API_MATCHER, status_code=status_code
+        )
+
+        with pytest.raises(HTTPError):
+            default_gl_client.edit_release_notes(mock_tag, RELEASE_NOTES)
+
+        assert m.called
+        assert len(m.request_history) == 1
+        assert m.last_request.method == "PUT"
+        assert (
+                m.last_request.url
+                == "{api_url}/projects/{project_id}/releases/{mock_tag}".format(
+                api_url=default_gl_client.api_url,
+                project_id=default_gl_client.project_id,
+                mock_tag=mock_tag
+            )
+        )
+        assert m.last_request.json() == {"description": RELEASE_NOTES}
+
+
+@pytest.mark.parametrize("prerelease", (True, False))
+def test_create_or_update_release_when_create_succeeds(default_gl_client, prerelease):
+
+    with mock.patch.object(
+            default_gl_client, "create_release"
+    ) as mock_create_release, mock.patch.object(
+        default_gl_client, "edit_release_notes"
+    ) as mock_edit_release_notes:
+        mock_create_release.return_value = A_GOOD_TAG
+        mock_edit_release_notes.return_value = A_GOOD_TAG
+        assert (
+                default_gl_client.create_or_update_release(
+                    A_GOOD_TAG, RELEASE_NOTES, prerelease
+                )
+                == A_GOOD_TAG
+        )
+        mock_create_release.assert_called_once_with(
+            tag=A_GOOD_TAG, release_notes=RELEASE_NOTES, prerelease=prerelease
+        )
+        mock_edit_release_notes.assert_not_called()
+
+
+@pytest.mark.parametrize("prerelease", (True, False))
+def test_create_or_update_release_when_create_fails_and_update_succeeds(default_gl_client, prerelease):
+    bad_request = HTTPError("400 Bad Request")
+    with mock.patch.object(
+            default_gl_client, "create_release"
+    ) as mock_create_release, mock.patch.object(
+        default_gl_client, "edit_release_notes"
+    ) as mock_edit_release_notes:
+        # TODO: not sure what the error code would be for an existing tag.
+        mock_create_release.side_effect = bad_request
+        mock_edit_release_notes.return_value = A_GOOD_TAG
+        assert (
+                default_gl_client.create_or_update_release(
+                    A_GOOD_TAG, RELEASE_NOTES, prerelease
+                )
+                == A_GOOD_TAG
+        )
+        mock_edit_release_notes.assert_called_once_with(
+            release_id=A_GOOD_TAG, release_notes=RELEASE_NOTES
+        )
+
+
+@pytest.mark.parametrize("prerelease", (True, False))
+def test_create_or_update_release_when_create_fails_and_update_fails(default_gl_client, prerelease
+):
+    bad_request = HTTPError("400 Bad Request")
+    not_found = HTTPError("404 Not Found")
+    with mock.patch.object(
+            default_gl_client, "create_release"
+    ) as mock_create_release, mock.patch.object(
+        default_gl_client, "edit_release_notes"
+    ) as mock_edit_release_notes:
+        mock_create_release.side_effect = bad_request
+        mock_edit_release_notes.side_effect = not_found
+
+        with pytest.raises(HTTPError):
+            default_gl_client.create_or_update_release(
+                A_GOOD_TAG, RELEASE_NOTES, prerelease
+            )


### PR DESCRIPTION
This supports GITLAB_CI exclusively via CI_JOB_TOKEN.

Switching from PAT to JOB-TOKEN is relatively easy as it  only requires switching the key used in the header  from PRIVATE-TOKEN to JOB-TOKEN respectively.

But the the original Gitlab hvcs class supports running outside of gitlab-ci and thus queries the API to get information that is available in the environment of the gitlab-ci job. 
Additionally, some of the queries used by the original Gitlab class are not allowed using a Job Token.
 cfr. [api-usage](https://python-gitlab.readthedocs.io/en/stable/api-usage.html)
``` python
# make an API request to create the gl.user object. This is not required but may be useful
# to validate your token authentication. Note that this will not work with job tokens.
gl.auth()
```

Supporting both running inside and outside Gitlab-CI within the same class is also possible, but we would have to make it explicit to avoid conflicts in the config resolution.

