### PR TITLE
fix(cli-help): enable subcommand help even if config is invalid 

### DIFF
--- a/semantic_release/cli/commands/changelog.py
+++ b/semantic_release/cli/commands/changelog.py
@@ -16,7 +16,7 @@ from semantic_release.cli.common import (
 from semantic_release.cli.util import noop_report
 
 if TYPE_CHECKING:
-    from semantic_release.cli.config import RuntimeContext
+    from semantic_release.cli.commands.cli_context import CliContextObj
     from semantic_release.version import Version
 
 log = logging.getLogger(__name__)
@@ -34,10 +34,11 @@ log = logging.getLogger(__name__)
     default=None,
     help="Post the generated release notes to the remote VCS's release for this tag",
 )
-@click.pass_context
-def changelog(ctx: click.Context, release_tag: str | None = None) -> None:
+@click.pass_obj
+def changelog(cli_ctx: CliContextObj, release_tag: str | None = None) -> None:
     """Generate and optionally publish a changelog for your project"""
-    runtime: RuntimeContext = ctx.obj
+    ctx = click.get_current_context()
+    runtime = cli_ctx.runtime_ctx
     repo = runtime.repo
     parser = runtime.commit_parser
     translator = runtime.version_translator

--- a/semantic_release/cli/commands/cli_context.py
+++ b/semantic_release/cli/commands/cli_context.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import click
+from click.core import ParameterSource
+from git import InvalidGitRepositoryError
+from pydantic import ValidationError
+
+from semantic_release.cli.config import (
+    RawConfig,
+    RuntimeContext,
+)
+from semantic_release.cli.util import load_raw_config_file, rprint
+from semantic_release.errors import InvalidConfiguration, NotAReleaseBranch
+
+if TYPE_CHECKING:
+    from semantic_release.cli.config import GlobalCommandLineOptions
+
+    class CliContext(click.Context):
+        obj: CliContextObj
+
+
+class CliContextObj:
+    def __init__(
+        self,
+        ctx: click.Context,
+        logger: logging.Logger,
+        global_opts: GlobalCommandLineOptions,
+    ) -> None:
+        self._runtime_ctx: RuntimeContext | None = None
+        self.ctx = ctx
+        self.logger = logger
+        self.global_opts = global_opts
+
+    @property
+    def runtime_ctx(self) -> RuntimeContext:
+        """
+        Lazy load the runtime context. This is done to avoid configuration loading when
+        the command is not run. This is useful for commands like `--help` and `--version`
+        """
+        if self._runtime_ctx is None:
+            self._runtime_ctx = self._init_runtime_ctx()
+        return self._runtime_ctx
+
+    def _init_runtime_ctx(self) -> RuntimeContext:
+        config_path = Path(self.global_opts.config_file)
+        conf_file_exists = config_path.exists()
+        was_conf_file_user_provided = bool(
+            self.ctx.get_parameter_source("config_file")
+            not in (
+                ParameterSource.DEFAULT,
+                ParameterSource.DEFAULT_MAP,
+            )
+        )
+
+        try:
+            if was_conf_file_user_provided and not conf_file_exists:
+                raise FileNotFoundError(
+                    f"File {self.global_opts.config_file} does not exist"
+                )
+
+            config_obj = (
+                {} if not conf_file_exists else load_raw_config_file(config_path)
+            )
+            if not config_obj:
+                self.logger.info(
+                    "configuration empty, falling back to default configuration"
+                )
+
+            raw_config = RawConfig.model_validate(config_obj)
+            runtime = RuntimeContext.from_raw_config(
+                raw_config,
+                global_cli_options=self.global_opts,
+            )
+        except NotAReleaseBranch as exc:
+            rprint(f"[bold {'red' if self.global_opts.strict else 'orange1'}]{exc!s}")
+            # If not strict, exit 0 so other processes can continue. For example, in
+            # multibranch CI it might be desirable to run a non-release branch's pipeline
+            # without specifying conditional execution of PSR based on branch name
+            self.ctx.exit(2 if self.global_opts.strict else 0)
+        except FileNotFoundError as exc:
+            click.echo(str(exc), err=True)
+            self.ctx.exit(2)
+        except (
+            ValidationError,
+            InvalidConfiguration,
+            InvalidGitRepositoryError,
+        ) as exc:
+            click.echo(str(exc), err=True)
+            self.ctx.exit(1)
+
+        # This allows us to mask secrets in the logging
+        # by applying it to all the configured handlers
+        for handler in logging.getLogger().handlers:
+            handler.addFilter(runtime.masker)
+
+        return runtime

