### PR TITLE
fix: enable user configuration of `build_command` env vars

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -139,7 +139,7 @@ This setting is discussed in more detail at :ref:`multibranch-releases`
 
 ----
 
-.. _config-build-command:
+.. _config-build_command:
 
 ``build_command``
 """""""""""""""""
@@ -155,6 +155,9 @@ version. The following table summarizes all the environment variables that
 are passed on to the ``build_command`` runtime if they exist in the parent
 process.
 
+If you would like to pass additional environment variables to your build
+command, see :ref:`config-build_command_env`.
+
 ========================  ======================================================================
 Variable Name             Description
 ========================  ======================================================================
@@ -169,6 +172,37 @@ PATH                      Pass-through ``PATH`` of parent process
 PSR_DOCKER_GITHUB_ACTION  Pass-through ``true`` if exists in process env, unset otherwise
 VIRTUAL_ENV               Pass-through ``VIRTUAL_ENV`` if exists in process env, unset otherwise
 ========================  ======================================================================
+
+**Default:** ``None`` (not specified)
+
+----
+
+.. _config-build_command_env:
+
+``build_command_env``
+"""""""""""""""""""""
+
+**Type:** ``Optional[list[str]]``
+
+List of environment variables to include or pass-through on to the build command that executes
+during :ref:`cmd-version`.
+
+This configuration option allows the user to extend the list of environment variables
+from the table above in :ref:`config-build_command`. The input is a list of strings
+where each individual string handles a single variable definition. There are two formats
+accepted and are detailed in the following table:
+
+==================  ===================================================================
+FORMAT              Description
+==================  ===================================================================
+``VAR_NAME``        Detects value from the PSR process environment, and passes value to
+                    ``build_command`` process
+
+``VAR_NAME=value``  Sets variable name to value inside of ``build_command`` process
+==================  ===================================================================
+
+.. note:: Although variable name capitalization is not required, it is recommended as
+          to be in-line with the POSIX-compliant recommendation for shell variable names.
 
 **Default:** ``None`` (not specified)
 

--- a/semantic_release/cli/commands/version.py
+++ b/semantic_release/cli/commands/version.py
@@ -517,7 +517,7 @@ def version(  # noqa: C901
                     filter(
                         lambda k_v: k_v[1] is not None,  # type: ignore
                         {
-                            "NEW_VERSION": str(new_version),
+                            # Common values
                             "PATH": os.getenv("PATH", ""),
                             "HOME": os.getenv("HOME", None),
                             "VIRTUAL_ENV": os.getenv("VIRTUAL_ENV", None),
@@ -535,6 +535,10 @@ def version(  # noqa: C901
                             "PSR_DOCKER_GITHUB_ACTION": os.getenv(
                                 "PSR_DOCKER_GITHUB_ACTION", None
                             ),
+                            # User defined overrides of environment (from config)
+                            **runtime.build_command_env,
+                            # PSR injected environment variables
+                            "NEW_VERSION": str(new_version),
                         }.items(),
                     )
                 ),

--- a/tests/command_line/test_version.py
+++ b/tests/command_line/test_version.py
@@ -551,7 +551,6 @@ def test_version_prints_current_version_if_no_new_version(
 def test_version_runs_build_command(
     repo_with_git_flow_angular_commits: Repo,
     cli_runner: CliRunner,
-    example_pyproject_toml: Path,
     update_pyproject_toml: UpdatePyprojectTomlFn,
     shell: str,
 ):
@@ -602,6 +601,84 @@ def test_version_runs_build_command(
                 ],
             },
         )
