### PR TITLE
fix(algorithm): enable maintenance prereleases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,11 @@ on:
 # default token permissions = none
 permissions: {}
 
+# If a new push is made to the branch, cancel the previous run
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   commitlint:

--- a/tests/e2e/cmd_version/bump_version/trunk_based_dev/test_repo_trunk_dual_version_support.py
+++ b/tests/e2e/cmd_version/bump_version/trunk_based_dev/test_repo_trunk_dual_version_support.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+import tomlkit
+from flatdict import FlatDict
+from freezegun import freeze_time
+
+from semantic_release.cli.commands.main import main
+
+from tests.const import (
+    DEFAULT_BRANCH_NAME,
+    MAIN_PROG_NAME,
+    VERSION_SUBCMD,
+)
+from tests.fixtures.repos.trunk_based_dev import (
+    repo_w_trunk_only_dual_version_spt_angular_commits,
+    repo_w_trunk_only_dual_version_spt_emoji_commits,
+    repo_w_trunk_only_dual_version_spt_scipy_commits,
+)
+from tests.util import assert_successful_exit_code, temporary_working_directory
+
+if TYPE_CHECKING:
+    from pathlib import Path
+    from unittest.mock import MagicMock
+
+    from click.testing import CliRunner
+    from requests_mock import Mocker
+
+    from tests.e2e.cmd_version.bump_version.conftest import (
+        GetSanitizedMdChangelogContentFn,
+        GetSanitizedRstChangelogContentFn,
+        InitMirrorRepo4RebuildFn,
+    )
+    from tests.fixtures.example_project import ExProjectDir
+    from tests.fixtures.git_repo import (
+        BuildRepoFromDefinitionFn,
+        BuildSpecificRepoFn,
+        CommitConvention,
+        GetGitRepo4DirFn,
+        RepoActionConfigure,
+        RepoActionRelease,
+        RepoActions,
+        SplitRepoActionsByReleaseTagsFn,
+    )
+
+
+@pytest.mark.parametrize(
+    "repo_fixture_name",
+    [
+        repo_w_trunk_only_dual_version_spt_angular_commits.__name__,
+        *[
+            pytest.param(repo_fixture_name, marks=pytest.mark.comprehensive)
+            for repo_fixture_name in [
+                repo_w_trunk_only_dual_version_spt_emoji_commits.__name__,
+                repo_w_trunk_only_dual_version_spt_scipy_commits.__name__,
+            ]
+        ],
+    ],
+)
+def test_trunk_repo_rebuild_dual_version_spt_official_releases_only(
+    repo_fixture_name: str,
+    cli_runner: CliRunner,
+    build_trunk_only_repo_w_dual_version_support: BuildSpecificRepoFn,
+    split_repo_actions_by_release_tags: SplitRepoActionsByReleaseTagsFn,
+    init_mirror_repo_for_rebuild: InitMirrorRepo4RebuildFn,
+    example_project_dir: ExProjectDir,
+    git_repo_for_directory: GetGitRepo4DirFn,
+    build_repo_from_definition: BuildRepoFromDefinitionFn,
+    mocked_git_push: MagicMock,
+    post_mocker: Mocker,
+    default_tag_format_str: str,
+    version_py_file: Path,
+    get_sanitized_md_changelog_content: GetSanitizedMdChangelogContentFn,
+    get_sanitized_rst_changelog_content: GetSanitizedRstChangelogContentFn,
+):
+    # build target repo into a temporary directory
+    target_repo_dir = example_project_dir / repo_fixture_name
+    commit_type: CommitConvention = (
+        repo_fixture_name.split("commits", 1)[0].split("_")[-2]  # type: ignore[assignment]
+    )
+    target_repo_definition = build_trunk_only_repo_w_dual_version_support(
+        repo_name=repo_fixture_name,
+        commit_type=commit_type,
+        dest_dir=target_repo_dir,
+    )
+    target_git_repo = git_repo_for_directory(target_repo_dir)
+    target_repo_pyproject_toml = FlatDict(
+        tomlkit.loads((target_repo_dir / "pyproject.toml").read_text(encoding="utf-8")),
+        delimiter=".",
+    )
+    tag_format_str: str = target_repo_pyproject_toml.get(  # type: ignore[assignment]
+        "tool.semantic_release.tag_format",
+        default_tag_format_str,
+    )
+
+    # split repo actions by release actions
+    releasetags_2_steps: dict[str, list[RepoActions]] = (
+        split_repo_actions_by_release_tags(target_repo_definition, tag_format_str)
+    )
+    configuration_step: RepoActionConfigure = releasetags_2_steps.pop("")[0]  # type: ignore[assignment]
+
+    # Create the mirror repo directory
+    mirror_repo_dir = init_mirror_repo_for_rebuild(
+        mirror_repo_dir=(example_project_dir / "mirror"),
+        configuration_step=configuration_step,
+    )
+    mirror_git_repo = git_repo_for_directory(mirror_repo_dir)
+
+    # rebuild repo from scratch stopping before each release tag
+    for curr_release_tag, steps in releasetags_2_steps.items():
+        # make sure mocks are clear
+        mocked_git_push.reset_mock()
+        post_mocker.reset_mock()
+
+        # Extract expected result from target repo
+        head_reference_name = (
+            curr_release_tag
+            if curr_release_tag != "Unreleased"
+            else DEFAULT_BRANCH_NAME
+        )
+        target_git_repo.git.checkout(head_reference_name, detach=True)
+        expected_md_changelog_content = get_sanitized_md_changelog_content(
+            repo_dir=target_repo_dir
+        )
+        expected_rst_changelog_content = get_sanitized_rst_changelog_content(
+            repo_dir=target_repo_dir
+        )
+        expected_pyproject_toml_content = (
+            target_repo_dir / "pyproject.toml"
+        ).read_text()
+        expected_version_file_content = (target_repo_dir / version_py_file).read_text()
+        expected_release_commit_text = target_git_repo.head.commit.message
+
+        # In our repo env, start building the repo from the definition
+        build_repo_from_definition(
+            dest_dir=mirror_repo_dir,
+            repo_construction_steps=steps[:-1],  # stop before the release step
+        )
+        release_action_step: RepoActionRelease = steps[-1]  # type: ignore[assignment]
+
+        # Act: run PSR on the repo instead of the RELEASE step
+        with freeze_time(
+            release_action_step["details"]["datetime"]
+        ), temporary_working_directory(mirror_repo_dir):
+            build_metadata_args = (
+                [
+                    "--build-metadata",
+                    release_action_step["details"]["version"].split("+", maxsplit=1)[
+                        -1
+                    ],
+                ]
+                if len(release_action_step["details"]["version"].split("+", maxsplit=1))
+                > 1
+                else []
+            )
+            cli_cmd = [MAIN_PROG_NAME, "--strict", VERSION_SUBCMD, *build_metadata_args]
+            result = cli_runner.invoke(main, cli_cmd[1:])
+
+        # take measurement after running the version command
+        actual_release_commit_text = mirror_git_repo.head.commit.message
+        actual_pyproject_toml_content = (mirror_repo_dir / "pyproject.toml").read_text()
+        actual_version_file_content = (mirror_repo_dir / version_py_file).read_text()
+        actual_md_changelog_content = get_sanitized_md_changelog_content(
+            repo_dir=mirror_repo_dir
+        )
+        actual_rst_changelog_content = get_sanitized_rst_changelog_content(
+            repo_dir=mirror_repo_dir
+        )
+
+        # Evaluate (normal release actions should have occurred as expected)
+        assert_successful_exit_code(result, cli_cmd)
+        # Make sure version file is updated
+        assert expected_pyproject_toml_content == actual_pyproject_toml_content
+        assert expected_version_file_content == actual_version_file_content
+        # Make sure changelog is updated
+        assert expected_md_changelog_content == actual_md_changelog_content
+        assert expected_rst_changelog_content == actual_rst_changelog_content
+        # Make sure commit is created
+        assert expected_release_commit_text == actual_release_commit_text
+        # Make sure tag is created
+        assert curr_release_tag in [tag.name for tag in mirror_git_repo.tags]
+        assert mocked_git_push.call_count == 2  # 1 for commit, 1 for tag
+        assert post_mocker.call_count == 1  # vcs release creation occured

