### PR TITLE
feat: provide limited parent context environment to `build_command`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,6 @@ RUN \
     # Cleanup
     && apt clean -y
 
+ENV PSR_DOCKER_GITHUB_ACTION=true
+
 ENTRYPOINT ["/bin/bash", "-l", "/psr/action.sh"]

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -141,10 +141,34 @@ This setting is discussed in more detail at :ref:`multibranch-releases`
 
 .. _config-build-command:
 
-``build_command (Optional[str])``
-"""""""""""""""""""""""""""""""""
+``build_command``
+"""""""""""""""""
 
-Command to use when building the current project during :ref:`cmd-version`
+**Type:** ``Optional[str]``
+
+Command to use to build the current project during :ref:`cmd-version`.
+
+Python Semantic Release will execute the build command in the OS default
+shell with a subset of environment variables. PSR provides the variable
+``NEW_VERSION`` in the environment with the value of the next determined
+version. The following table summarizes all the environment variables that
+are passed on to the ``build_command`` runtime if they exist in the parent
+process.
+
+========================  ======================================================================
+Variable Name             Description
+========================  ======================================================================
+CI                        Pass-through ``true`` if exists in process env, unset otherwise
+BITBUCKET_CI              ``true`` if Bitbucket CI variables exist in env, unset otherwise
+GITHUB_ACTIONS            Pass-through ``true`` if exists in process env, unset otherwise
+GITEA_ACTIONS             Pass-through ``true`` if exists in process env, unset otherwise
+GITLAB_CI                 Pass-through ``true`` if exists in process env, unset otherwise
+HOME                      Pass-through ``HOME`` of parent process
+NEW_VERSION               Semantically determined next version (ex. ``1.2.3``)
+PATH                      Pass-through ``PATH`` of parent process
+PSR_DOCKER_GITHUB_ACTION  Pass-through ``true`` if exists in process env, unset otherwise
+VIRTUAL_ENV               Pass-through ``VIRTUAL_ENV`` if exists in process env, unset otherwise
+========================  ======================================================================
 
 **Default:** ``None`` (not specified)
 


### PR DESCRIPTION
## Purpose

Enable more sophisticated build command scripts by passing valuable environment variables to subprocess

## Rationale 

In order to give users more context to the environment in which the `build_command` is executed, this PR defines a set of environment variables to pass to the subprocess.  One such action is to pass the newly determined next version value into the environment in case it needs to be used for the build process.  This is helpful for configuring tools like `setuptools_scm` which need the `SETUPTOOLS_SCM_PRETEND_VERSION` defined when a tag doesn't yet exist.  Secondly, it is helpful to pass the CI environment flags so that the build script can adapt accordingly.  

One such item is the need to re-install build dependencies when in the Docker GitHub Action of `python-semantic-release`, you don't want to do this normally so using the environment variable to detect the environment helps define some conditional workflows.

Maybe in the future we can pass most of the environment through but I wanted to prevent passing any token values or other secrets that might exist in the environment.

## How I tested

I build a simple [test project](https://github.com/codejedi365/psr-test-gha) to point at this branch's GitHub action and verify it worked as desired.
