### PR TITLE
chore(dependabot): adjust conf to relax bumping flexible requirement specs

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,6 +1,7 @@
 ---
 version: 2
 updates:
+
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
@@ -14,6 +15,8 @@ updates:
       - dependencies
     open-pull-requests-limit: 10
     rebase-strategy: auto
+    versioning-strategy: "increase-if-necessary"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Purpose

Quiet down the number of dependabot PRs for every minor or patch version that comes out when the current range definition will automatically pull the latest dependency for the user/developer.

## Rationale

This more so comes from experience that the default strategy for dependabot does not bode well for using ranges. It has a tendency to bump the lowest part of the range up until there is no more range!  That was definitely not the intention so this strategy adheres to ranges and only opens a PR when a version outside of the range is available.