### PR TITLE
feat(gha): configure ssh signed tags in GitHub Action

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -103,6 +103,7 @@ if [[ -n "$INPUT_SSH_PUBLIC_SIGNING_KEY" && -n "$INPUT_SSH_PRIVATE_SIGNING_KEY" 
 	git config --global gpg.ssh.allowedSignersFile ~/.ssh/allowed_signers
 	git config --global user.signingKey ~/.ssh/signing_key
 	git config --global commit.gpgsign true
+	git config --global tag.gpgsign true
 fi
 
 # Copy inputs into correctly-named environment variables


### PR DESCRIPTION
## Purpose

- Applies digital signatures to tags created by the PSR GitHub Action
- Resolves: #936

## Rationale

We already configure provided SSH keys for signing the commits that are written by PSR in the GitHub Action but it was not applied to the tag's as the configuration setting was missing.  This PR updates the configuration to apply the signature to any tags created within PSR's GitHub Action (Docker).

## How I tested

User tested in their environment when modifying their action to point at this PR's base branch. Confirmed in issue.