### PR TITLE
fix: enable `--print-last-released*` when in detached head or non-release branch

### DIFF
--- a/tests/command_line/test_main.py
+++ b/tests/command_line/test_main.py
@@ -85,8 +85,8 @@ def test_not_a_release_branch_detached_head_exit_code(
     cli_cmd = [MAIN_PROG_NAME, VERSION_SUBCMD, "--no-commit"]
     result = cli_runner.invoke(main, cli_cmd[1:])
 
-    # as non-strict, this will return success exit code
-    assert_successful_exit_code(result, cli_cmd)
+    # detached head states should throw an error as release branches cannot be determined
+    assert_exit_code(1, result, cli_cmd)
     assert expected_err_msg in result.stderr
 
 


### PR DESCRIPTION
## Purpose

- Remove unnecessary prerequisite release branch match when irrelevant to use
- Resolve #900

## Rationale

When using PSR to evaluate what the last released tag was, it is irrelevant to impose release branch restrictions on the usage as it doesn't matter what branch you are actually on.  `--print` and `--print-tag` are not included here as those determine the next version value and those do currently rely upon the release branch configuration.

## How I tested

Created test cases that evaluate non-release branch environments in regular or strict mode while using `--print-last-released`, `--print-last-released-tag`. The tests also evaluated the same command when in a detached head state.