### PR TITLE
add prelease-token in github action.sh

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -50,6 +50,10 @@ if [ -n "$INPUT_BUILD_METADATA" ]; then
 	ARGS+=("--build-metadata $INPUT_BUILD_METADATA")
 fi
 
+if [ -n "$INPUT_PRERELEASE_TOKEN" ]; then
+	ARGS+=("--prerelease-token $INPUT_PRERELEASE_TOKEN")
+fi
+
 # Change to configured directory
 cd "${INPUT_DIRECTORY}"
 


### PR DESCRIPTION
# Problem
The github action doesn't translate the prelease_token option from the action.yml into the corresponding command line parameter. 

# Fix 
Add the parameter to ARGS in action.sh.