### PR TITLE
docs: Remove duplicate note in configuration.rst

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -100,11 +100,6 @@ In this structure:
 Settings
 --------
 
-.. note::
-  If you are using the built-in GitHub Action, the default value is set to
-  ``github-actions <actions@github.com>``. You can modify this with the
-  ``git_committer_name`` and ``git_committer_email`` inputs.
-
 .. _config-root:
 
 ``[tool.semantic_release]``


### PR DESCRIPTION
This note is specific to the `commit_author` configuration property, but exists both in its correct place and as a note under the higher-level heading `Settings`