### PR TITLE
test(fixtures): refactor to cache base git repo fixture

### DIFF
--- a/tests/fixtures/example_project.py
+++ b/tests/fixtures/example_project.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import os
-import shutil
-import sys
 from pathlib import Path
 from textwrap import dedent
 from typing import TYPE_CHECKING, Generator
@@ -27,6 +25,7 @@ from tests.const import (
     EXAMPLE_SETUP_CFG_CONTENT,
     EXAMPLE_SETUP_PY_CONTENT,
 )
+from tests.util import copy_dir_tree
 
 if TYPE_CHECKING:
     from typing import Any, Protocol
@@ -177,23 +176,7 @@ def init_example_project(
         )
 
     # Copy the cached project files into the current test's project directory
-    if sys.version_info[:2] == (3, 7):
-        # For 3.7 compatibility, destination can't exist, and dirs_exist_ok isn't available
-        # since destination had to be removed, handle changing directories to prevent error
-        os.chdir(str(example_project_dir.parent))
-        shutil.rmtree(str(example_project_dir), ignore_errors=True)
-        shutil.copytree(
-            src=str(cached_example_project),
-            dst=str(example_project_dir),
-        )
-        os.chdir(str(example_project_dir))
-        return
-
-    shutil.copytree(
-        src=str(cached_example_project),
-        dst=str(example_project_dir),
-        dirs_exist_ok=True,
-    )
+    copy_dir_tree(cached_example_project, example_project_dir)
 
 
 @pytest.fixture

--- a/tests/util.py
+++ b/tests/util.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import os
 import secrets
+import shutil
 import string
 from contextlib import contextmanager
+from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING, Any, Iterable, Tuple, TypeVar
 
@@ -17,6 +19,7 @@ from semantic_release.commit_parser.token import ParseResult
 
 if TYPE_CHECKING:
     import filecmp
+    from pathlib import Path
 
     try:
         from typing import TypeAlias
@@ -30,6 +33,16 @@ if TYPE_CHECKING:
     from semantic_release.cli.config import RuntimeContext
 
     GitCommandWrapperType: TypeAlias = main.Repo.GitCommandWrapperType
+
+
+def copy_dir_tree(src_dir: Path | str, dst_dir: Path | str) -> None:
+    """Compatibility wrapper for shutil.copytree"""
+    # python3.8+
+    shutil.copytree(
+        src=str(src_dir),
+        dst=str(dst_dir),
+        dirs_exist_ok=True,
+    )
 
 
 def shortuid(length: int = 8) -> str:


### PR DESCRIPTION
## Purpose

Improve speed of test code and reduce the number of IO operations

## Rationale

PR 2 for test caching. Now the base git repo (git init & configuration on top of the example project) is cached for all the repos to extend from without having to execute the init action every time.  This is phase 2 before the caching of each repo type.

> (from #799) In other development towards changelog testing, I came across the high use of IO operations as we rebuild a project with each test case.  This causes a lot of IO operations, and even more so on the use of git.  I followed the rabbit hole, and this PR is the first of a few that help increase the test execution speed through deliberate abstraction/modularity.  I felt it all at once would be way to confusing and too much for a good review.

This also includes some slight modification to the test fixtures and test setup to better ensure that the files exist as it is not possible to handle when the fixtures resolve/execute when passed as parameters (and their ordering).

## How I tested

Besides checking the result here in the CI, I originally was able to confirm the caching mechanism through the VSCode debugger and many break points through the code to see how many times each fixture was called.  Once this commit was implemented, the session scope ensured that `cached_example_git_project` was only called once but the `git_repo_factory` fixture called every test run by the `repo_*` fixtures.

## How to Verify

To get VSCode to run the debugger, you have to change the `tool.pytest.ini_options.addopts` by removing the `--cov*` options and then changing `-nauto` to `-n0`.  Once you do this, add a breakpoint to the start of `git_repo_factory`, and `cached_example_git_project`.  Then execute a test (a minimum of 2 that use a `repo_*`) with the debugger. When you step through, you will see how many times each is called, and you will see the cleanup occur as well if you put a few breakpoints in `teardown_cached_dir`. 