--- a/tests/e2e/cmd_version/bump_version/trunk_based_dev/test_repo_trunk_dual_version_support_w_prereleases.py
+++ b/tests/e2e/cmd_version/bump_version/trunk_based_dev/test_repo_trunk_dual_version_support_w_prereleases.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+import tomlkit
+from flatdict import FlatDict
+from freezegun import freeze_time
+
+from semantic_release.cli.commands.main import main
+
+from tests.const import (
+    DEFAULT_BRANCH_NAME,
+    MAIN_PROG_NAME,
+    VERSION_SUBCMD,
+)
+from tests.fixtures.repos.trunk_based_dev import (
+    repo_w_trunk_only_dual_version_spt_w_prereleases_angular_commits,
+    repo_w_trunk_only_dual_version_spt_w_prereleases_emoji_commits,
+    repo_w_trunk_only_dual_version_spt_w_prereleases_scipy_commits,
+)
+from tests.util import assert_successful_exit_code, temporary_working_directory
+
+if TYPE_CHECKING:
+    from pathlib import Path
+    from unittest.mock import MagicMock
+
+    from click.testing import CliRunner
+    from requests_mock import Mocker
+
+    from tests.e2e.cmd_version.bump_version.conftest import (
+        GetSanitizedMdChangelogContentFn,
+        GetSanitizedRstChangelogContentFn,
+        InitMirrorRepo4RebuildFn,
+    )
+    from tests.fixtures.example_project import ExProjectDir
+    from tests.fixtures.git_repo import (
+        BuildRepoFromDefinitionFn,
+        BuildSpecificRepoFn,
+        CommitConvention,
+        GetGitRepo4DirFn,
+        RepoActionConfigure,
+        RepoActionRelease,
+        RepoActions,
+        SplitRepoActionsByReleaseTagsFn,
+    )
+
+
+@pytest.mark.parametrize(
+    "repo_fixture_name",
+    [
+        repo_w_trunk_only_dual_version_spt_w_prereleases_angular_commits.__name__,
+        *[
+            pytest.param(repo_fixture_name, marks=pytest.mark.comprehensive)
+            for repo_fixture_name in [
+                repo_w_trunk_only_dual_version_spt_w_prereleases_emoji_commits.__name__,
+                repo_w_trunk_only_dual_version_spt_w_prereleases_scipy_commits.__name__,
+            ]
+        ],
+    ],
+)
+def test_trunk_repo_rebuild_dual_version_spt_w_official_n_prereleases(
+    repo_fixture_name: str,
+    cli_runner: CliRunner,
+    build_trunk_only_repo_w_dual_version_spt_w_prereleases: BuildSpecificRepoFn,
+    split_repo_actions_by_release_tags: SplitRepoActionsByReleaseTagsFn,
+    init_mirror_repo_for_rebuild: InitMirrorRepo4RebuildFn,
+    example_project_dir: ExProjectDir,
+    git_repo_for_directory: GetGitRepo4DirFn,
+    build_repo_from_definition: BuildRepoFromDefinitionFn,
+    mocked_git_push: MagicMock,
+    post_mocker: Mocker,
+    default_tag_format_str: str,
+    version_py_file: Path,
+    get_sanitized_md_changelog_content: GetSanitizedMdChangelogContentFn,
+    get_sanitized_rst_changelog_content: GetSanitizedRstChangelogContentFn,
+):
+    # build target repo into a temporary directory
+    target_repo_dir = example_project_dir / repo_fixture_name
+    commit_type: CommitConvention = (
+        repo_fixture_name.split("commits", 1)[0].split("_")[-2]  # type: ignore[assignment]
+    )
+    target_repo_definition = build_trunk_only_repo_w_dual_version_spt_w_prereleases(
+        repo_name=repo_fixture_name,
+        commit_type=commit_type,
+        dest_dir=target_repo_dir,
+    )
+    target_git_repo = git_repo_for_directory(target_repo_dir)
+    target_repo_pyproject_toml = FlatDict(
+        tomlkit.loads((target_repo_dir / "pyproject.toml").read_text(encoding="utf-8")),
+        delimiter=".",
+    )
+    tag_format_str: str = target_repo_pyproject_toml.get(  # type: ignore[assignment]
+        "tool.semantic_release.tag_format",
+        default_tag_format_str,
+    )
+
+    # split repo actions by release actions
+    releasetags_2_steps: dict[str, list[RepoActions]] = (
+        split_repo_actions_by_release_tags(target_repo_definition, tag_format_str)
+    )
+    configuration_step: RepoActionConfigure = releasetags_2_steps.pop("")[0]  # type: ignore[assignment]
+
+    # Create the mirror repo directory
+    mirror_repo_dir = init_mirror_repo_for_rebuild(
+        mirror_repo_dir=(example_project_dir / "mirror"),
+        configuration_step=configuration_step,
+    )
+    mirror_git_repo = git_repo_for_directory(mirror_repo_dir)
+
+    # rebuild repo from scratch stopping before each release tag
+    for curr_release_tag, steps in releasetags_2_steps.items():
+        # make sure mocks are clear
+        mocked_git_push.reset_mock()
+        post_mocker.reset_mock()
+
+        # Extract expected result from target repo
+        head_reference_name = (
+            curr_release_tag
+            if curr_release_tag != "Unreleased"
+            else DEFAULT_BRANCH_NAME
+        )
+        target_git_repo.git.checkout(head_reference_name, detach=True)
+        expected_md_changelog_content = get_sanitized_md_changelog_content(
+            repo_dir=target_repo_dir
+        )
+        expected_rst_changelog_content = get_sanitized_rst_changelog_content(
+            repo_dir=target_repo_dir
+        )
+        expected_pyproject_toml_content = (
+            target_repo_dir / "pyproject.toml"
+        ).read_text()
+        expected_version_file_content = (target_repo_dir / version_py_file).read_text()
+        expected_release_commit_text = target_git_repo.head.commit.message
+
+        # In our repo env, start building the repo from the definition
+        build_repo_from_definition(
+            dest_dir=mirror_repo_dir,
+            repo_construction_steps=steps[:-1],  # stop before the release step
+        )
+        release_action_step: RepoActionRelease = steps[-1]  # type: ignore[assignment]
+
+        # Act: run PSR on the repo instead of the RELEASE step
+        with freeze_time(
+            release_action_step["details"]["datetime"]
+        ), temporary_working_directory(mirror_repo_dir):
+            build_metadata_args = (
+                [
+                    "--build-metadata",
+                    release_action_step["details"]["version"].split("+", maxsplit=1)[
+                        -1
+                    ],
+                ]
+                if len(release_action_step["details"]["version"].split("+", maxsplit=1))
+                > 1
+                else []
+            )
+            prerelease_args = (
+                [
+                    "--as-prerelease",
+                    "--prerelease-token",
+                    (
+                        release_action_step["details"]["version"]
+                        .split("-", maxsplit=1)[-1]
+                        .split(".", maxsplit=1)[0]
+                    ),
+                ]
+                if len(release_action_step["details"]["version"].split("-", maxsplit=1))
+                > 1
+                else []
+            )
+            cli_cmd = [
+                MAIN_PROG_NAME,
+                "--strict",
+                VERSION_SUBCMD,
+                *build_metadata_args,
+                *prerelease_args,
+            ]
+            result = cli_runner.invoke(main, cli_cmd[1:])
+
+        # take measurement after running the version command
+        actual_release_commit_text = mirror_git_repo.head.commit.message
+        actual_pyproject_toml_content = (mirror_repo_dir / "pyproject.toml").read_text()
+        actual_version_file_content = (mirror_repo_dir / version_py_file).read_text()
+        actual_md_changelog_content = get_sanitized_md_changelog_content(
+            repo_dir=mirror_repo_dir
+        )
+        actual_rst_changelog_content = get_sanitized_rst_changelog_content(
+            repo_dir=mirror_repo_dir
+        )
+
+        # Evaluate (normal release actions should have occurred as expected)
+        assert_successful_exit_code(result, cli_cmd)
+        # Make sure version file is updated
+        assert expected_pyproject_toml_content == actual_pyproject_toml_content
+        assert expected_version_file_content == actual_version_file_content
+        # Make sure changelog is updated
+        assert expected_md_changelog_content == actual_md_changelog_content
+        assert expected_rst_changelog_content == actual_rst_changelog_content
+        # Make sure commit is created
+        assert expected_release_commit_text == actual_release_commit_text
+        # Make sure tag is created
+        assert curr_release_tag in [tag.name for tag in mirror_git_repo.tags]
+        assert mocked_git_push.call_count == 2  # 1 for commit, 1 for tag
+        assert post_mocker.call_count == 1  # vcs release creation occured