--- a/semantic_release/cli/commands/generate_config.py
+++ b/semantic_release/cli/commands/generate_config.py
@@ -38,7 +38,7 @@ def generate_config(fmt: str = "toml", is_pyproject_toml: bool = False) -> None:
     your needs. For example, to append the default configuration to your pyproject.toml
     file, you can use the following command:
 
-        semantic-release generate-config -f toml >> pyproject.toml
+        semantic-release generate-config --pyproject >> pyproject.toml
     """
     # due to possible IntEnum values (which are not supported by tomlkit.dumps, see sdispater/tomlkit#237),
     # we must ensure the transformation of the model to a dict uses json serializable values

--- a/semantic_release/cli/commands/publish.py
+++ b/semantic_release/cli/commands/publish.py
@@ -1,9 +1,16 @@
+from __future__ import annotations
+
 import logging
+from typing import TYPE_CHECKING
 
 import click
 
 from semantic_release.cli.util import noop_report
 from semantic_release.version import tags_and_versions
+
+if TYPE_CHECKING:
+    from semantic_release.cli.commands.cli_context import CliContextObj
+
 
 log = logging.getLogger(__name__)
 
@@ -20,10 +27,11 @@ log = logging.getLogger(__name__)
     help="The tag associated with the release to publish to",
     default="latest",
 )
-@click.pass_context
-def publish(ctx: click.Context, tag: str = "latest") -> None:
+@click.pass_obj
+def publish(cli_ctx: CliContextObj, tag: str = "latest") -> None:
     """Build and publish a distribution to a VCS release."""
-    runtime = ctx.obj
+    ctx = click.get_current_context()
+    runtime = cli_ctx.runtime_ctx
     repo = runtime.repo
     hvcs_client = runtime.hvcs_client
     translator = runtime.version_translator

--- a/tests/command_line/test_help.py
+++ b/tests/command_line/test_help.py
@@ -1,21 +1,222 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import pytest
 
+import semantic_release
 from semantic_release.cli import changelog, generate_config, main, publish, version
 
+if TYPE_CHECKING:
+    from click import Command
+    from click.testing import CliRunner
+    from git import Repo
 
-@pytest.mark.parametrize("help_option", ("-h", "--help"))
+    from tests.fixtures import UpdatePyprojectTomlFn
+
+
+# Define the expected exit code for the help command
+help_exit_code = 0
+
+
+@pytest.mark.parametrize(
+    "help_option", ("-h", "--help"), ids=lambda opt: opt.lstrip("-")
+)
 @pytest.mark.parametrize(
     "command",
     (main, changelog, generate_config, publish, version),
     ids=lambda cmd: cmd.name,
 )
-def test_help(help_option, command, cli_runner):
-    result = cli_runner.invoke(command, [help_option])
+def test_help_no_repo(
+    help_option: str,
+    command: Command,
+    cli_runner: CliRunner,
+    change_to_ex_proj_dir: None,
+):
+    """
+    Test that the help message is displayed even when the current directory is not a git repository
+    and there is not a configuration file available.
+    Documented issue #840
+    """
+    # Generate some expected output that should be specific per command
+    cmd_usage = str.join(
+        " ",
+        list(
+            filter(
+                None,
+                [
+                    "Usage:",
+                    semantic_release.__name__,
+                    command.name if command.name != "main" else "",
+                    "[OPTIONS]",
+                    "" if command.name != main.name else "COMMAND [ARGS]...",
+                ],
+            )
+        ),
+    )
 
-    assert result.exit_code == 0
-    # commands have help text
-    assert result.output
+    # Create the arguments list for subcommands unless its main
+    args = list(
+        filter(None, [command.name if command.name != main.name else "", help_option])
+    )
 
-    if command is not main:
-        # commands have their own unique help text
-        assert result.output != cli_runner.invoke(main, [help_option]).output
+    # Run the command with the help option
+    result = cli_runner.invoke(main, args, prog_name=semantic_release.__name__)
+
+    # Evaluate result
+    assert help_exit_code == result.exit_code
+    assert cmd_usage in result.output
+
+
+@pytest.mark.parametrize(
+    "help_option", ("-h", "--help"), ids=lambda opt: opt.lstrip("-")
+)
+@pytest.mark.parametrize(
+    "command",
+    (main, changelog, generate_config, publish, version),
+    ids=lambda cmd: cmd.name,
+)
+def test_help_valid_config(
+    help_option: str,
+    command: Command,
+    cli_runner: CliRunner,
+    repo_with_single_branch_angular_commits: Repo,
+):
+    """
+    Test that the help message is displayed when the current directory is a git repository
+    and there is a valid configuration file available.
+    Documented issue #840
+    """
+    cmd_usage = str.join(
+        " ",
+        list(
+            filter(
+                None,
+                [
+                    "Usage:",
+                    semantic_release.__name__,
+                    command.name if command.name != main.name else "",
+                    "[OPTIONS]",
+                    "" if command.name != main.name else "COMMAND [ARGS]...",
+                ],
+            )
+        ),
+    )
+
+    # Create the arguments list for subcommands unless its main
+    args = list(
+        filter(None, [command.name if command.name != main.name else "", help_option])
+    )
+
+    # Run the command with the help option
+    result = cli_runner.invoke(main, args, prog_name=semantic_release.__name__)
+
+    # Evaluate result
+    assert help_exit_code == result.exit_code
+    assert cmd_usage in result.output
+
+
+@pytest.mark.parametrize(
+    "help_option", ("-h", "--help"), ids=lambda opt: opt.lstrip("-")
+)
+@pytest.mark.parametrize(
+    "command",
+    (main, changelog, generate_config, publish, version),
+    ids=lambda cmd: cmd.name,
+)
+def test_help_invalid_config(
+    help_option: str,
+    command: Command,
+    cli_runner: CliRunner,
+    repo_with_single_branch_angular_commits: Repo,
+    update_pyproject_toml: UpdatePyprojectTomlFn,
+):
+    """
+    Test that the help message is displayed when the current directory is a git repository
+    and there is an invalid configuration file available.
+    Documented issue #840
+    """
+    # Update the configuration file to have an invalid value
+    update_pyproject_toml("tool.semantic_release.remote.type", "invalidhvcs")
+
+    # Generate some expected output that should be specific per command
+    cmd_usage = str.join(
+        " ",
+        list(
+            filter(
+                None,
+                [
+                    "Usage:",
+                    semantic_release.__name__,
+                    command.name if command.name != "main" else "",
+                    "[OPTIONS]",
+                    "" if command.name != main.name else "COMMAND [ARGS]...",
+                ],
+            )
+        ),
+    )
+
+    # Create the arguments list for subcommands unless its main
+    args = list(
+        filter(None, [command.name if command.name != main.name else "", help_option])
+    )
+
+    # Run the command with the help option
+    result = cli_runner.invoke(main, args, prog_name=semantic_release.__name__)
+
+    # Evaluate result
+    assert help_exit_code == result.exit_code
+    assert cmd_usage in result.output
+
+
+@pytest.mark.parametrize(
+    "help_option", ("-h", "--help"), ids=lambda opt: opt.lstrip("-")
+)
+@pytest.mark.parametrize(
+    "command",
+    (main, changelog, generate_config, publish, version),
+    ids=lambda cmd: cmd.name,
+)
+def test_help_non_release_branch(
+    help_option: str,
+    command: Command,
+    cli_runner: CliRunner,
+    repo_with_single_branch_angular_commits: Repo,
+):
+    """
+    Test that the help message is displayed even when the current branch is not a release branch.
+    Documented issue #840
+    """
+    # Create & checkout a non-release branch
+    repo = repo_with_single_branch_angular_commits
+    non_release_branch = repo.create_head("feature-branch")
+    non_release_branch.checkout()
+
+    # Generate some expected output that should be specific per command
+    cmd_usage = str.join(
+        " ",
+        list(
+            filter(
+                None,
+                [
+                    "Usage:",
+                    semantic_release.__name__,
+                    command.name if command.name != "main" else "",
+                    "[OPTIONS]",
+                    "" if command.name != main.name else "COMMAND [ARGS]...",
+                ],
+            )
+        ),
+    )
+
+    # Create the arguments list for subcommands unless its main
+    args = list(
+        filter(None, [command.name if command.name != main.name else "", help_option])
+    )
+
+    # Run the command with the help option
+    result = cli_runner.invoke(main, args, prog_name=semantic_release.__name__)
+
+    # Evaluate result
+    assert help_exit_code == result.exit_code
+    assert cmd_usage in result.output

--- a/tests/unit/semantic_release/cli/test_config.py
+++ b/tests/unit/semantic_release/cli/test_config.py
@@ -21,13 +21,12 @@ from semantic_release.commit_parser.tag import TagParserOptions
 from semantic_release.const import DEFAULT_COMMIT_AUTHOR
 from semantic_release.enums import LevelBump
 
+from tests.fixtures.repos import repo_with_no_tags_angular_commits
 from tests.util import CustomParserOpts
 
 if TYPE_CHECKING:
     from pathlib import Path
     from typing import Any
-
-    from git import Repo
 
     from tests.fixtures.example_project import ExProjectDir
 
@@ -144,11 +143,12 @@ def test_default_toml_config_valid(example_project_dir: ExProjectDir):
         ({"GIT_COMMIT_AUTHOR": "foo <foo>"}, "foo <foo>"),
     ],
 )
+@pytest.mark.usefixtures(repo_with_no_tags_angular_commits.__name__)
 def test_commit_author_configurable(
     example_pyproject_toml: Path,
-    repo_with_no_tags_angular_commits: Repo,
     mock_env: dict[str, str],
     expected_author: str,
+    change_to_ex_proj_dir: str,
 ):
     content = tomlkit.loads(example_pyproject_toml.read_text(encoding="utf-8")).unwrap()
 
@@ -156,10 +156,9 @@ def test_commit_author_configurable(
         raw = RawConfig.model_validate(content)
         runtime = RuntimeContext.from_raw_config(
             raw=raw,
-            repo=repo_with_no_tags_angular_commits,
             global_cli_options=GlobalCommandLineOptions(),
         )
-        assert (
+        resulting_author = (
             f"{runtime.commit_author.name} <{runtime.commit_author.email}>"
-            == expected_author
         )
+        assert expected_author == resulting_author

--- a/tests/util.py
+++ b/tests/util.py
@@ -13,7 +13,7 @@ from pydantic.dataclasses import dataclass
 
 from semantic_release.changelog.context import make_changelog_context
 from semantic_release.changelog.release_history import ReleaseHistory
-from semantic_release.cli.commands import main
+from semantic_release.cli import config as cliConfigModule
 from semantic_release.commit_parser._base import CommitParser, ParserOptions
 from semantic_release.commit_parser.token import ParseResult
 
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
 
     _R = TypeVar("_R")
 
-    GitCommandWrapperType: TypeAlias = main.Repo.GitCommandWrapperType
+    GitCommandWrapperType: TypeAlias = cliConfigModule.Repo.GitCommandWrapperType
 
 
 def copy_dir_tree(src_dir: Path | str, dst_dir: Path | str) -> None:
@@ -171,7 +171,7 @@ def prepare_mocked_git_command_wrapper_type(
     >>> mocked_push.assert_called_once()
     """
 
