### PR TITLE
chore: update ruff cmd & ci execution

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,22 @@ jobs:
           python -m pip install pytest-github-actions-annotate-failures
 
       - name: pytest
-        run: PYTHONHASHSEED=123345 python -m pytest -v tests
+        id: tests
+        run: |
+          python -m pytest              \
+            -vv                         \
+            -nauto                      \
+            --cov=semantic_release      \
+            --cov-context=test          \
+            --cov-report=term-missing   \
+            --cov-fail-under=80         \
+            --junit-xml=tests/reports/pytest-results.xml
+
+      - name: Report | Upload Test Results
+        uses: mikepenz/action-junit-report@v4.2.1
+        if: ${{ always() && steps.tests.outcome != 'skipped' }}
+        with:
+          report_paths: ./tests/reports/*.xml
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
           python -m ruff check . \
             --config pyproject.toml \
             --diff \
-            --show-source \
+            --output-format=full \
             --exit-non-zero-on-fix
 
       - name: mypy

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -37,7 +37,22 @@ jobs:
           python -m pip install pytest-github-actions-annotate-failures
 
       - name: pytest
-        run: PYTHONHASHSEED=123345 python -m pytest -v tests
+        id: tests
+        run: |
+          python -m pytest              \
+            -vv                         \
+            -nauto                      \
+            --cov=semantic_release      \
+            --cov-context=test          \
+            --cov-report=term-missing   \
+            --cov-fail-under=80         \
+            --junit-xml=tests/reports/pytest-results.xml
+
+      - name: Report | Upload Test Results
+        uses: mikepenz/action-junit-report@v4.2.1
+        if: ${{ always() && steps.tests.outcome != 'skipped' }}
+        with:
+          report_paths: ./tests/reports/*.xml
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -60,7 +60,7 @@ jobs:
           python -m ruff check . \
             --config pyproject.toml \
             --diff \
-            --show-source \
+            --output-format=full \
             --exit-non-zero-on-fix
 
       - name: mypy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,18 +83,21 @@ env = [
   "PYTHONHASHSEED = 123456"
 ]
 addopts = [
+  # TO DEBUG in single process, swap auto to 0
   "-nauto",
+  # "-n0",
   "-ra",
   "--diff-symbols",
   "--cache-clear",
-  "--cov=semantic_release",
-  "--cov-context=test",
-  "--cov-report",
-  "html:coverage-html",
-  "--cov-report",
-  "term",
+  # No default coverage - causes problems with debuggers
+  # "--cov=semantic_release",
+  # "--cov-context=test",
+  # "--cov-report=html:coverage-html",
+  # "--cov-report=term-missing",
 ]
-python_files = ["tests/test_*.py", "tests/**/test_*.py"]
+testpaths = [
+  "tests"
+]
 
 [tool.coverage.html]
 show_contexts = true


### PR DESCRIPTION
## Purpose

- Improve defaults of local testing
- resolve deprecation warning from ruff

## Rationale

For local use, the coverage plugin messes up debuggers and slows down the test execution.  This change keeps the coverage metrics around as an enforcement mechanism in the CI but does not force the developer to constantly adjust the test configuration for debugging purposes.  Luckily `xdist` will handle debugging just fine but will be in subprocesses which is a change that is more manageable and obvious rather than the coverage (just doesn't hit a breakpoint ever). 

Also resolved the ruff option deprecation of the `--show-source` option which has been changed to `--output-format=full`.