### PR TITLE
fix(gha): fix missing `git_commit_author` definition in action

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -60,6 +60,10 @@ fi
 if ! [ "${INPUT_GIT_COMMITTER_EMAIL:="-"}" = "-" ]; then
 	git config --global user.email "$INPUT_GIT_COMMITTER_EMAIL"
 fi
+if [ "${INPUT_GIT_COMMITTER_NAME:="-"}" != "-" ] && [ "${INPUT_GIT_COMMITTER_EMAIL:="-"}" != "-" ]; then
+	# Must export this value to the environment for PSR to consume the override
+	export GIT_COMMIT_AUTHOR="$INPUT_GIT_COMMITTER_NAME <$INPUT_GIT_COMMITTER_EMAIL>"
+fi
 
 # See https://github.com/actions/runner-images/issues/6775#issuecomment-1409268124
 # and https://github.com/actions/runner-images/issues/6775#issuecomment-1410270956

--- a/action.yml
+++ b/action.yml
@@ -1,40 +1,44 @@
 ---
-name: "Python Semantic Release"
+name: Python Semantic Release
 
-description: "Automatic Semantic Versioning for Python projects"
+description: Automatic Semantic Versioning for Python projects
 
 inputs:
   root_options:
-    description: "Additional options for the main command. Example: -vv --noop"
-    required: false
     default: "-v"
+    required: false
+    description: |
+      Additional options for the main command. Example: -vv --noop
 
   directory:
-    description: "Sub-directory to cd into before running semantic-release"
     default: "."
     required: false
+    description: Sub-directory to cd into before running semantic-release
 
   github_token:
-    description: "GitHub token used to push release notes and new commits/tags"
+    type: string
     required: true
+    description: GitHub token used to push release notes and new commits/tags
 
   git_committer_name:
-    description: "The human name for the “committer” field"
-    default: "github-actions"
+    type: string
     required: false
+    description: The human name for the “committer” field
 
   git_committer_email:
-    description: "The email address for the “committer” field"
-    default: "github-actions@github.com"
+    type: string
     required: false
+    description: The email address for the “committer” field
 
   ssh_public_signing_key:
-    description: "The ssh public key used to sign commits"
+    type: string
     required: false
+    description: The ssh public key used to sign commits
 
   ssh_private_signing_key:
-    description: "The ssh private key used to sign commits"
+    type: string
     required: false
+    description: The ssh private key used to sign commits
 
   # `semantic-release version` command line options
   prerelease:
@@ -108,5 +112,5 @@ outputs:
       The Git tag corresponding to the version output
 
 runs:
-  using: "docker"
-  image: "Dockerfile"
+  using: docker
+  image: Dockerfile


### PR DESCRIPTION
## Purpose

Fix an issue introduced in `9.7.0` where `git_commiter_email` & `git_commiter_name` were not passed on through to PSR when using the GitHub Action

Resolve: #918

## Rationale

The `GIT_COMMIT_AUTHOR` variable was not exported or created in the environment which caused PSR to use the configuration file and/or default semantic-release values.  It was accidentally removed during the refactor as it was not obvious of its use.

## How I tested

Using my test project, [psr-test-gha](https://github.com/codejedi365/psr-test-gha), I was able to successfully release with the configuration defaults when no default is given and then commit with custom provided values.