+
+
+def test_version_runs_build_command_w_user_env(
+    repo_with_git_flow_angular_commits: Repo,
+    cli_runner: CliRunner,
+    update_pyproject_toml: UpdatePyprojectTomlFn,
+):
+    # Setup
+    patched_os_environment = {
+        "CI": "true",
+        "PATH": os.getenv("PATH"),
+        "HOME": os.getenv("HOME"),
+        "VIRTUAL_ENV": os.getenv("VIRTUAL_ENV", "./.venv"),
+        # Simulate that all CI's are set
+        "GITHUB_ACTIONS": "true",
+        "GITLAB_CI": "true",
+        "GITEA_ACTIONS": "true",
+        "BITBUCKET_REPO_FULL_NAME": "python-semantic-release/python-semantic-release.git",
+        "PSR_DOCKER_GITHUB_ACTION": "true",
+        # User environment variables (varying passthrough results)
+        "MY_CUSTOM_VARIABLE": "custom",
+        "IGNORED_VARIABLE": "ignore_me",
+        "OVERWRITTEN_VAR": "initial",
+        "SET_AS_EMPTY_VAR": "not_empty",
+    }
+    build_command = "bash -c \"echo 'hello world'\""
+    update_pyproject_toml("tool.semantic_release.build_command", build_command)
+    update_pyproject_toml(
+        "tool.semantic_release.build_command_env",
+        [
+            # Includes arbitrary whitespace which will be removed
+            " MY_CUSTOM_VARIABLE ",             # detect and pass from environment
+            " OVERWRITTEN_VAR = overrided",     # pass hardcoded value which overrides environment
+            " SET_AS_EMPTY_VAR = ",             # keep variable initialized but as empty string
+            " HARDCODED_VAR=hardcoded ",        # pass hardcoded value that doesn't override anything
+            "VAR_W_EQUALS = a-var===condition", # only splits on 1st equals sign
+            "=ignored-invalid-named-var",       # TODO: validation error instead, but currently just ignore
+        ]
+    )
+
+    # Mock out subprocess.run
+    with mock.patch(
+        "subprocess.run", return_value=CompletedProcess(args=(), returncode=0)
+    ) as patched_subprocess_run, mock.patch(
+        "shellingham.detect_shell", return_value=("bash", "/usr/bin/bash")
+    ), mock.patch.dict("os.environ", patched_os_environment, clear=True):
+        # ACT: run & force a new version that will trigger the build command
+        result = cli_runner.invoke(
+            main, [version_subcmd, "--patch", "--no-commit", "--no-tag", "--no-changelog", "--no-push"]
+        )
+
+        patched_subprocess_run.assert_called_once_with(
+            ["bash", "-c", build_command],
+            check=True,
+            env={
+                "NEW_VERSION": "1.2.1",  # injected into environment
+                "CI": patched_os_environment["CI"],
+                "BITBUCKET_CI": "true",  # Converted
+                "GITHUB_ACTIONS": patched_os_environment["GITHUB_ACTIONS"],
+                "GITEA_ACTIONS": patched_os_environment["GITEA_ACTIONS"],
+                "GITLAB_CI": patched_os_environment["GITLAB_CI"],
+                "HOME": patched_os_environment["HOME"],
+                "PATH": patched_os_environment["PATH"],
+                "VIRTUAL_ENV": patched_os_environment["VIRTUAL_ENV"],
+                "PSR_DOCKER_GITHUB_ACTION": patched_os_environment[
+                    "PSR_DOCKER_GITHUB_ACTION"
+                ],
+                "MY_CUSTOM_VARIABLE": patched_os_environment["MY_CUSTOM_VARIABLE"],
+                "OVERWRITTEN_VAR": "overrided",
+                "SET_AS_EMPTY_VAR": "",
+                "HARDCODED_VAR": "hardcoded",
+                # Note that IGNORED_VARIABLE is not here.
+                "VAR_W_EQUALS": "a-var===condition",
+            },
+        )
+
+        # Make sure it did not error internally
+        assert result.exit_code == 0
 
 
 def test_version_skips_build_command_with_skip_build(


### PR DESCRIPTION
## Purpose

- Add the ability for the user to configure the set of environment variables to pass to the build command subprocess
- Resolve #922

## Rationale

Primarily to be good stewards of the provided authentication tokens to PSR, we do not blindly pass the entire parent process environment on to the child process of the build.  However, as #922 mentioned, there is a legitimate need to pass some user-defined environment variables on to the `build_command` child process.  This happy median is to provide a `build_command_env` configuration option that will handle definitions of either hardcoded values or variables desired to be passed along to the subprocess.

## How I tested

Added a separate cli test with a `pyproject.toml` configuration that included all the ways users can provide an environment variable.  We allow direct pass through, and hardcoded variables (empty or not).  I also ran the `psr-test-gha` repo with a build script that would of failed if it didn't receive the proper environment variables and it succeeded.