--- a/tests/fixtures/repos/trunk_based_dev/__init__.py
+++ b/tests/fixtures/repos/trunk_based_dev/__init__.py
@@ -1,3 +1,5 @@
+from tests.fixtures.repos.trunk_based_dev.repo_w_dual_version_support import *
+from tests.fixtures.repos.trunk_based_dev.repo_w_dual_version_support_w_prereleases import *
 from tests.fixtures.repos.trunk_based_dev.repo_w_no_tags import *
 from tests.fixtures.repos.trunk_based_dev.repo_w_prereleases import *
 from tests.fixtures.repos.trunk_based_dev.repo_w_tags import *

--- a/tests/fixtures/repos/trunk_based_dev/repo_w_dual_version_support.py
+++ b/tests/fixtures/repos/trunk_based_dev/repo_w_dual_version_support.py
@@ -1,0 +1,460 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from itertools import count
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from semantic_release.cli.config import ChangelogOutputFormat
+
+import tests.conftest
+import tests.const
+import tests.util
+from tests.const import (
+    DEFAULT_BRANCH_NAME,
+    EXAMPLE_HVCS_DOMAIN,
+    INITIAL_COMMIT_MESSAGE,
+    RepoActionStep,
+)
+
+if TYPE_CHECKING:
+    from typing import Sequence
+
+    from tests.conftest import (
+        GetCachedRepoDataFn,
+        GetMd5ForSetOfFilesFn,
+        GetStableDateNowFn,
+    )
+    from tests.fixtures.example_project import (
+        ExProjectDir,
+    )
+    from tests.fixtures.git_repo import (
+        BuildRepoFromDefinitionFn,
+        BuildRepoOrCopyCacheFn,
+        BuildSpecificRepoFn,
+        BuiltRepoResult,
+        CommitConvention,
+        ConvertCommitSpecsToCommitDefsFn,
+        ExProjectGitRepoFn,
+        GetRepoDefinitionFn,
+        RepoActions,
+        RepoActionWriteChangelogsDestFile,
+        TomlSerializableTypes,
+    )
+
+
+MAINTENANCE_BRANCH_NAME = "v1.x"
+
+
+@pytest.fixture(scope="session")
+def deps_files_4_repo_w_dual_version_support(
+    deps_files_4_example_git_project: list[Path],
+) -> list[Path]:
+    return [
+        *deps_files_4_example_git_project,
+        # This file
+        Path(__file__).absolute(),
+        # because of imports
+        Path(tests.const.__file__).absolute(),
+        Path(tests.util.__file__).absolute(),
+        # because of the fixtures
+        Path(tests.conftest.__file__).absolute(),
+    ]
+
+
+@pytest.fixture(scope="session")
+def build_spec_hash_4_repo_w_dual_version_support(
+    get_md5_for_set_of_files: GetMd5ForSetOfFilesFn,
+    deps_files_4_repo_w_dual_version_support: list[Path],
+) -> str:
+    # Generates a hash of the build spec to set when to invalidate the cache
+    return get_md5_for_set_of_files(deps_files_4_repo_w_dual_version_support)
+
+
+@pytest.fixture(scope="session")
+def get_repo_definition_4_trunk_only_repo_w_dual_version_support(
+    convert_commit_specs_to_commit_defs: ConvertCommitSpecsToCommitDefsFn,
+    changelog_md_file: Path,
+    changelog_rst_file: Path,
+    stable_now_date: GetStableDateNowFn,
+) -> GetRepoDefinitionFn:
+    """
+    Builds a repository with trunk-only committing (no-branching) strategy with
+    only official releases with latest and previous version support.
+    """
+
+    def _get_repo_from_defintion(
+        commit_type: CommitConvention,
+        hvcs_client_name: str = "github",
+        hvcs_domain: str = EXAMPLE_HVCS_DOMAIN,
+        tag_format_str: str | None = None,
+        extra_configs: dict[str, TomlSerializableTypes] | None = None,
+        mask_initial_release: bool = False,
+    ) -> Sequence[RepoActions]:
+        stable_now_datetime = stable_now_date()
+        commit_timestamp_gen = (
+            (stable_now_datetime + timedelta(seconds=i)).isoformat(timespec="seconds")
+            for i in count(step=1)
+        )
+
+        changelog_file_definitons: Sequence[RepoActionWriteChangelogsDestFile] = [
+            {
+                "path": changelog_md_file,
+                "format": ChangelogOutputFormat.MARKDOWN,
+            },
+            {
+                "path": changelog_rst_file,
+                "format": ChangelogOutputFormat.RESTRUCTURED_TEXT,
+            },
+        ]
+
+        repo_construction_steps: list[RepoActions] = []
+
+        repo_construction_steps.append(
+            {
+                "action": RepoActionStep.CONFIGURE,
+                "details": {
+                    "commit_type": commit_type,
+                    "hvcs_client_name": hvcs_client_name,
+                    "hvcs_domain": hvcs_domain,
+                    "tag_format_str": tag_format_str,
+                    "mask_initial_release": mask_initial_release,
+                    "extra_configs": {
+                        # Set the default release branch
+                        "tool.semantic_release.branches.latest": {
+                            "match": r"^(main|master)$",
+                            "prerelease": False,
+                        },
+                        "tool.semantic_release.branches.maintenance": {
+                            "match": r"^v1\.x$",
+                            "prerelease": False,
+                        },
+                        "tool.semantic_release.allow_zero_version": False,
+                        **(extra_configs or {}),
+                    },
+                },
+            }
+        )
+
+        # Make initial release
+        new_version = "1.0.0"
+
+        repo_construction_steps.extend(
+            [
+                {
+                    "action": RepoActionStep.MAKE_COMMITS,
+                    "details": {
+                        "commits": convert_commit_specs_to_commit_defs(
+                            [
+                                {
+                                    "angular": INITIAL_COMMIT_MESSAGE,
+                                    "emoji": INITIAL_COMMIT_MESSAGE,
+                                    "scipy": INITIAL_COMMIT_MESSAGE,
+                                    "datetime": next(commit_timestamp_gen),
+                                    "include_in_changelog": bool(
+                                        commit_type == "emoji"
+                                    ),
+                                },
+                                {
+                                    "angular": "feat: add new feature",
+                                    "emoji": ":sparkles: add new feature",
+                                    "scipy": "ENH: add new feature",
+                                    "datetime": next(commit_timestamp_gen),
+                                    "include_in_changelog": True,
+                                },
+                            ],
+                            commit_type,
+                        ),
+                    },
+                },
+                {
+                    "action": RepoActionStep.RELEASE,
+                    "details": {
+                        "version": new_version,
+                        "datetime": next(commit_timestamp_gen),
+                        "pre_actions": [
+                            {
+                                "action": RepoActionStep.WRITE_CHANGELOGS,
+                                "details": {
+                                    "new_version": new_version,
+                                    "dest_files": changelog_file_definitons,
+                                },
+                            },
+                        ],
+                    },
+                },
+            ]
+        )
+
+        # Make a fix and officially release it
+        new_version = "1.0.1"
+        repo_construction_steps.extend(
+            [
+                {
+                    "action": RepoActionStep.MAKE_COMMITS,
+                    "details": {
+                        "commits": convert_commit_specs_to_commit_defs(
+                            [
+                                {
+                                    "angular": "fix: correct some text",
+                                    "emoji": ":bug: correct some text",
+                                    "scipy": "MAINT: correct some text",
+                                    "datetime": next(commit_timestamp_gen),
+                                    "include_in_changelog": True,
+                                },
+                            ],
+                            commit_type,
+                        ),
+                    },
+                },
+                {
+                    "action": RepoActionStep.RELEASE,
+                    "details": {
+                        "version": new_version,
+                        "datetime": next(commit_timestamp_gen),
+                        "pre_actions": [
+                            {
+                                "action": RepoActionStep.WRITE_CHANGELOGS,
+                                "details": {
+                                    "new_version": new_version,
+                                    "dest_files": changelog_file_definitons,
+                                },
+                            },
+                        ],
+                    },
+                },
+            ]
+        )
+
+        # Make a breaking change and officially release it
+        new_version = "2.0.0"
+        repo_construction_steps.extend(
+            [
+                {
+                    "action": RepoActionStep.GIT_CHECKOUT,
+                    "details": {
+                        "create_branch": {
+                            "name": MAINTENANCE_BRANCH_NAME,
+                            "start_branch": DEFAULT_BRANCH_NAME,
+                        }
+                    },
+                },
+                {
+                    "action": RepoActionStep.GIT_CHECKOUT,
+                    "details": {"branch": DEFAULT_BRANCH_NAME},
+                },
+                {
+                    "action": RepoActionStep.MAKE_COMMITS,
+                    "details": {
+                        "commits": convert_commit_specs_to_commit_defs(
+                            [
+                                {
+                                    "angular": str.join(
+                                        "\n\n",
+                                        [
+                                            "feat: add revolutionary feature",
+                                            "BREAKING CHANGE: this is a breaking change",
+                                        ],
+                                    ),
+                                    "emoji": str.join(
+                                        "\n\n",
+                                        [
+                                            ":boom: add revolutionary feature",
+                                            "This change is a breaking change",
+                                        ],
+                                    ),
+                                    "scipy": str.join(
+                                        "\n\n",
+                                        [
+                                            "API: add revolutionary feature",
+                                            "BREAKING CHANGE: this is a breaking change",
+                                        ],
+                                    ),
+                                    "datetime": next(commit_timestamp_gen),
+                                    "include_in_changelog": True,
+                                },
+                            ],
+                            commit_type,
+                        ),
+                    },
+                },
+                {
+                    "action": RepoActionStep.RELEASE,
+                    "details": {
+                        "version": new_version,
+                        "datetime": next(commit_timestamp_gen),
+                        "pre_actions": [
+                            {
+                                "action": RepoActionStep.WRITE_CHANGELOGS,
+                                "details": {
+                                    "new_version": new_version,
+                                    "dest_files": changelog_file_definitons,
+                                },
+                            },
+                        ],
+                    },
+                },
+            ]
+        )
+
+        # Fix a critical bug in the previous version and officially release it
+        new_version = "1.0.2"
+        repo_construction_steps.extend(
+            [
+                {
+                    "action": RepoActionStep.GIT_CHECKOUT,
+                    "details": {"branch": MAINTENANCE_BRANCH_NAME},
+                },
+                {
+                    "action": RepoActionStep.MAKE_COMMITS,
+                    "details": {
+                        "commits": convert_commit_specs_to_commit_defs(
+                            [
+                                {
+                                    "angular": "fix: correct critical bug",
+                                    "emoji": ":bug: correct critical bug",
+                                    "scipy": "MAINT: correct critical bug",
+                                    "datetime": next(commit_timestamp_gen),
+                                    "include_in_changelog": True,
+                                },
+                            ],
+                            commit_type,
+                        ),
+                    },
+                },
+                {
+                    "action": RepoActionStep.RELEASE,
+                    "details": {
+                        "version": new_version,
+                        "datetime": next(commit_timestamp_gen),
+                        "pre_actions": [
+                            {
+                                "action": RepoActionStep.WRITE_CHANGELOGS,
+                                "details": {
+                                    "new_version": new_version,
+                                    "max_version": new_version,
+                                    "dest_files": changelog_file_definitons,
+                                },
+                            },
+                        ],
+                    },
+                },
+            ]
+        )
+
+        # Return to the latest release variant
+        repo_construction_steps.extend(
+            [
+                {
+                    "action": RepoActionStep.GIT_CHECKOUT,
+                    "details": {"branch": DEFAULT_BRANCH_NAME},
+                },
+                # TODO: return and make another release on the latest version
+                # currently test variant of the changelog generator can't support this
+            ]
+        )
+
+        return repo_construction_steps
+
+    return _get_repo_from_defintion
+
+
+@pytest.fixture(scope="session")
+def build_trunk_only_repo_w_dual_version_support(
+    build_repo_from_definition: BuildRepoFromDefinitionFn,
+    get_repo_definition_4_trunk_only_repo_w_dual_version_support: GetRepoDefinitionFn,
+    get_cached_repo_data: GetCachedRepoDataFn,
+    build_repo_or_copy_cache: BuildRepoOrCopyCacheFn,
+    build_spec_hash_4_repo_w_dual_version_support: str,
+) -> BuildSpecificRepoFn:
+    def _build_specific_repo_type(
+        repo_name: str, commit_type: CommitConvention, dest_dir: Path
+    ) -> Sequence[RepoActions]:
+        def _build_repo(cached_repo_path: Path) -> Sequence[RepoActions]:
+            repo_construction_steps = (
+                get_repo_definition_4_trunk_only_repo_w_dual_version_support(
+                    commit_type=commit_type,
+                )
+            )
+            return build_repo_from_definition(cached_repo_path, repo_construction_steps)
+
+        build_repo_or_copy_cache(
+            repo_name=repo_name,
+            build_spec_hash=build_spec_hash_4_repo_w_dual_version_support,
+            build_repo_func=_build_repo,
+            dest_dir=dest_dir,
+        )
+
+        if not (cached_repo_data := get_cached_repo_data(proj_dirname=repo_name)):
+            raise ValueError("Failed to retrieve repo data from cache")
+
+        return cached_repo_data["build_definition"]
+
+    return _build_specific_repo_type
+
+
+# --------------------------------------------------------------------------- #
+# Test-level fixtures that will cache the built directory & set up test case  #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def repo_w_trunk_only_dual_version_spt_angular_commits(
+    build_trunk_only_repo_w_dual_version_support: BuildSpecificRepoFn,
+    example_project_git_repo: ExProjectGitRepoFn,
+    example_project_dir: ExProjectDir,
+    change_to_ex_proj_dir: None,
+) -> BuiltRepoResult:
+    repo_name = repo_w_trunk_only_dual_version_spt_angular_commits.__name__
+    commit_type: CommitConvention = repo_name.split("_")[-2]  # type: ignore[assignment]
+
+    return {
+        "definition": build_trunk_only_repo_w_dual_version_support(
+            repo_name=repo_name,
+            commit_type=commit_type,
+            dest_dir=example_project_dir,
+        ),
+        "repo": example_project_git_repo(),
+    }
+
+
+@pytest.fixture
+def repo_w_trunk_only_dual_version_spt_emoji_commits(
+    build_trunk_only_repo_w_dual_version_support: BuildSpecificRepoFn,
+    example_project_git_repo: ExProjectGitRepoFn,
+    example_project_dir: ExProjectDir,
+    change_to_ex_proj_dir: None,
+) -> BuiltRepoResult:
+    repo_name = repo_w_trunk_only_dual_version_spt_emoji_commits.__name__
+    commit_type: CommitConvention = repo_name.split("_")[-2]  # type: ignore[assignment]
+
+    return {
+        "definition": build_trunk_only_repo_w_dual_version_support(
+            repo_name=repo_name,
+            commit_type=commit_type,
+            dest_dir=example_project_dir,
+        ),
+        "repo": example_project_git_repo(),
+    }
+
+
+@pytest.fixture
+def repo_w_trunk_only_dual_version_spt_scipy_commits(
+    build_trunk_only_repo_w_dual_version_support: BuildSpecificRepoFn,
+    example_project_git_repo: ExProjectGitRepoFn,
+    example_project_dir: ExProjectDir,
+    change_to_ex_proj_dir: None,
+) -> BuiltRepoResult:
+    repo_name = repo_w_trunk_only_dual_version_spt_scipy_commits.__name__
+    commit_type: CommitConvention = repo_name.split("_")[-2]  # type: ignore[assignment]
+
+    return {
+        "definition": build_trunk_only_repo_w_dual_version_support(
+            repo_name=repo_name,
+            commit_type=commit_type,
+            dest_dir=example_project_dir,
+        ),
+        "repo": example_project_git_repo(),
+    }

