### PR TITLE
build(MANIFEST): fix sdist contents to include docs & tests

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,9 @@
-include README.md MANIFEST.in LICENSE pyproject.toml
-recursive-include *.j2
+# Make sure Jinja templates are included
+recursive-include ./ *.j2
+
+# Make sure non-python files are included
 graft semantic_release/data
+
+# include docs & testing into sdist, ignored for wheel build
+graft tests/
+graft docs/


### PR DESCRIPTION
## Purpose

Create a more comprehensive `sdist` (which is expected to include your testing and documentation) without causing changes to the wheel artifact

## Rationale

I used the documentation on the setuptools website for MANIFEST syntax and read through the error logs of the build step.  Ends up the `recursive-include` syntax was incorrect so I fixed that. Also it is unnecessary to lay out specific files as build will automatically include certain files which we defined explicitly (`pyproject.toml`, `LICENSE`, `MANIFEST.in`, etc.).  Lastly, I added the tests and docs to the MANIFEST and was happy to see that they only were included with the sdist but then ignored in the wheel packaging.

## How I tested

I ran the build locally and then unpacked the `sdist` & `whl` files separately and evaluated the contents using the instructions below. 

## How to Verify

```sh
# checkout the PR 
git fetch origin pull/854/head:pr-854
git checkout pr-854

# execute the build
pip install build~=0.10.0
rm -rf dist/ && python -m build

# unpack the build contents
mkdir -vp dist/tmp/{sdist,whl} && cd dist/tmp
tar -xf ../python-semantic-release-9.*.tar.gz -C sdist
unzip ../python_semantic_release-9.*.whl -d whl

# evaluate the sdist build contents (includes the docs, tests, pyproject.toml, LICENSE, MANIFEST.in, etc )
tree -CF sdist

# evaluate the whl build contents (no tests, docs, but includes data/ & .j2)
tree -CF whl
```