### PR TITLE
feat(version-cmd): add toggle of `--no-verify` option to `git commit`

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -702,6 +702,24 @@ When :ref:`config-allow_zero_version` is set to ``false``, this setting is ignor
 
 ----
 
+.. _config-no_git_verify:
+
+``no_git_verify``
+"""""""""""""""""
+
+**Type:** ``bool``
+
+This flag is passed along to ``git`` upon performing a ``git commit`` during :ref:`cmd-version`.
+
+When true, it will bypass any git hooks that are set for the repository when Python Semantic
+Release makes a version commit.  When false, the commit is performed as normal. This option
+has no effect when there are not any git hooks configured nor when the ``--no-commit`` option
+is passed.
+
+**Default:** ``false``
+
+----
+
 .. _config-publish:
 
 ``publish``

--- a/semantic_release/cli/commands/version.py
+++ b/semantic_release/cli/commands/version.py
@@ -330,6 +330,7 @@ def version(  # noqa: C901
     commit_author = runtime.commit_author
     commit_message = runtime.commit_message
     major_on_zero = runtime.major_on_zero
+    no_verify = runtime.no_git_verify
     build_command = runtime.build_command
     opts = runtime.global_cli_options
     gha_output = VersionGitHubActionsOutput()
@@ -613,6 +614,7 @@ def version(  # noqa: C901
         )
 
         command += f"git commit -m '{indented_commit_message}'"
+        command += "--no-verify" if no_verify else ""
 
         noop_report(
             indented(
@@ -628,6 +630,7 @@ def version(  # noqa: C901
             repo.git.commit(
                 m=commit_message.format(version=new_version),
                 date=int(commit_date.timestamp()),
+                no_verify=no_verify,
             )
 
     # Run the tagging after potentially creating a new HEAD commit.

--- a/semantic_release/cli/config.py
+++ b/semantic_release/cli/config.py
@@ -225,6 +225,7 @@ class RawConfig(BaseModel):
     major_on_zero: bool = True
     allow_zero_version: bool = True
     remote: RemoteConfig = RemoteConfig()
+    no_git_verify: bool = False
     tag_format: str = "v{version}"
     publish: PublishConfig = PublishConfig()
     version_toml: Optional[Tuple[str, ...]] = None
@@ -347,6 +348,7 @@ class RuntimeContext:
     major_on_zero: bool
     allow_zero_version: bool
     prerelease: bool
+    no_git_verify: bool
     assets: List[str]
     commit_author: Actor
     commit_message: str
@@ -596,6 +598,7 @@ class RuntimeContext:
             upload_to_vcs_release=raw.publish.upload_to_vcs_release,
             global_cli_options=global_cli_options,
             masker=masker,
+            no_git_verify=raw.no_git_verify,
         )
         # credential masker
         self.apply_log_masking(self.masker)


### PR DESCRIPTION
## Purpose

Provide a flag in the configuration to disable git hooks that are present in the repository that might prevent `semantic-release version` from completing successfully.

## Rationale

This commit adds the configuration option, `no_git_verify`, that toggles the addition of `--no-verify` command line switch on git commit operations that are run with the `version` command.