### PR TITLE
fix: issue vs PR/MR urls

### DIFF
--- a/semantic_release/changelog/context.py
+++ b/semantic_release/changelog/context.py
@@ -31,5 +31,9 @@ def make_changelog_context(
         repo_name=hvcs_client.repo_name,
         repo_owner=hvcs_client.owner,
         history=release_history,
-        filters=(hvcs_client.pull_request_url, hvcs_client.commit_hash_url),
+        filters=(
+            hvcs_client.issue_url,
+            hvcs_client.pull_request_url,
+            hvcs_client.commit_hash_url,
+        ),
     )

--- a/semantic_release/hvcs/_base.py
+++ b/semantic_release/hvcs/_base.py
@@ -154,6 +154,14 @@ class HvcsBase:
         _not_supported(self, "commit_hash_url")
         return ""
 
+    def issue_url(self, issue_number: str) -> str:
+        """
+        Given a number for an issue, return a web URL that links to that issue
+        in the remote VCS.
+        """
+        _not_supported(self, "issue_url")
+        return ""
+
     def pull_request_url(self, pr_number: str) -> str:
         """
         Given a number for a PR/Merge request/equivalent, return a web URL that links

--- a/semantic_release/hvcs/bitbucket.py
+++ b/semantic_release/hvcs/bitbucket.py
@@ -107,6 +107,9 @@ class Bitbucket(HvcsBase):
             f"commits/{commit_hash}"
         )
 
+    def issue_url(self, issue_number: str | int) -> str:
+        return f"https://{self.hvcs_domain}/{self.owner}/{self.repo_name}/issues/{issue_number}"
+
     def pull_request_url(self, pr_number: str | int) -> str:
         return (
             f"https://{self.hvcs_domain}/{self.owner}/{self.repo_name}/"

--- a/semantic_release/hvcs/gitea.py
+++ b/semantic_release/hvcs/gitea.py
@@ -233,5 +233,8 @@ class Gitea(HvcsBase):
     def commit_hash_url(self, commit_hash: str) -> str:
         return f"https://{self.hvcs_domain}/{self.owner}/{self.repo_name}/commit/{commit_hash}"
 
+    def issue_url(self, issue_number: str | int) -> str:
+        return f"https://{self.hvcs_domain}/{self.owner}/{self.repo_name}/issues/{issue_number}"
+
     def pull_request_url(self, pr_number: str | int) -> str:
         return f"https://{self.hvcs_domain}/{self.owner}/{self.repo_name}/pulls/{pr_number}"

--- a/semantic_release/hvcs/github.py
+++ b/semantic_release/hvcs/github.py
@@ -280,5 +280,8 @@ class Github(HvcsBase):
     def commit_hash_url(self, commit_hash: str) -> str:
         return f"https://{self.hvcs_domain}/{self.owner}/{self.repo_name}/commit/{commit_hash}"
 
+    def issue_url(self, issue_number: str | int) -> str:
+        return f"https://{self.hvcs_domain}/{self.owner}/{self.repo_name}/issues/{issue_number}"
+
     def pull_request_url(self, pr_number: str | int) -> str:
-        return f"https://{self.hvcs_domain}/{self.owner}/{self.repo_name}/issues/{pr_number}"
+        return self.issue_url(issue_number=pr_number)

--- a/semantic_release/hvcs/gitlab.py
+++ b/semantic_release/hvcs/gitlab.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import mimetypes
 import os
 from functools import lru_cache
 from urllib.parse import urlsplit
@@ -16,20 +15,6 @@ from semantic_release.hvcs.token_auth import TokenAuth
 from semantic_release.hvcs.util import build_requests_session
 
 log = logging.getLogger(__name__)
-
-# Add a mime type for wheels
-# Fix incorrect entries in the `mimetypes` registry.
-# On Windows, the Python standard library's `mimetypes` reads in
-# mappings from file extension to MIME type from the Windows
-# registry. Other applications can and do write incorrect values
-# to this registry, which causes `mimetypes.guess_type` to return
-# incorrect values, which causes TensorBoard to fail to render on
-# the frontend.
-# This method hard-codes the correct mappings for certain MIME
-# types that are known to be either used by python-semantic-release or
-# problematic in general.
-mimetypes.add_type("application/octet-stream", ".whl")
-mimetypes.add_type("text/markdown", ".md")
 
 
 class Gitlab(HvcsBase):
@@ -160,5 +145,11 @@ class Gitlab(HvcsBase):
     def commit_hash_url(self, commit_hash: str) -> str:
         return f"https://{self.hvcs_domain}/{self.owner}/{self.repo_name}/-/commit/{commit_hash}"
 
+    def issue_url(self, issue_number: str | int) -> str:
+        return f"https://{self.hvcs_domain}/{self.owner}/{self.repo_name}/-/issues/{issue_number}"
+
+    def merge_request_url(self, mr_number: str | int) -> str:
+        return f"https://{self.hvcs_domain}/{self.owner}/{self.repo_name}/-/merge_requests/{mr_number}"
+
     def pull_request_url(self, pr_number: str | int) -> str:
-        return f"https://{self.hvcs_domain}/{self.owner}/{self.repo_name}/-/issues/{pr_number}"
+        return self.merge_request_url(mr_number=pr_number)

--- a/tests/unit/semantic_release/hvcs/test_bitbucket.py
+++ b/tests/unit/semantic_release/hvcs/test_bitbucket.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from unittest import mock
 
@@ -145,25 +147,34 @@ def test_remote_url(
         assert default_bitbucket_client.remote_url(use_token=use_token) == expected
 
 
-def test_commit_hash_url(default_bitbucket_client):
+def test_commit_hash_url(default_bitbucket_client: Bitbucket):
     sha = "244f7e11bcb1e1ce097db61594056bc2a32189a0"
-    assert default_bitbucket_client.commit_hash_url(
-        sha
-    ) == "https://{domain}/{owner}/{repo}/commits/{sha}".format(
+    expected_url = "https://{domain}/{owner}/{repo}/commits/{sha}".format(
         domain=default_bitbucket_client.hvcs_domain,
         owner=default_bitbucket_client.owner,
         repo=default_bitbucket_client.repo_name,
         sha=sha,
     )
+    assert expected_url == default_bitbucket_client.commit_hash_url(sha)
+
+
+@pytest.mark.parametrize("issue_number", (420, "420"))
+def test_issue_url(default_bitbucket_client: Bitbucket, issue_number: int | str):
+    expected_url = "https://{domain}/{owner}/{repo}/issues/{issue_number}".format(
+        domain=default_bitbucket_client.hvcs_domain,
+        owner=default_bitbucket_client.owner,
+        repo=default_bitbucket_client.repo_name,
+        issue_number=issue_number,
+    )
+    assert expected_url == default_bitbucket_client.issue_url(issue_number)
 
 
 @pytest.mark.parametrize("pr_number", (420, "420"))
-def test_pull_request_url(default_bitbucket_client, pr_number):
-    assert default_bitbucket_client.pull_request_url(
-        pr_number=pr_number
-    ) == "https://{domain}/{owner}/{repo}/pull-requests/{pr_number}".format(
+def test_pull_request_url(default_bitbucket_client: Bitbucket, pr_number: int | str):
+    expected_url = "https://{domain}/{owner}/{repo}/pull-requests/{pr_number}".format(
         domain=default_bitbucket_client.hvcs_domain,
         owner=default_bitbucket_client.owner,
         repo=default_bitbucket_client.repo_name,
         pr_number=pr_number,
     )
+    assert expected_url == default_bitbucket_client.pull_request_url(pr_number)

--- a/tests/unit/semantic_release/hvcs/test_gitea.py
+++ b/tests/unit/semantic_release/hvcs/test_gitea.py
@@ -160,16 +160,26 @@ def test_commit_hash_url(default_gitea_client):
     )
 
 
+@pytest.mark.parametrize("issue_number", (420, "420"))
+def test_issue_url(default_gitea_client: Gitea, issue_number: int | str):
+    expected_url = "https://{domain}/{owner}/{repo}/issues/{issue_number}".format(
+        domain=default_gitea_client.hvcs_domain,
+        owner=default_gitea_client.owner,
+        repo=default_gitea_client.repo_name,
+        issue_number=issue_number,
+    )
+    assert expected_url == default_gitea_client.issue_url(issue_number)
+
+
 @pytest.mark.parametrize("pr_number", (420, "420"))
-def test_pull_request_url(default_gitea_client, pr_number):
-    assert default_gitea_client.pull_request_url(
-        pr_number=pr_number
-    ) == "https://{domain}/{owner}/{repo}/pulls/{pr_number}".format(
+def test_pull_request_url(default_gitea_client: Gitea, pr_number: int | str):
+    expected_url = "https://{domain}/{owner}/{repo}/pulls/{pr_number}".format(
         domain=default_gitea_client.hvcs_domain,
         owner=default_gitea_client.owner,
         repo=default_gitea_client.repo_name,
         pr_number=pr_number,
     )
+    assert expected_url == default_gitea_client.pull_request_url(pr_number)
 
 
 def test_asset_upload_url(default_gitea_client):

--- a/tests/unit/semantic_release/hvcs/test_github.py
+++ b/tests/unit/semantic_release/hvcs/test_github.py
@@ -207,16 +207,26 @@ def test_commit_hash_url(default_gh_client):
     )
 
 
+@pytest.mark.parametrize("issue_number", (420, "420"))
+def test_issue_url(default_gh_client: Github, issue_number: str | int):
+    expected_url = "https://{domain}/{owner}/{repo}/issues/{issue_num}".format(
+        domain=default_gh_client.hvcs_domain,
+        owner=default_gh_client.owner,
+        repo=default_gh_client.repo_name,
+        issue_num=issue_number,
+    )
+    assert expected_url == default_gh_client.issue_url(issue_number=issue_number)
+
+
 @pytest.mark.parametrize("pr_number", (420, "420"))
-def test_pull_request_url(default_gh_client, pr_number):
-    assert default_gh_client.pull_request_url(
-        pr_number=pr_number
-    ) == "https://{domain}/{owner}/{repo}/issues/{pr_number}".format(
+def test_pull_request_url(default_gh_client: Github, pr_number: str | int):
+    expected_url = "https://{domain}/{owner}/{repo}/issues/{pr_number}".format(
         domain=default_gh_client.hvcs_domain,
         owner=default_gh_client.owner,
         repo=default_gh_client.repo_name,
         pr_number=pr_number,
     )
+    assert expected_url == default_gh_client.pull_request_url(pr_number=pr_number)
 
 
 ############

--- a/tests/unit/semantic_release/hvcs/test_gitlab.py
+++ b/tests/unit/semantic_release/hvcs/test_gitlab.py
@@ -332,23 +332,26 @@ def test_commit_hash_url(default_gl_client: Gitlab):
     assert expected_url == default_gl_client.commit_hash_url(REF)
 
 
+@pytest.mark.parametrize("issue_number", (420, "420"))
+def test_issue_url(default_gl_client: Gitlab, issue_number: int | str):
+    expected_url = "https://{domain}/{owner}/{repo}/-/issues/{issue_number}".format(
         domain=default_gl_client.hvcs_domain,
         owner=default_gl_client.owner,
         repo=default_gl_client.repo_name,
-        sha=REF,
+        issue_number=issue_number,
     )
+    assert expected_url == default_gl_client.issue_url(issue_number=issue_number)
 
 
 @pytest.mark.parametrize("pr_number", (420, "420"))
-def test_pull_request_url(default_gl_client, pr_number):
-    assert default_gl_client.pull_request_url(
-        pr_number=pr_number
-    ) == "https://{domain}/{owner}/{repo}/-/issues/{pr_number}".format(
+def test_pull_request_url(default_gl_client: Gitlab, pr_number: int | str):
+    expected_url = "https://{domain}/{owner}/{repo}/-/merge_requests/{mr_number}".format(
         domain=default_gl_client.hvcs_domain,
         owner=default_gl_client.owner,
         repo=default_gl_client.repo_name,
-        pr_number=pr_number,
+        mr_number=pr_number,
     )
+    assert expected_url == default_gl_client.pull_request_url(pr_number=pr_number)
 
 
 @pytest.mark.parametrize("tag", (A_GOOD_TAG, A_LOCKED_TAG))


### PR DESCRIPTION
## Purpose

Not all HVCS call Pull Requests the same way as GitHub.  GitHub considers an PR another issue and allows for the same url resolution of PRs as issues.  GitLab on the other hand uses a separate number scheme and url to match Merge Requests as separate than issues.

## Rationale

I corrected the implementation of GitLab to have separate MR and issue url generation.  This meant that a new filter needed to be past to the changelog context and all the other hvcs needed to inherit/override the same issue function.  The unit tests were updated to generate these urls properly across all HVCS's.  

## How I tested

- Must add a test that actually adds a commit that hvcs should apply a url to however our testing does not currently provide this.

## How to Verify
