### PR TITLE
fix(gha): add missing `tag` option to GitHub Action definition

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-# Convert "true"/"false" into command line args
+# Convert "true"/"false" into command line args, returns "" if not defined
 eval_boolean_action_input() {
 	local -r input_name="$1"
 	shift
@@ -12,7 +12,9 @@ eval_boolean_action_input() {
 	shift
 	local -r if_false="$1"
 
-	if [ "$flag_value" = "true" ]; then
+	if [ -z "$flag_value" ]; then
+		echo ""
+	elif [ "$flag_value" = "true" ]; then
 		echo "$if_true"
 	elif [ "$flag_value" = "false" ]; then
 		echo "$if_false"
@@ -42,6 +44,7 @@ export VCS_RELEASE="${INPUT_VCS_RELEASE:="false"}"
 export ARGS=()
 ARGS+=("$(eval_boolean_action_input "prerelease" "$PRERELEASE" "--prerelease" "")") || exit 1
 ARGS+=("$(eval_boolean_action_input "commit" "$COMMIT" "--commit" "--no-commit")") || exit 1
+ARGS+=("$(eval_boolean_action_input "tag" "$INPUT_TAG" "--tag" "--no-tag")") || exit 1
 ARGS+=("$(eval_boolean_action_input "push" "$PUSH" "--push" "--no-push")") || exit 1
 ARGS+=("$(eval_boolean_action_input "changelog" "$CHANGELOG" "--changelog" "--no-changelog")") || exit 1
 ARGS+=("$(eval_boolean_action_input "vcs_release" "$VCS_RELEASE" "--vcs-release" "--no-vcs-release")") || exit 1

--- a/action.yml
+++ b/action.yml
@@ -56,15 +56,22 @@ inputs:
     default: "true"
     description: Whether or not to commit changes locally
 
+  tag:
+    type: string
+    required: false
+    description: |
+      Whether or not to make a local version tag. Defaults are handled
+      by python-semantic-release internal version command.
+
   push:
     type: string
     required: false
     default: "true"
     description: |
       Whether or not to push local commits to the Git repository.
-      Defaults to "true", but when the "commit" input is "false"
-      this will also be set to "false" regardless of the value
-      supplied.
+      Defaults to "true", but when either the "commit" or "tag"
+      input is "false", this push setting will also be set to
+      "false" regardless of the value supplied.
 
   changelog:
     type: string


### PR DESCRIPTION
## Purpose

- Update the GitHub action definitions to include the `--tag` command line option added in `v8.4.0`
- Resolve: #906

## Rationale

First I must add the definition to the `action.yml` file to ensure that users can provide a `tag` directive to their `GitHub Action` definition.  This then translates to a new environment variable that is passed to the `action.sh`.  That variable must be read in order to determine if it should add a true or false command line option to the `semantic-release version` command.  Lastly, I decided to remove all the extra default values from the `action.*` files because they we are maintaining multiple locations where the defaults are set for the project. 
