### PR TITLE
test(fixtures): cache the base example project directory

### DIFF
--- a/tests/command_line/conftest.py
+++ b/tests/command_line/conftest.py
@@ -53,8 +53,8 @@ def mocked_git_push(monkeypatch: MonkeyPatch) -> MagicMock:
 
 
 @pytest.fixture
-def config_path(example_project: Path) -> Path:
-    return example_project / DEFAULT_CONFIG_FILE
+def config_path(example_project_dir: Path) -> Path:
+    return example_project_dir / DEFAULT_CONFIG_FILE
 
 
 @pytest.fixture

--- a/tests/command_line/test_changelog.py
+++ b/tests/command_line/test_changelog.py
@@ -57,13 +57,13 @@ def test_changelog_noop_is_noop(
     tag: str | None,
     arg0: str | None,
     tmp_path_factory: pytest.TempPathFactory,
-    example_project: ExProjectDir,
+    example_project_dir: ExProjectDir,
     cli_runner: CliRunner,
 ):
     args = [arg0, tag] if tag and arg0 else []
     tempdir = tmp_path_factory.mktemp("test_noop")
     shutil.rmtree(str(tempdir.resolve()))
-    shutil.copytree(src=str(example_project.resolve()), dst=tempdir)
+    shutil.copytree(src=str(example_project_dir.resolve()), dst=tempdir)
 
     # Set up a requests HTTP session so we can catch the HTTP calls and ensure
     # they're made