-    class MockGitCommandWrapperType(main.Repo.GitCommandWrapperType):
+    class MockGitCommandWrapperType(cliConfigModule.Repo.GitCommandWrapperType):
         def __getattr__(self, name: str) -> Any:
             try:
                 return object.__getattribute__(self, f"mocked_{name}")


### PR DESCRIPTION
## Purpose

- Ensure help information is always accessible even when configuration is invalid

## Rationale

This resolves #840, by means of lazy loading of the configuration file until the runtime context is actually needed. Which ever subcommand actually needs the runtime context object will access the property of the click context object which is set in the top level click function.  The reason this was not working already is because when a subcommand help is accessed it fully runs through the `main()` click function first before evaluating the subcommand's options.  This was causing the failure too soon.  I found some click documentation for the `@click.pass_obj` which helps manage our type confusion in this passing of a newly defined CliContextObj which handles the lazy loading.

## How I tested

I wrote a few unit tests for validating the help functionality is called when the project in the current working directory has different states. The theory is that our help should always work no matter if its in an empty folder (no git), a valid git project with valid config, a git project with invalid config, and executing on a non-release branch.

## How to verify

```sh
git fetch origin pull/853/head:pr-853

# checkout the PR as a detached HEAD state with only the unit tests
git checkout pr-853~2 --detach

# execute unit-tests 
pytest tests/command_line/test_help.py

# update to the HEAD of the PR (with fixes)
git merge --ff-only pr-853

# run pytest again to see success
pytest tests/command_line/test_help.py

# run full suite for verification
pytest tests
```