### PR TITLE
chore: update pre-commit hooks

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -73,7 +73,6 @@ jobs:
       - name: ruff
         run: |
           python -m ruff check . \
-            --config pyproject.toml \
             --diff \
             --output-format=full \
             --exit-non-zero-on-fix

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,15 +13,13 @@ repos:
 
   # Security & credential scanning/alerting
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: debug-statements
       - id: detect-aws-credentials
         args: ["--allow-missing-credentials"]
       - id: detect-private-key
       - id: check-builtin-literals
-      - id: check-executables-have-shebangs
-      - id: check-shebang-scripts-are-executable
       - id: check-yaml
       - id: check-toml
       - id: check-case-conflict
@@ -31,16 +29,6 @@ repos:
       - id: mixed-line-ending
       - id: check-ast
 
-  # Formatters that may modify source files automatically
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    # Keep old ruff formatting rules until other merge requests are completed
-    rev: v0.1.11
-    hooks:
-      - id: ruff-format
-        name: ruff (format)
-        args: ["."]
-        pass_filenames: false
-
   - repo: https://github.com/adamchainz/blacken-docs
     rev: 1.16.0
     hooks:
@@ -48,14 +36,14 @@ repos:
         additional_dependencies: ["black==23.10.1"]
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.1
+    rev: v3.16.0
     hooks:
       - id: pyupgrade
         args: ["--py38-plus", "--keep-runtime-typing"]
 
   # Linters and validation
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.2
+    rev: v0.4.9
     hooks:
       - id: ruff
         name: ruff (lint)
@@ -63,15 +51,14 @@ repos:
           - "--fix"
           - "--exit-non-zero-on-fix"
           - "--statistics"
-          - "--output-format=text"
-          - "."
-        pass_filenames: false
+          - "--output-format=full"
+      - id: ruff-format
+        name: ruff (format)
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.9.0"
+    rev: "v1.10.0"
     hooks:
       - id: mypy
-        args: ["--config-file", "pyproject.toml"]
         additional_dependencies:
           - "pydantic>=2,<3"
           - "types-requests"

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -107,7 +107,7 @@ If a setting is not provided, than PSR will fill in the value with the default v
 Python Semantic Release expects a root level key to start the configuration definition. Make
 sure to use the correct root key dependending on the configuration format you are using.
 
-.. note:: If you are using ``pyproject.toml``, this heading should include the `tool`` prefix
+.. note:: If you are using ``pyproject.toml``, this heading should include the ``tool`` prefix
           as specified within PEP 517, resulting in ``[tool.semantic_release]``.
 
 .. note:: If you are using a ``releaserc.toml``, use ``[semantic_release]`` as the root key

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -282,7 +282,6 @@ ignore = [
 ]
 
 external = ["V"]
-ignore-init-module-imports = true
 task-tags = ["NOTE", "TODO", "FIXME", "XXX"]
 
 [tool.ruff.format]

--- a/semantic_release/cli/commands/publish.py
+++ b/semantic_release/cli/commands/publish.py
@@ -63,4 +63,4 @@ def publish(cli_ctx: CliContextObj, tag: str = "latest") -> None:
 
     log.info("Uploading distributions to release")
     for pattern in dist_glob_patterns:
-        hvcs_client.upload_dists(tag=tag, dist_glob=pattern)
+        hvcs_client.upload_dists(tag=tag, dist_glob=pattern)  # type: ignore[attr-defined]

--- a/semantic_release/cli/config.py
+++ b/semantic_release/cli/config.py
@@ -558,7 +558,7 @@ class RuntimeContext:
             # with our forced empty value at the end which can be dropped
             parts = [*env_var_def.split("=", 1), ""]
             # removes any odd spacing around =, and extracts name=value
-            name, env_val = [part.strip() for part in parts[:2]]
+            name, env_val = (part.strip() for part in parts[:2])
 
             if not name:
                 # Skip when invalid format (ex. starting with = and no name)


### PR DESCRIPTION
Note: the current `ruff` pre-commit checks check `.`, however, there are multiple existing errors. Maybe it would make sense to switch `ruff` to run on changed files only unless `--all-files` is passed? That would be gentler, especially if we're not requiring all these checks to pass (that said, #958 has some misc fixes that resolve _some_ of the outstanding flagged and non-ignored issues).
 
- Update pre-commit hooks
- Switch away from deprecated flag to `ruff`
- Resolve two minor pre-commit hook findings

Note: I still see the following finding from `mypy`:
```
semantic_release/cli/commands/publish.py: note: In function "publish":
semantic_release/cli/commands/publish.py:66:9: error: "HvcsBase" has no
attribute "upload_dists"  [attr-defined]
            hvcs_client.upload_dists(tag=tag, dist_glob=pattern)
            ^~~~~~~~~~~~~~~~~~~~~~~~
Found 1 error in 1 file (checked 49 source files)
```
Maybe an inheritance issue with it being in `remote_hvcs_base.py` vs `_base.py`?

There is also some commented out code that ruff is flagging - I can remove in another PR if you'd like.