@@ -88,7 +88,7 @@ def test_changelog_noop_is_noop(
 
     assert result.exit_code == 0
 
-    dcmp = filecmp.dircmp(str(example_project.resolve()), tempdir)
+    dcmp = filecmp.dircmp(str(example_project_dir.resolve()), tempdir)
 
     differing_files = flatten_dircmp(dcmp)
     assert not differing_files
@@ -112,13 +112,13 @@ def test_changelog_noop_is_noop(
 def test_changelog_content_regenerated(
     repo: Repo,
     tmp_path_factory: pytest.TempPathFactory,
-    example_project: ExProjectDir,
+    example_project_dir: ExProjectDir,
     example_changelog_md: Path,
     cli_runner: CliRunner,
 ):
     tempdir = tmp_path_factory.mktemp("test_changelog")
     shutil.rmtree(str(tempdir.resolve()))
-    shutil.copytree(src=str(example_project.resolve()), dst=tempdir)
+    shutil.copytree(src=str(example_project_dir.resolve()), dst=tempdir)
 
     # Remove the changelog and then check that we can regenerate it
     os.remove(str(example_changelog_md.resolve()))
@@ -126,7 +126,7 @@ def test_changelog_content_regenerated(
     result = cli_runner.invoke(main, [changelog.name or "changelog"])
     assert result.exit_code == 0
 
-    dcmp = filecmp.dircmp(str(example_project.resolve()), tempdir)
+    dcmp = filecmp.dircmp(str(example_project_dir.resolve()), tempdir)
 
     differing_files = flatten_dircmp(dcmp)
     assert not differing_files
@@ -140,12 +140,12 @@ def test_changelog_content_regenerated(
 def test_changelog_release_tag_not_in_history(
     args: list[str],
     tmp_path_factory: pytest.TempPathFactory,
-    example_project: ExProjectDir,
+    example_project_dir: ExProjectDir,
     cli_runner: CliRunner,
 ):
     tempdir = tmp_path_factory.mktemp("test_changelog")
     shutil.rmtree(str(tempdir.resolve()))
-    shutil.copytree(src=str(example_project.resolve()), dst=tempdir)
+    shutil.copytree(src=str(example_project_dir.resolve()), dst=tempdir)
 
     result = cli_runner.invoke(main, [changelog.name or "changelog", *args])
     assert result.exit_code == 2
@@ -158,12 +158,12 @@ def test_changelog_post_to_release(
     args: list[str],
     monkeypatch: pytest.MonkeyPatch,
     tmp_path_factory: pytest.TempPathFactory,
-    example_project: ExProjectDir,
+    example_project_dir: ExProjectDir,
     cli_runner: CliRunner,
 ):
     tempdir = tmp_path_factory.mktemp("test_changelog")
     shutil.rmtree(str(tempdir.resolve()))
-    shutil.copytree(src=str(example_project.resolve()), dst=tempdir)
+    shutil.copytree(src=str(example_project_dir.resolve()), dst=tempdir)
 
     # Set up a requests HTTP session so we can catch the HTTP calls and ensure they're
     # made

--- a/tests/command_line/test_version.py
+++ b/tests/command_line/test_version.py
@@ -45,10 +45,10 @@ if TYPE_CHECKING:
         lazy_fixture("repo_with_git_flow_and_release_channels_angular_commits"),
     ],
 )
-def test_version_noop_is_noop(tmp_path_factory, example_project, repo, cli_runner):
+def test_version_noop_is_noop(tmp_path_factory, example_project_dir, repo, cli_runner):
     # Make a commit to ensure we have something to release
     # otherwise the "no release will be made" logic will kick in first
-    new_file = example_project / "temp.txt"
+    new_file = example_project_dir / "temp.txt"
     new_file.write_text("noop version test")
 
     repo.git.add(str(new_file.resolve()))
@@ -56,7 +56,7 @@ def test_version_noop_is_noop(tmp_path_factory, example_project, repo, cli_runne
 
     tempdir = tmp_path_factory.mktemp("test_noop")
     shutil.rmtree(str(tempdir.resolve()))
-    shutil.copytree(src=str(example_project.resolve()), dst=tempdir)
+    shutil.copytree(src=str(example_project_dir.resolve()), dst=tempdir)
 
     head_before = repo.head.commit
     tags_before = sorted(repo.tags, key=lambda tag: tag.name)
@@ -67,7 +67,7 @@ def test_version_noop_is_noop(tmp_path_factory, example_project, repo, cli_runne
     head_after = repo.head.commit
 
     assert result.exit_code == 0
-    dcmp = filecmp.dircmp(str(example_project.resolve()), tempdir)
+    dcmp = filecmp.dircmp(str(example_project_dir.resolve()), tempdir)
 
     differing_files = flatten_dircmp(dcmp)
     assert not differing_files
@@ -210,11 +210,11 @@ def test_version_noop_is_noop(tmp_path_factory, example_project, repo, cli_runne
     ],
 )
 def test_version_print(
-    repo, cli_args, expected_stdout, example_project, tmp_path_factory, cli_runner
+    repo, cli_args, expected_stdout, example_project_dir, tmp_path_factory, cli_runner
 ):
     # Make a commit to ensure we have something to release
     # otherwise the "no release will be made" logic will kick in first
-    new_file = example_project / "temp.txt"
+    new_file = example_project_dir / "temp.txt"
     new_file.write_text("noop version test")
 
     repo.git.add(str(new_file.resolve()))
@@ -222,7 +222,7 @@ def test_version_print(
 
     tempdir = tmp_path_factory.mktemp("test_version_print")
     shutil.rmtree(str(tempdir.resolve()))
-    shutil.copytree(src=str(example_project.resolve()), dst=tempdir)
+    shutil.copytree(src=str(example_project_dir.resolve()), dst=tempdir)
     head_before = repo.head.commit
     tags_before = sorted(repo.tags, key=lambda tag: tag.name)
 
@@ -235,7 +235,7 @@ def test_version_print(
     assert tags_before == tags_after
     assert head_before == head_after
     assert result.stdout.rstrip("\n") == expected_stdout
-    dcmp = filecmp.dircmp(str(example_project.resolve()), tempdir)
+    dcmp = filecmp.dircmp(str(example_project_dir.resolve()), tempdir)
     differing_files = flatten_dircmp(dcmp)
     assert not differing_files
 
@@ -390,14 +390,14 @@ def test_version_no_push_force_level(
     repo: Repo,
     cli_args: list[str],
     expected_new_version: str,
-    example_project: ExProjectDir,
+    example_project_dir: ExProjectDir,
     example_pyproject_toml: Path,
     tmp_path_factory: pytest.TempPathFactory,
     cli_runner: CliRunner,
 ):
     tempdir = tmp_path_factory.mktemp("test_version")
     shutil.rmtree(str(tempdir.resolve()))
-    shutil.copytree(src=str(example_project.resolve()), dst=tempdir)
+    shutil.copytree(src=str(example_project_dir.resolve()), dst=tempdir)
     head_before = repo.head.commit
     tags_before = sorted(repo.tags, key=lambda tag: tag.name)
 
@@ -414,7 +414,7 @@ def test_version_no_push_force_level(
     assert head_before != head_after  # A commit has been made
     assert head_before in repo.head.commit.parents
 
-    dcmp = filecmp.dircmp(str(example_project.resolve()), tempdir)
+    dcmp = filecmp.dircmp(str(example_project_dir.resolve()), tempdir)
     differing_files = flatten_dircmp(dcmp)
 
     # Changelog already reflects changes this should introduce
@@ -441,7 +441,7 @@ def test_version_no_push_force_level(
 
     # Compare _version.py
     new_init_py = (
-        (example_project / "src" / EXAMPLE_PROJECT_NAME / "_version.py")
+        (example_project_dir / "src" / EXAMPLE_PROJECT_NAME / "_version.py")
         .read_text(encoding="utf-8")
         .splitlines(keepends=True)
     )
@@ -641,13 +641,13 @@ def test_version_only_update_files_no_git_actions(
     cli_runner: CliRunner,
     tmp_path_factory: pytest.TempPathFactory,
     example_pyproject_toml: Path,
-    example_project: ExProjectDir,
+    example_project_dir: ExProjectDir,
 ) -> None:
     # Arrange
     expected_new_version = "0.3.0"
     tempdir = tmp_path_factory.mktemp("test_version")
     shutil.rmtree(str(tempdir.resolve()))
-    shutil.copytree(src=str(example_project), dst=tempdir)
+    shutil.copytree(src=str(example_project_dir), dst=tempdir)
 
     head_before = runtime_context_with_tags.repo.head.commit
     tags_before = runtime_context_with_tags.repo.tags
@@ -670,7 +670,7 @@ def test_version_only_update_files_no_git_actions(
         f"'semantic-release {str.join(' ', args)}': " + resp.stderr
     )
 
-    dcmp = filecmp.dircmp(str(example_project.resolve()), tempdir)
+    dcmp = filecmp.dircmp(str(example_project_dir.resolve()), tempdir)
     differing_files = flatten_dircmp(dcmp)
 
     # Files that should receive version change
@@ -697,7 +697,7 @@ def test_version_only_update_files_no_git_actions(
 
     # Compare _version.py
     new_version_py = (
-        (example_project / "src" / EXAMPLE_PROJECT_NAME / "_version.py")
+        (example_project_dir / "src" / EXAMPLE_PROJECT_NAME / "_version.py")
         .read_text(encoding="utf-8")
         .splitlines(keepends=True)
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,2 +1,39 @@
 """Note: fixtures are stored in the tests/fixtures directory for better organisation"""
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
 from tests.fixtures import *
+
+if TYPE_CHECKING:
+    from typing import Generator, Protocol
+
+    class TeardownCachedDirFn(Protocol):
+        def __call__(self, directory: Path) -> Path:
+            ...
+
+
+@pytest.fixture(scope="session")
+def cached_files_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    return tmp_path_factory.mktemp("cached_files_dir")
+
+
+@pytest.fixture(scope="session")
+def teardown_cached_dir() -> Generator[TeardownCachedDirFn, None, None]:
+    directories: list[Path] = []
+
+    def _teardown_cached_dir(directory: Path | str) -> Path:
+        directories.append(Path(directory))
+        return directories[-1]
+
+    try:
+        yield _teardown_cached_dir
+    finally:
+        # clean up any registered cached directories
+        for directory in directories:
+            if directory.exists():
+                shutil.rmtree(str(directory))

--- a/tests/fixtures/git_repo.py
+++ b/tests/fixtures/git_repo.py
@@ -49,12 +49,14 @@ def example_git_https_url():
     params=[lazy_fixture("example_git_ssh_url")]
 )
 def git_repo_factory(
-    request: pytest.FixtureRequest, example_project: ExProjectDir
+    request: pytest.FixtureRequest,
+    init_example_project: None,
+    example_project_dir: ExProjectDir,
 ) -> Generator[RepoInitFn, None, None]:
     repos: list[Repo] = []
 
     def git_repo() -> Repo:
-        repo = Repo.init(example_project.resolve())
+        repo = Repo.init(example_project_dir.resolve())
 
         # store the repo so we can close it later
         repos.append(repo)

--- a/tests/unit/semantic_release/cli/test_config.py
+++ b/tests/unit/semantic_release/cli/test_config.py
@@ -17,6 +17,7 @@ from semantic_release.cli.config import (
 from semantic_release.const import DEFAULT_COMMIT_AUTHOR
 
 if TYPE_CHECKING:
+    from pathlib import Path
     from typing import Any
 
 
@@ -49,8 +50,8 @@ def test_invalid_hvcs_type(remote_config: dict[str, Any]):
     assert "remote.type" in str(excinfo.value)
 
 
-def test_default_toml_config_valid(example_project):
-    default_config_file = example_project / "default.toml"
+def test_default_toml_config_valid(example_project_dir):
+    default_config_file = example_project_dir / "default.toml"
     default_config_file.write_text(
         tomlkit.dumps(RawConfig().model_dump(mode="json", exclude_none=True))
     )
@@ -74,10 +75,9 @@ def test_default_toml_config_valid(example_project):
     ],
 )
 def test_commit_author_configurable(
-    example_project, repo_with_no_tags_angular_commits, mock_env, expected_author
+    example_pyproject_toml: Path, repo_with_no_tags_angular_commits, mock_env, expected_author
 ):
-    pyproject_toml = example_project / "pyproject.toml"
-    content = tomlkit.loads(pyproject_toml.read_text(encoding="utf-8")).unwrap()
+    content = tomlkit.loads(example_pyproject_toml.read_text(encoding="utf-8")).unwrap()
 
     with mock.patch.dict("os.environ", mock_env):
         raw = RawConfig.model_validate(content)

--- a/tests/unit/semantic_release/hvcs/test_gitea.py
+++ b/tests/unit/semantic_release/hvcs/test_gitea.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 import base64
 import glob
 import os
 import re
+from typing import TYPE_CHECKING
 from unittest import mock
 from urllib.parse import urlencode
 
@@ -14,6 +17,9 @@ from semantic_release.hvcs.token_auth import TokenAuth
 
 from tests.const import EXAMPLE_REPO_NAME, EXAMPLE_REPO_OWNER, RELEASE_NOTES
 from tests.util import netrc_file
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 @pytest.fixture
@@ -508,7 +514,11 @@ def test_create_or_update_release_when_create_fails_and_no_release_for_tag(
 @pytest.mark.parametrize("status_code", (200, 201))
 @pytest.mark.parametrize("mock_release_id", range(3))
 def test_upload_asset_succeeds(
-    default_gitea_client, example_changelog_md, status_code, mock_release_id
+    init_example_project: None,
+    default_gitea_client: Gitea,
+    example_changelog_md: Path,
+    status_code: int,
+    mock_release_id: int,
 ):
     urlparams = {"name": example_changelog_md.name}
     with requests_mock.Mocker(session=default_gitea_client.session) as m:
@@ -539,7 +549,11 @@ def test_upload_asset_succeeds(
 @pytest.mark.parametrize("status_code", (400, 500, 503))
 @pytest.mark.parametrize("mock_release_id", range(3))
 def test_upload_asset_fails(
-    default_gitea_client, example_changelog_md, status_code, mock_release_id
+    init_example_project: None,
+    default_gitea_client: Gitea,
+    example_changelog_md: Path,
+    status_code: int,
+    mock_release_id: int,
 ):
     urlparams = {"name": example_changelog_md.name}
     with requests_mock.Mocker(session=default_gitea_client.session) as m:

--- a/tests/unit/semantic_release/hvcs/test_github.py
+++ b/tests/unit/semantic_release/hvcs/test_github.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
 import base64
 import glob
 import mimetypes
 import os
 import re
+from typing import TYPE_CHECKING
 from unittest import mock
 from urllib.parse import urlencode
 
@@ -15,6 +18,9 @@ from semantic_release.hvcs.token_auth import TokenAuth
 
 from tests.const import EXAMPLE_REPO_NAME, EXAMPLE_REPO_OWNER, RELEASE_NOTES
 from tests.util import netrc_file
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 @pytest.fixture
@@ -564,7 +570,11 @@ def test_asset_upload_url(default_gh_client):
 @pytest.mark.parametrize("status_code", (200, 201))
 @pytest.mark.parametrize("mock_release_id", range(3))
 def test_upload_asset_succeeds(
-    default_gh_client, example_changelog_md, status_code, mock_release_id
+    init_example_project: None,
+    default_gh_client: Github,
+    example_changelog_md: Path,
+    status_code: int,
+    mock_release_id: int,
 ):
     label = "abc123"
     urlparams = {"name": example_changelog_md.name, "label": label}
@@ -618,7 +628,11 @@ def test_upload_asset_succeeds(
 @pytest.mark.parametrize("status_code", (400, 404, 429, 500, 503))
 @pytest.mark.parametrize("mock_release_id", range(3))
 def test_upload_asset_fails(
-    default_gh_client, example_changelog_md, status_code, mock_release_id
+    init_example_project: None,
+    default_gh_client: Github,
+    example_changelog_md: Path,
+    status_code: int,
+    mock_release_id: int,
 ):
     label = "abc123"
     urlparams = {"name": example_changelog_md.name, "label": label}

--- a/tests/unit/semantic_release/version/test_declaration.py
+++ b/tests/unit/semantic_release/version/test_declaration.py
@@ -15,7 +15,8 @@ from semantic_release.version.version import Version
 from tests.const import EXAMPLE_PROJECT_VERSION
 
 
-def test_pyproject_toml_version_found(example_pyproject_toml):
+@pytest.mark.usefixtures("init_example_project")
+def test_pyproject_toml_version_found(example_pyproject_toml: Path):
     decl = TomlVersionDeclaration(
         example_pyproject_toml.resolve(), "tool.poetry.version"
     )
@@ -24,7 +25,8 @@ def test_pyproject_toml_version_found(example_pyproject_toml):
     assert versions.pop() == Version.parse(EXAMPLE_PROJECT_VERSION)
 
 
-def test_setup_cfg_version_found(example_setup_cfg):
+@pytest.mark.usefixtures("init_example_project")
+def test_setup_cfg_version_found(example_setup_cfg: Path):
     decl = PatternVersionDeclaration(
         example_setup_cfg.resolve(), r"^version *= *(?P<version>.*)$"
     )
@@ -48,6 +50,7 @@ def test_setup_cfg_version_found(example_setup_cfg):
         ),
     ],
 )
+@pytest.mark.usefixtures("init_example_project")
 def test_version_replace(decl_cls, config_file, search_text):
     new_version = Version(1, 0, 0)
     decl = decl_cls(config_file.resolve(), search_text)


### PR DESCRIPTION
## Purpose

Improve speed of test code and reduce the number of IO operations

## Rationale

In other development towards changelog testing, I came across the high use of IO operations as we rebuild a project with each test case.  This causes a lot of IO operations, and even more so on the use of git.  I followed the rabbit hole, and this PR is the first of a few that help increase the test execution speed through deliberate abstraction/modularity.  I felt it all at once would be way to confusing and too much for a good review.

## How I tested

Besides checking the result here in the CI, I originally was able to confirm the caching mechanism through the VSCode debugger and many break points through the code to see how many times each fixture was called.  Once this commit was implemented, the session scope ensured that it was only called once but the init fixture called every test run.

## How to Verify

To get VSCode to run the debugger, you have to change the `tool.pytest.ini_options.addopts` by removing the `--cov*` options and then changing `-nauto` to `-n0`.  Once you do this, add a breakpoint to the start of `init_example_project`, and `cached_example_project`.  Then execute a test (a minimum of 2 that use `init_example_project`) with the debugger. When you step through, you will see how many times each is called, and you will see the cleanup occur as well if you put a few breakpoints in `teardown_cached_dir`. 
