### PR TITLE
fix(commit_parser): strip DOS carriage-returns in commits

### DIFF
--- a/semantic_release/commit_parser/token.py
+++ b/semantic_release/commit_parser/token.py
@@ -21,7 +21,8 @@ class ParsedCommit(NamedTuple):
     @property
     def message(self) -> str:
         m = self.commit.message
-        return m.decode("utf-8") if isinstance(m, bytes) else m
+        message_str = m.decode("utf-8") if isinstance(m, bytes) else m
+        return message_str.replace("\r", "")
 
     @property
     def hexsha(self) -> str:
@@ -39,7 +40,8 @@ class ParseError(NamedTuple):
     @property
     def message(self) -> str:
         m = self.commit.message
-        return m.decode("utf-8") if isinstance(m, bytes) else m
+        message_str = m.decode("utf-8") if isinstance(m, bytes) else m
+        return message_str.replace("\r", "")
 
     @property
     def hexsha(self) -> str:


### PR DESCRIPTION
The default template can result in mixed (UNIX / DOS style) carriage returns in the generated changelog. Use a string replace in the commit parser to strip the DOS CRs ("\r"). While it's possible to do the replacement in the template, IMO, this is the better / correct way to fix it.

I checked, and seems like maybe it's only needed when we're _not_ doing a byte decode (so the case where `m` is a raw string)? I can add it back to both if you'd like, though.

Fixes #955
Note: this may result in some diffs in generated changelogs.

See also #952 

I'm happy to adjust existing tests in a way that would catch this and / or add a new test if someone can give me a general pointer on the best way / best place to do this. Also feel free to suggest a terser or more idiomatic way to do this.