### PR TITLE
feat(version): Add new version print flags to display the last released version and tag.

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -144,6 +144,33 @@ command line options::
     semantic-release version --patch --print
     semantic-release version --prerelease --print
 
+.. _cmd-version-option-print-tag:
+
+``--print-tag``
+***************
+
+Same as the :ref:`cmd-version-option-print` flag but prints the complete tag
+name (ex. ``v1.0.0`` or ``py-v1.0.0``) instead of the raw version number
+(``1.0.0``).
+
+.. _cmd-version-option-print-last-released:
+
+``--print-last-released``
+*************************
+
+Print the last released version based on the Git tags.  This flag is useful if you just
+want to see the released version without determining what the next version will be.
+Note if the version can not be found nothing will be printed.
+
+.. _cmd-version-option-print-last-released-tag:
+
+``--print-last-released-tag``
+***************
+
+Same as the :ref:`cmd-version-option-print-last-released` flag but prints the
+complete tag name (ex. ``v1.0.0`` or ``py-v1.0.0``) instead of the raw version
+number (``1.0.0``).
+
 .. _cmd-version-option-force-level:
 
 ``--major/--minor/--patch``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ readme = "README.rst"
 authors = [{ name = "Rolf Erik Lekang", email = "me@rolflekang.com" }]
 dependencies = [
   "click>=8,<9",
+  "click-option-group~=0.5",
   "gitpython>=3.0.8,<4",
   "requests>=2.25,<3",
   "jinja2>=3.1.2,<4",


### PR DESCRIPTION
This adds a the command `semantic-release current-version` so semantic-release can be used to determine the current tag on the branch based on semantic-release config.