### PR TITLE
fix(gh-actions-output): fixed trailing newline to match GITHUB_OUTPUT format

### DIFF
--- a/semantic_release/cli/github_actions_output.py
+++ b/semantic_release/cli/github_actions_output.py
@@ -62,7 +62,10 @@ class VersionGitHubActionsOutput:
             "version": str(self.version),
             "tag": self.tag,
         }
-        return "\n".join(f"{key}={value!s}" for key, value in outputs.items())
+
+        return str.join("", [
+            f"{key}={value!s}\n" for key, value in outputs.items()
+        ])
 
     def write_if_possible(self, filename: str | None = None) -> None:
         output_file = filename or os.getenv(self.OUTPUT_ENV_VAR)

--- a/tests/unit/semantic_release/cli/test_github_actions_output.py
+++ b/tests/unit/semantic_release/cli/test_github_actions_output.py
@@ -1,3 +1,8 @@
+from __future__ import annotations
+
+from textwrap import dedent
+from typing import TYPE_CHECKING
+
 import pytest
 
 from semantic_release import Version
@@ -5,62 +10,68 @@ from semantic_release.cli.github_actions_output import VersionGitHubActionsOutpu
 
 from tests.util import actions_output_to_dict
 
+if TYPE_CHECKING:
+    from pathlib import Path
+
 
 @pytest.mark.parametrize("released", (True, False))
-def test_version_github_actions_output_format(released):
-    version = Version.parse("1.2.3")
-    output = VersionGitHubActionsOutput()
-
-    output.version = version
-    output.released = released
-
-    text = output.to_output_text()
-    # fmt: off
-    assert (
-        text == f"released={str(released).lower()}\n"
-                f"version={version!s}\n"
-                f"tag={version.as_tag()}"
+def test_version_github_actions_output_format(released: bool):
+    version_str = "1.2.3"
+    expected_output = dedent(
+        f"""\
+        released={'true' if released else 'false'}
+        version={version_str}
+        tag=v{version_str}
+        """
     )
-    # fmt: on
+    output = VersionGitHubActionsOutput(
+        released=released,
+        version=Version.parse(version_str),
+    )
+
+    # Evaluate (expected -> actual)
+    assert expected_output == output.to_output_text()
 
 
 def test_version_github_actions_output_fails_if_missing_output():
-    version = Version.parse("1.2.3")
-    output = VersionGitHubActionsOutput()
+    output = VersionGitHubActionsOutput(
+        version=Version.parse("1.2.3"),
+    )
 
-    output.version = version
-
+    # Execute with expected failure
     with pytest.raises(ValueError, match="required outputs were not set"):
         output.to_output_text()
 
 
 def test_version_github_actions_output_writes_to_github_output_if_available(
-    monkeypatch, tmp_path
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ):
     mock_output_file = tmp_path / "action.out"
-    version = Version.parse("1.2.3")
-    output = VersionGitHubActionsOutput()
-
-    output.version = version
-    output.released = True
-
+    version_str = "1.2.3"
     monkeypatch.setenv("GITHUB_OUTPUT", str(mock_output_file.resolve()))
+    output = VersionGitHubActionsOutput(
+        version=Version.parse(version_str),
+        released=True,
+    )
+
     output.write_if_possible()
 
     action_outputs = actions_output_to_dict(
         mock_output_file.read_text(encoding="utf-8")
     )
 
-    assert action_outputs["version"] == str(version)
-    assert action_outputs["released"] == "true"
+    # Evaluate (expected -> actual)
+    assert version_str == action_outputs["version"]
+    assert str(True).lower() == action_outputs["released"]
 
 
-def test_version_github_actions_output_no_error_if_not_in_gha(monkeypatch):
-    version = Version.parse("1.2.3")
-    output = VersionGitHubActionsOutput()
-
-    output.version = version
-    output.released = True
+def test_version_github_actions_output_no_error_if_not_in_gha(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    output = VersionGitHubActionsOutput(
+        version=Version.parse("1.2.3"),
+        released=True,
+    )
 
     monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
     output.write_if_possible()


### PR DESCRIPTION
## Purpose

Resolve #884 bug of a missing trailing newline which is expected by GitHub Actions

## Rationale

The bug existed because `str.join()` only inserts a value between elements which means the last element did not receive a newline. 

## How I tested

Refactored the existing tests to more visually define the exact output value that should be placed in the output file. The tests now properly detect when the newline is missing.

## How to verify

```sh
git fetch origin pull/885/head:pr-885

# checkout the PR as a detached HEAD state with only the unit tests
git checkout pr-885~1 --detach

# execute unit-tests 
pytest tests/unit/semantic_release/cli/test_github_actions_output.py

# update to the HEAD of the PR (with fixes)
git merge --ff-only pr-885

# run pytest again to see success
pytest tests/unit/semantic_release/cli/test_github_actions_output.py

# run full suite for verification
pytest
```