### PR TITLE
Allow special characters in implicit ssh urls

### DIFF
--- a/semantic_release/helpers.py
+++ b/semantic_release/helpers.py
@@ -114,12 +114,12 @@ def parse_git_url(url: str) -> ParsedGitUrl:
     # Normalizers are a list of tuples of (pattern, replacement)
     normalizers = [
         # normalize implicit ssh urls to explicit ssh://
-        (r"^(\w+@)", r"ssh://\1"),
+        (r"^([\w._-]+@)", r"ssh://\1"),
         # normalize git+ssh:// urls to ssh://
         (r"^git\+ssh://", "ssh://"),
         # normalize an scp like syntax to URL compatible syntax
         # excluding port definitions (:#####) & including numeric usernames
-        (r"(ssh://(?:\w+@)?[\w.-]+):(?!\d{1,5}/\w+/)(.*)$", r"\1/\2"),
+        (r"(ssh://(?:[\w._-]+@)?[\w.-]+):(?!\d{1,5}/\w+/)(.*)$", r"\1/\2"),
         # normalize implicit file (windows || posix) urls to explicit file:// urls
         (r"^([C-Z]:/)|^/(\w)", r"file:///\1\2"),
     ]

--- a/tests/unit/semantic_release/test_helpers.py
+++ b/tests/unit/semantic_release/test_helpers.py
@@ -62,6 +62,15 @@ from semantic_release.helpers import ParsedGitUrl, parse_git_url
             ),
         ),
         (
+            "first.last_test-1@subsubdomain.subdomain.company-net.com:username/myproject.git",
+            ParsedGitUrl(
+                "ssh",
+                "first.last_test-1@subsubdomain.subdomain.company-net.com",
+                "username",
+                "myproject",
+            ),
+        ),
+        (
             "ssh://git@github.com:3759/myproject.git",
             ParsedGitUrl("ssh", "git@github.com", "3759", "myproject"),
         ),


### PR DESCRIPTION
Currently, the implicit ssh url regex only allows letters and numbers. These urls can include special characters from email addresses (._-). This corrects that regex and adds an applicable unit test condition.