### PR TITLE
feat: extend gitlab to edit a previous release if exists

### DIFF
--- a/semantic_release/hvcs/github.py
+++ b/semantic_release/hvcs/github.py
@@ -304,7 +304,7 @@ class Github(RemoteHvcsBase):
         """
         Edit a release with updated change notes
         https://docs.github.com/rest/reference/repos#update-a-release
-        :param id: ID of release to update
+        :param release_id: ID of release to update
         :param release_notes: The release notes for this version
         :return: The ID of the release that was edited
         """
@@ -329,8 +329,9 @@ class Github(RemoteHvcsBase):
     ) -> int:
         """
         Post release changelog
-        :param version: The version number
+        :param tag: The version number
         :param release_notes: The release notes for this version
+        :param prerelease: Whether or not this release should be created as a prerelease
         :return: The status of the request
         """
         log.info("Creating release for %s", tag)
@@ -427,8 +428,8 @@ class Github(RemoteHvcsBase):
     def upload_dists(self, tag: str, dist_glob: str) -> int:
         """
         Upload distributions to a release
-        :param version: Version to upload for
-        :param path: Path to the dist directory
+        :param tag: Version to upload for
+        :param dist_glob: Path to the dist directory
         :return: The number of distributions successfully uploaded
         """
         # Find the release corresponding to this version

--- a/semantic_release/hvcs/gitlab.py
+++ b/semantic_release/hvcs/gitlab.py
@@ -100,7 +100,7 @@ class Gitlab(RemoteHvcsBase):
         # ref: https://docs.gitlab.com/ee/api/releases/index.html#create-a-release
         client.projects.get(self.owner + "/" + self.repo_name).releases.create(
             {
-                "name": "Release " + tag,
+                "name": tag,
                 "tag_name": tag,
                 "tag_message": tag,
                 "description": release_notes,

--- a/semantic_release/hvcs/gitlab.py
+++ b/semantic_release/hvcs/gitlab.py
@@ -13,6 +13,7 @@ from urllib3.util.url import Url, parse_url
 
 from semantic_release.helpers import logged_function
 from semantic_release.hvcs.remote_hvcs_base import RemoteHvcsBase
+from semantic_release.hvcs.util import suppress_not_found
 
 if TYPE_CHECKING:
     from typing import Any, Callable
@@ -107,6 +108,22 @@ class Gitlab(RemoteHvcsBase):
         log.info("Successfully created release for %s", tag)
         return tag
 
+    @logged_function(log)
+    @suppress_not_found
+    def get_release_id_by_tag(self, tag: str) -> int | None:
+        """
+        Get a release by its tag name
+        https://docs.github.com/rest/reference/repos#get-a-release-by-tag-name
+        :param tag: Tag to get release for
+        :return: ID of release, if found, else None
+        """
+        client = gitlab.Gitlab(self.hvcs_domain.url, private_token=self.token)
+        client.auth()
+        proj_release = client.projects.get(self.owner + "/" + self.repo_name).releases.get(
+            tag
+        )
+        return proj_release.asdict().get("commit.id")
+
     # TODO: make str types accepted here
     @logged_function(log)
     def edit_release_notes(  # type: ignore[override]
@@ -141,7 +158,15 @@ class Gitlab(RemoteHvcsBase):
                 self.owner,
                 self.repo_name,
             )
-            return self.edit_release_notes(release_id=tag, release_notes=release_notes)
+        release_commit_id = self.get_release_id_by_tag(tag)
+        if release_commit_id is None:
+            raise ValueError(
+                f"release commit id for tag {tag} not found, and could not be created"
+            )
+
+        log.debug("Found existing release commit %s, updating", release_commit_id)
+        # If this errors we let it die
+        return self.edit_release_notes(release_id=tag, release_notes=release_notes)
 
     def remote_url(self, use_token: bool = True) -> str:
         """Get the remote url including the token for authentication if requested"""

--- a/semantic_release/hvcs/gitlab.py
+++ b/semantic_release/hvcs/gitlab.py
@@ -102,6 +102,7 @@ class Gitlab(RemoteHvcsBase):
             {
                 "name": "Release " + tag,
                 "tag_name": tag,
+                "tag_message": tag,
                 "description": release_notes,
             }
         )


### PR DESCRIPTION
## Purpose

- Improve Gitlab interface implementation to handle previously defined release & update it
- Improve overall unit testing for HVCS

## Rationale

Brings GitLab more in line with the features of GitHub to be able to edit a previous release's notes via the `changelog` subcommand.

I also found that with the switch to using `example.com` as the domain there were more errors in the test suite as I would receive a 404 that would cause testing to fail.  Clearly this means we were actually touching the real gitlab so I mocked out those appropriately.

## How I tested

I tested manually with a project access token on my local machine with a gitlab project. I first ran the pipeline to create a release normally and then used `semantic-release changelog --post-to-release-tag v1.0.0` to update the release notes with a new template. 

Closes: #727