### PR TITLE
fix(util): properly parse windows line-endings in commit messages

### DIFF
--- a/semantic_release/commit_parser/util.py
+++ b/semantic_release/commit_parser/util.py
@@ -9,11 +9,14 @@ def parse_paragraphs(text: str) -> list[str]:
     """
     This will take a text block and return a list containing each
     paragraph with single line breaks collapsed into spaces.
+
+    To handle Windows line endings, carriage returns '\r' are removed before
+    separating into paragraphs.
+
     :param text: The text string to be divided.
     :return: A list of condensed paragraphs, as strings.
     """
-    return [
-        paragraph.replace("\n", " ")
-        for paragraph in text.split("\n\n")
-        if len(paragraph) > 0
-    ]
+    return list(filter(None, [
+        paragraph.replace("\n", " ").strip()
+        for paragraph in text.replace("\r", "").split("\n\n")
+    ]))

--- a/tests/unit/semantic_release/commit_parser/test_util.py
+++ b/tests/unit/semantic_release/commit_parser/test_util.py
@@ -7,9 +7,17 @@ from semantic_release.commit_parser.util import parse_paragraphs
     "text, expected",
     [
         ("", []),
-        ("\n\n \n\n \n", [" ", "  "]),
+        ("\n\n \n\n \n", []),                  # Unix (LF) - empty lines
+        ("\r\n\r\n \r\n\r\n \n", []),          # Windows (CRLF) - empty lines
+        ("\n\nA\n\nB\n", ["A", "B"]),          # Unix (LF)
+        ("\r\n\r\nA\r\n\r\nB\n", ["A", "B"]),  # Windows (CRLF)
         (
             "Long\nexplanation\n\nfull of interesting\ndetails",
+            ["Long explanation", "full of interesting details"],
+        ),
+        (
+            # Windows (CRLF)
+            "Long\r\nexplanation\r\n\r\nfull of interesting\r\ndetails",
             ["Long explanation", "full of interesting details"],
         ),
     ],


### PR DESCRIPTION
Due to windows line-endings `\r\n`, it would improperly split the commit description (it failed to split at all) and cause detection of Breaking changes to fail. The breaking changes regular expression looks to the start of the line for the proper syntax.

Resolves: #820