### PR TITLE
chore(stalebot): add config to manage aging issues & PRs

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,58 @@
+# Configuration for probot-stale                                                     #
+# CAO: https://github.com/probot/stale/tree/4232daafc73492864b559b55c9cf2689d19d5b23 #
+# ================================================================================== #
+# Rule summary
+# ---------------------------------------------------------------------------------- #
+#  Comment & mark 90-day old issues as stale
+#    Close stalled issues after 7 days
+#  Comment & mark 60-day old PR as stale
+#    Close stalled PRs after 10 days
+#  Any issue/pr with a planned milestone is exempt
+#  Issues/PRs with a confirmed label are exempt
+# ================================================================================== #
+# See repo url for descriptions of settings
+
+# ALL
+staleLabel: stale
+limitPerRun: 30 # numActions/hour
+
+
+issues:
+  daysUntilStale: 90
+  daysUntilClose: 7
+  exemptProjects: false
+  exemptMilestones: true
+  exemptAssignees: false
+  exemptLabels:
+    - confirmed
+    - help-wanted
+  markComment: >
+    This issue is stale because it has been open 90 days with no recent activity.
+    It will be closed in 7 days, if no further activity occurs. Thank you for
+    your contributions.
+  unmarkComment: >
+    Thank you for the update and contribution! The stale label has been removed
+    and this issue will not be closed at this time.
+  closeComment: >
+    This issue was closed because activity was dormant for 97 days.
+
+
+pulls:
+  daysUntilStale: 60
+  daysUntilClose: 10
+  exemptProjects: false
+  exemptMilestones: true
+  exemptAssignees: false
+  exemptLabels:
+    - confirmed
+    # Ignore PRs opened by Dependabot
+    - dependencies
+  markComment: >
+    This PR is stale because it has been open 60 days with no recent activity.
+    It will be closed in 10 days, if no further activity occurs. Thank you for
+    your contributions.
+  unmarkComment: >
+    Thank you for the update and contribution! The stale label has been removed
+    and this PR will not be closed at this time.
+  closeComment: >
+    This PR was closed because activity was dormant for 70 days.


### PR DESCRIPTION
## Purpose

Enable the GitHub Stalebot application to manage long term issues and PRs that never get closed or remembered because of lack of time/interest 

## Rationale

This is an awesome capability built into GitHub that helps reduce the clutter and reminds both external members and contributors to keep track of issues and PRs created.  If unresponsive then it will be closed after a period of time. It has a two stage approach where it marks issues/prs as stale with a warning and then actually closes it at a later designated time.  I put in fairly gracious timelines more than what I normally use for projects.  We have a number of PRs that seem prior to v8 and plenty of tickets that never were closed before. This will help keep it manageable. 

## Additional

- Will need a maintainer to create the label `confirmed`. Of course, I can't apply the tag with current permissions but it gives collaborators/maintainers the ability to turn off stalebot alerts for specific issues/PRs that you don't want to close but might reach beyond a threshold.  

I also made sure to include Dependabot's `dependencies` label so that the bots don't fight each other lol... but really its because dependabot handles its own PR management and a premature close, can tell dependabot to not update you in the future for that version.