--- a/tests/fixtures/repos/trunk_based_dev/repo_w_dual_version_support_w_prereleases.py
+++ b/tests/fixtures/repos/trunk_based_dev/repo_w_dual_version_support_w_prereleases.py
@@ -1,0 +1,545 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from itertools import count
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from semantic_release.cli.config import ChangelogOutputFormat
+
+import tests.conftest
+import tests.const
+import tests.util
+from tests.const import (
+    DEFAULT_BRANCH_NAME,
+    EXAMPLE_HVCS_DOMAIN,
+    INITIAL_COMMIT_MESSAGE,
+    RepoActionStep,
+)
+
+if TYPE_CHECKING:
+    from typing import Sequence
+
+    from tests.conftest import (
+        GetCachedRepoDataFn,
+        GetMd5ForSetOfFilesFn,
+        GetStableDateNowFn,
+    )
+    from tests.fixtures.example_project import (
+        ExProjectDir,
+    )
+    from tests.fixtures.git_repo import (
+        BuildRepoFromDefinitionFn,
+        BuildRepoOrCopyCacheFn,
+        BuildSpecificRepoFn,
+        BuiltRepoResult,
+        CommitConvention,
+        ConvertCommitSpecsToCommitDefsFn,
+        ExProjectGitRepoFn,
+        GetRepoDefinitionFn,
+        RepoActions,
+        RepoActionWriteChangelogsDestFile,
+        TomlSerializableTypes,
+    )
+
+
+MAINTENANCE_BRANCH_NAME = "v1.x"
+
+
+@pytest.fixture(scope="session")
+def deps_files_4_repo_w_dual_version_spt_w_prereleases(
+    deps_files_4_example_git_project: list[Path],
+) -> list[Path]:
+    return [
+        *deps_files_4_example_git_project,
+        # This file
+        Path(__file__).absolute(),
+        # because of imports
+        Path(tests.const.__file__).absolute(),
+        Path(tests.util.__file__).absolute(),
+        # because of the fixtures
+        Path(tests.conftest.__file__).absolute(),
+    ]
+
+
+@pytest.fixture(scope="session")
+def build_spec_hash_4_repo_w_dual_version_spt_w_prereleases(
+    get_md5_for_set_of_files: GetMd5ForSetOfFilesFn,
+    deps_files_4_repo_w_dual_version_spt_w_prereleases: list[Path],
+) -> str:
+    # Generates a hash of the build spec to set when to invalidate the cache
+    return get_md5_for_set_of_files(deps_files_4_repo_w_dual_version_spt_w_prereleases)
+
+
+@pytest.fixture(scope="session")
+def get_repo_definition_4_trunk_only_repo_w_dual_version_spt_w_prereleases(
+    convert_commit_specs_to_commit_defs: ConvertCommitSpecsToCommitDefsFn,
+    changelog_md_file: Path,
+    changelog_rst_file: Path,
+    stable_now_date: GetStableDateNowFn,
+) -> GetRepoDefinitionFn:
+    """
+    Builds a repository with trunk-only committing (no-branching) strategy with
+    only official releases with latest and previous version support.
+    """
+
+    def _get_repo_from_defintion(
+        commit_type: CommitConvention,
+        hvcs_client_name: str = "github",
+        hvcs_domain: str = EXAMPLE_HVCS_DOMAIN,
+        tag_format_str: str | None = None,
+        extra_configs: dict[str, TomlSerializableTypes] | None = None,
+        mask_initial_release: bool = False,
+    ) -> Sequence[RepoActions]:
+        stable_now_datetime = stable_now_date()
+        commit_timestamp_gen = (
+            (stable_now_datetime + timedelta(seconds=i)).isoformat(timespec="seconds")
+            for i in count(step=1)
+        )
+
+        changelog_file_definitons: Sequence[RepoActionWriteChangelogsDestFile] = [
+            {
+                "path": changelog_md_file,
+                "format": ChangelogOutputFormat.MARKDOWN,
+            },
+            {
+                "path": changelog_rst_file,
+                "format": ChangelogOutputFormat.RESTRUCTURED_TEXT,
+            },
+        ]
+
+        repo_construction_steps: list[RepoActions] = []
+
+        repo_construction_steps.append(
+            {
+                "action": RepoActionStep.CONFIGURE,
+                "details": {
+                    "commit_type": commit_type,
+                    "hvcs_client_name": hvcs_client_name,
+                    "hvcs_domain": hvcs_domain,
+                    "tag_format_str": tag_format_str,
+                    "mask_initial_release": mask_initial_release,
+                    "extra_configs": {
+                        # Set the default release branch
+                        "tool.semantic_release.branches.latest": {
+                            "match": r"^(main|master)$",
+                            "prerelease": False,
+                        },
+                        "tool.semantic_release.branches.maintenance": {
+                            "match": r"^v1\.x$",
+                            "prerelease": False,
+                        },
+                        "tool.semantic_release.allow_zero_version": False,
+                        **(extra_configs or {}),
+                    },
+                },
+            }
+        )
+
+        # Make initial release
+        new_version = "1.0.0"
+
+        repo_construction_steps.extend(
+            [
+                {
+                    "action": RepoActionStep.MAKE_COMMITS,
+                    "details": {
+                        "commits": convert_commit_specs_to_commit_defs(
+                            [
+                                {
+                                    "angular": INITIAL_COMMIT_MESSAGE,
+                                    "emoji": INITIAL_COMMIT_MESSAGE,
+                                    "scipy": INITIAL_COMMIT_MESSAGE,
+                                    "datetime": next(commit_timestamp_gen),
+                                    "include_in_changelog": bool(
+                                        commit_type == "emoji"
+                                    ),
+                                },
+                                {
+                                    "angular": "feat: add new feature",
+                                    "emoji": ":sparkles: add new feature",
+                                    "scipy": "ENH: add new feature",
+                                    "datetime": next(commit_timestamp_gen),
+                                    "include_in_changelog": True,
+                                },
+                            ],
+                            commit_type,
+                        ),
+                    },
+                },
+                {
+                    "action": RepoActionStep.RELEASE,
+                    "details": {
+                        "version": new_version,
+                        "datetime": next(commit_timestamp_gen),
+                        "pre_actions": [
+                            {
+                                "action": RepoActionStep.WRITE_CHANGELOGS,
+                                "details": {
+                                    "new_version": new_version,
+                                    "dest_files": changelog_file_definitons,
+                                },
+                            },
+                        ],
+                    },
+                },
+            ]
+        )
+
+        # Make a fix and officially release it
+        new_version = "1.0.1"
+        repo_construction_steps.extend(
+            [
+                {
+                    "action": RepoActionStep.MAKE_COMMITS,
+                    "details": {
+                        "commits": convert_commit_specs_to_commit_defs(
+                            [
+                                {
+                                    "angular": "fix: correct some text",
+                                    "emoji": ":bug: correct some text",
+                                    "scipy": "MAINT: correct some text",
+                                    "datetime": next(commit_timestamp_gen),
+                                    "include_in_changelog": True,
+                                },
+                            ],
+                            commit_type,
+                        ),
+                    },
+                },
+                {
+                    "action": RepoActionStep.RELEASE,
+                    "details": {
+                        "version": new_version,
+                        "datetime": next(commit_timestamp_gen),
+                        "pre_actions": [
+                            {
+                                "action": RepoActionStep.WRITE_CHANGELOGS,
+                                "details": {
+                                    "new_version": new_version,
+                                    "dest_files": changelog_file_definitons,
+                                },
+                            },
+                        ],
+                    },
+                },
+            ]
+        )
+
+        # Make a breaking change and officially release it
+        new_version = "2.0.0"
+        repo_construction_steps.extend(
+            [
+                {
+                    "action": RepoActionStep.GIT_CHECKOUT,
+                    "details": {
+                        "create_branch": {
+                            "name": MAINTENANCE_BRANCH_NAME,
+                            "start_branch": DEFAULT_BRANCH_NAME,
+                        }
+                    },
+                },
+                {
+                    "action": RepoActionStep.GIT_CHECKOUT,
+                    "details": {"branch": DEFAULT_BRANCH_NAME},
+                },
+                {
+                    "action": RepoActionStep.MAKE_COMMITS,
+                    "details": {
+                        "commits": convert_commit_specs_to_commit_defs(
+                            [
+                                {
+                                    "angular": str.join(
+                                        "\n\n",
+                                        [
+                                            "feat: add revolutionary feature",
+                                            "BREAKING CHANGE: this is a breaking change",
+                                        ],
+                                    ),
+                                    "emoji": str.join(
+                                        "\n\n",
+                                        [
+                                            ":boom: add revolutionary feature",
+                                            "This change is a breaking change",
+                                        ],
+                                    ),
+                                    "scipy": str.join(
+                                        "\n\n",
+                                        [
+                                            "API: add revolutionary feature",
+                                            "BREAKING CHANGE: this is a breaking change",
+                                        ],
+                                    ),
+                                    "datetime": next(commit_timestamp_gen),
+                                    "include_in_changelog": True,
+                                },
+                            ],
+                            commit_type,
+                        ),
+                    },
+                },
+                {
+                    "action": RepoActionStep.RELEASE,
+                    "details": {
+                        "version": new_version,
+                        "datetime": next(commit_timestamp_gen),
+                        "pre_actions": [
+                            {
+                                "action": RepoActionStep.WRITE_CHANGELOGS,
+                                "details": {
+                                    "new_version": new_version,
+                                    "dest_files": changelog_file_definitons,
+                                },
+                            },
+                        ],
+                    },
+                },
+            ]
+        )
+
+        # Attempt to fix a critical bug in the previous version and release it as a prerelease version
+        # This is based on https://github.com/python-semantic-release/python-semantic-release/issues/861
+        new_version = "1.0.2-hotfix.1"
+        repo_construction_steps.extend(
+            [
+                {
+                    "action": RepoActionStep.GIT_CHECKOUT,
+                    "details": {"branch": MAINTENANCE_BRANCH_NAME},
+                },
+                {
+                    "action": RepoActionStep.MAKE_COMMITS,
+                    "details": {
+                        "commits": convert_commit_specs_to_commit_defs(
+                            [
+                                {
+                                    "angular": "fix: correct critical bug",
+                                    "emoji": ":bug: correct critical bug",
+                                    "scipy": "MAINT: correct critical bug",
+                                    "datetime": next(commit_timestamp_gen),
+                                    "include_in_changelog": True,
+                                },
+                            ],
+                            commit_type,
+                        ),
+                    },
+                },
+                {
+                    "action": RepoActionStep.RELEASE,
+                    "details": {
+                        "version": new_version,
+                        "datetime": next(commit_timestamp_gen),
+                        "pre_actions": [
+                            {
+                                "action": RepoActionStep.WRITE_CHANGELOGS,
+                                "details": {
+                                    "new_version": new_version,
+                                    "max_version": new_version,
+                                    "dest_files": changelog_file_definitons,
+                                },
+                            },
+                        ],
+                    },
+                },
+            ]
+        )
+
+        # The Hotfix didn't work, so correct it and try again
+        new_version = "1.0.2-hotfix.2"
+        repo_construction_steps.extend(
+            [
+                {
+                    "action": RepoActionStep.MAKE_COMMITS,
+                    "details": {
+                        "commits": convert_commit_specs_to_commit_defs(
+                            [
+                                {
+                                    "angular": "fix: resolve critical bug",
+                                    "emoji": ":bug: resolve critical bug",
+                                    "scipy": "MAINT: resolve critical bug",
+                                    "datetime": next(commit_timestamp_gen),
+                                    "include_in_changelog": True,
+                                },
+                            ],
+                            commit_type,
+                        ),
+                    },
+                },
+                {
+                    "action": RepoActionStep.RELEASE,
+                    "details": {
+                        "version": new_version,
+                        "datetime": next(commit_timestamp_gen),
+                        "pre_actions": [
+                            {
+                                "action": RepoActionStep.WRITE_CHANGELOGS,
+                                "details": {
+                                    "new_version": new_version,
+                                    "max_version": new_version,
+                                    "dest_files": changelog_file_definitons,
+                                },
+                            },
+                        ],
+                    },
+                },
+            ]
+        )
+
+        # It finally was resolved so release it officially
+        new_version = "1.0.2"
+        repo_construction_steps.extend(
+            [
+                # {
+                #     "action": RepoActionStep.MAKE_COMMITS,
+                #     "details": {
+                #         "commits": convert_commit_specs_to_commit_defs(
+                #             [
+                #                 {
+                #                     "angular": "docs: update documentation regarding critical bug",
+                #                     "emoji": ":books: update documentation regarding critical bug",
+                #                     "scipy": "DOC: update documentation regarding critical bug",
+                #                     "datetime": next(commit_timestamp_gen),
+                #                     "include_in_changelog": True,
+                #                 },
+                #             ],
+                #             commit_type,
+                #         ),
+                #     },
+                # },
+                {
+                    "action": RepoActionStep.RELEASE,
+                    "details": {
+                        "version": new_version,
+                        "datetime": next(commit_timestamp_gen),
+                        "pre_actions": [
+                            {
+                                "action": RepoActionStep.WRITE_CHANGELOGS,
+                                "details": {
+                                    "new_version": new_version,
+                                    "max_version": new_version,
+                                    "dest_files": changelog_file_definitons,
+                                },
+                            },
+                        ],
+                    },
+                },
+            ]
+        )
+
+        # Return to the latest release variant
+        repo_construction_steps.extend(
+            [
+                {
+                    "action": RepoActionStep.GIT_CHECKOUT,
+                    "details": {"branch": DEFAULT_BRANCH_NAME},
+                },
+                # TODO: return and make another release on the latest version
+                # currently test variant of the changelog generator can't support this
+            ]
+        )
+
+        return repo_construction_steps
+
+    return _get_repo_from_defintion
+
+
+@pytest.fixture(scope="session")
+def build_trunk_only_repo_w_dual_version_spt_w_prereleases(
+    build_repo_from_definition: BuildRepoFromDefinitionFn,
+    get_repo_definition_4_trunk_only_repo_w_dual_version_spt_w_prereleases: GetRepoDefinitionFn,
+    get_cached_repo_data: GetCachedRepoDataFn,
+    build_repo_or_copy_cache: BuildRepoOrCopyCacheFn,
+    build_spec_hash_4_repo_w_dual_version_spt_w_prereleases: str,
+) -> BuildSpecificRepoFn:
+    def _build_specific_repo_type(
+        repo_name: str, commit_type: CommitConvention, dest_dir: Path
+    ) -> Sequence[RepoActions]:
+        def _build_repo(cached_repo_path: Path) -> Sequence[RepoActions]:
+            repo_construction_steps = (
+                get_repo_definition_4_trunk_only_repo_w_dual_version_spt_w_prereleases(
+                    commit_type=commit_type,
+                )
+            )
+            return build_repo_from_definition(cached_repo_path, repo_construction_steps)
+
+        build_repo_or_copy_cache(
+            repo_name=repo_name,
+            build_spec_hash=build_spec_hash_4_repo_w_dual_version_spt_w_prereleases,
+            build_repo_func=_build_repo,
+            dest_dir=dest_dir,
+        )
+
+        if not (cached_repo_data := get_cached_repo_data(proj_dirname=repo_name)):
+            raise ValueError("Failed to retrieve repo data from cache")
+
+        return cached_repo_data["build_definition"]
+
+    return _build_specific_repo_type
+
+
+# --------------------------------------------------------------------------- #
+# Test-level fixtures that will cache the built directory & set up test case  #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def repo_w_trunk_only_dual_version_spt_w_prereleases_angular_commits(
+    build_trunk_only_repo_w_dual_version_spt_w_prereleases: BuildSpecificRepoFn,
+    example_project_git_repo: ExProjectGitRepoFn,
+    example_project_dir: ExProjectDir,
+    change_to_ex_proj_dir: None,
+) -> BuiltRepoResult:
+    repo_name = (
+        repo_w_trunk_only_dual_version_spt_w_prereleases_angular_commits.__name__
+    )
+    commit_type: CommitConvention = repo_name.split("_")[-2]  # type: ignore[assignment]
+
+    return {
+        "definition": build_trunk_only_repo_w_dual_version_spt_w_prereleases(
+            repo_name=repo_name,
+            commit_type=commit_type,
+            dest_dir=example_project_dir,
+        ),
+        "repo": example_project_git_repo(),
+    }
+
+
+@pytest.fixture
+def repo_w_trunk_only_dual_version_spt_w_prereleases_emoji_commits(
+    build_trunk_only_repo_w_dual_version_spt_w_prereleases: BuildSpecificRepoFn,
+    example_project_git_repo: ExProjectGitRepoFn,
+    example_project_dir: ExProjectDir,
+    change_to_ex_proj_dir: None,
+) -> BuiltRepoResult:
+    repo_name = repo_w_trunk_only_dual_version_spt_w_prereleases_emoji_commits.__name__
+    commit_type: CommitConvention = repo_name.split("_")[-2]  # type: ignore[assignment]
+
+    return {
+        "definition": build_trunk_only_repo_w_dual_version_spt_w_prereleases(
+            repo_name=repo_name,
+            commit_type=commit_type,
+            dest_dir=example_project_dir,
+        ),
+        "repo": example_project_git_repo(),
+    }
+
+
+@pytest.fixture
+def repo_w_trunk_only_dual_version_spt_w_prereleases_scipy_commits(
+    build_trunk_only_repo_w_dual_version_spt_w_prereleases: BuildSpecificRepoFn,
+    example_project_git_repo: ExProjectGitRepoFn,
+    example_project_dir: ExProjectDir,
+    change_to_ex_proj_dir: None,
+) -> BuiltRepoResult:
+    repo_name = repo_w_trunk_only_dual_version_spt_w_prereleases_scipy_commits.__name__
+    commit_type: CommitConvention = repo_name.split("_")[-2]  # type: ignore[assignment]
+
+    return {
+        "definition": build_trunk_only_repo_w_dual_version_spt_w_prereleases(
+            repo_name=repo_name,
+            commit_type=commit_type,
+            dest_dir=example_project_dir,
+        ),
+        "repo": example_project_git_repo(),
+    }


