### PR TITLE
chore: bump build version in pyproject.toml and contributor guide

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -33,13 +33,13 @@ Install this module and the development dependencies
 
 .. code-block:: bash
 
-    pip install -e ".[dev,mypy,test]"
+    pip install -e .[dev,mypy,test]
 
 And if you'd like to build the documentation locally
 
 .. code-block:: bash
 
-    pip install -e ".[docs]"
+    pip install -e .[docs]
     sphinx-autobuild --open-browser docs docs/_build/html
 
 Testing
@@ -93,5 +93,5 @@ package locally:
 
 .. code-block:: bash
 
-    python -m pip install build~=1.2.1
+    pip install -e .[build]
     python -m build .

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -93,5 +93,5 @@ package locally:
 
 .. code-block:: bash
 
-    python -m pip install build~=0.10.0
+    python -m pip install build~=1.2.1
     python -m build .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,9 @@ issues = "https://github.com/python-semantic-release/python-semantic-release/iss
 repository = "http://github.com/python-semantic-release/python-semantic-release.git"
 
 [project.optional-dependencies]
+build = [
+  "build ~= 1.2"
+]
 docs = [
   "Sphinx ~= 6.0",
   "sphinxcontrib-apidoc == 0.5.0",
@@ -368,7 +371,7 @@ ignore_names = ["change_to_ex_proj_dir", "init_example_project"]
 logging_use_named_masks = true
 commit_parser = "angular"
 build_command = """
-    python -m pip install build~=1.2.1
+    python -m pip install -e .[build]
     python -m build .
 """
 major_on_zero = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -368,7 +368,7 @@ ignore_names = ["change_to_ex_proj_dir", "init_example_project"]
 logging_use_named_masks = true
 commit_parser = "angular"
 build_command = """
-    python -m pip install build~=0.10.0
+    python -m pip install build~=1.2.1
     python -m build .
 """
 major_on_zero = true


### PR DESCRIPTION
Hi there,

I was unsure, why the build version is pinned to such an old version. Is there a reason?

What do you think about also adding `build[uv]` and using `python -m build --installer=uv .`?

Ref: https://build.pypa.io/en/stable/#python--m-build---installer