### PR TITLE
refactor: drop other 3.7 references

### DIFF
--- a/docs/commit-parsing.rst
+++ b/docs/commit-parsing.rst
@@ -284,7 +284,7 @@ available.
 .. _Rust's error handling: https://doc.rust-lang.org/book/ch09-02-recoverable-errors-with-result.html
 .. _black: https://github.com/psf/black/blob/main/src/black/rusty.py
 .. _catching exceptions in Python is slower: https://docs.python.org/3/faq/design.html#how-fast-are-exceptions
-.. _namedtuple: https://docs.python.org/3.7/library/typing.html#typing.NamedTuple
+.. _namedtuple: https://docs.python.org/3/library/typing.html#typing.NamedTuple
 
 .. _commit-parsing-parser-options:
 

--- a/semantic_release/changelog/release_history.py
+++ b/semantic_release/changelog/release_history.py
@@ -3,20 +3,16 @@ from __future__ import annotations
 import logging
 from collections import defaultdict
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Iterable, Iterator
+from typing import TYPE_CHECKING, TypedDict
 
 from git.objects.tag import TagObject
 
-# For Python3.7 compatibility
-from typing_extensions import TypedDict
-
-from semantic_release.commit_parser import (
-    ParseError,
-)
+from semantic_release.commit_parser import ParseError
 from semantic_release.version.algorithm import tags_and_versions
 
 if TYPE_CHECKING:
-    import re
+    from re import Pattern
+    from typing import Iterable, Iterator
 
     from git.repo.base import Repo
     from git.util import Actor
@@ -39,7 +35,7 @@ class ReleaseHistory:
         repo: Repo,
         translator: VersionTranslator,
         commit_parser: CommitParser[ParseResult, ParserOptions],
-        exclude_commit_patterns: Iterable[re.Pattern[str]] = (),
+        exclude_commit_patterns: Iterable[Pattern[str]] = (),
     ) -> ReleaseHistory:
         all_git_tags_and_versions = tags_and_versions(repo.tags, translator)
         unreleased: dict[str, list[ParseResult]] = defaultdict(list)

--- a/semantic_release/changelog/template.py
+++ b/semantic_release/changelog/template.py
@@ -12,8 +12,10 @@ from jinja2.sandbox import SandboxedEnvironment
 from semantic_release.helpers import dynamic_import
 
 if TYPE_CHECKING:
+    from typing import Literal
+
     from jinja2 import Environment
-    from typing_extensions import Literal
+
 
 log = logging.getLogger(__name__)
 

--- a/semantic_release/cli/config.py
+++ b/semantic_release/cli/config.py
@@ -7,13 +7,15 @@ from collections.abc import Mapping
 from dataclasses import dataclass, is_dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Any, ClassVar, Dict, List, Optional, Tuple, Type, Union
+from typing import Any, ClassVar, Dict, List, Literal, Optional, Tuple, Type, Union
 
 from git import Actor
 from git.repo.base import Repo
 from jinja2 import Environment
 from pydantic import BaseModel, Field, RootModel, ValidationError, model_validator
-from typing_extensions import Annotated, Literal
+
+# For Python 3.8 compatibility
+from typing_extensions import Annotated
 
 from semantic_release import hvcs
 from semantic_release.changelog import environment

--- a/tests/util.py
+++ b/tests/util.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     try:
         from typing import TypeAlias
     except ImportError:
+        # for python 3.8 and 3.9
         from typing_extensions import TypeAlias
 
     from unittest.mock import MagicMock


### PR DESCRIPTION
In lieu of the `v9` release where support for `3.7` was removed, this PR cleans up any additional code adjustments specific to `3.7` support.