### PR DESCRIPTION
## Purpose

- Refactors the version incrementation algorithm to handle prereleases & official releases when supporting more than the latest major release

- Resolves: #861

## Rationale

This change implies that where ever you are releasing from within the repository, the only tags you know about are the ones in your direct history line.  This means that prereleases of older versions can be created which were not possible as documented in #861.  Official releases were possible of older versions but this maintains that implementation.

## How you tested

I added 2 more repo rebuild tests that demonstrate and validate the use of PSR for a dual version support environment of both official releases and prerelease variants of the last major version (after the latest major version has been released).

Note that the rebuild repos will need to demonstrate going back to the latest version and releasing a new release but currently the test infrastructure does not support building a changelog relevant to its git history.  

We also could extend a dual version environment to GitHub Flow and Git Flow strategies but I did not take the additional time to make that implementation as I don't think it added a lot of value.

## How to verify

1. Check out this pr
2. Reset 1 commit
3. Run `pytest --comprehensive`, see failures:
    - `test_trunk_repo_rebuild_dual_version_spt_official_releases_only`
    - `test_trunk_repo_rebuild_dual_version_spt_w_official_n_prereleases`
    - `test_increment_version_no_major_on_zero`
    - `test_increment_version_invalid_operation`
4. Update the repo to this PR head
5. Run `pytest --comprehensive` and see failures are resolved