### PR TITLE
chore: re-enable ruff warnings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,6 @@ jobs:
         run: |
           python -m ruff check . \
             --config pyproject.toml \
-            --diff \
             --output-format=full \
             --exit-non-zero-on-fix
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -73,7 +73,6 @@ jobs:
       - name: ruff
         run: |
           python -m ruff check . \
-            --diff \
             --output-format=full \
             --exit-non-zero-on-fix
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,6 +222,8 @@ ignore = [
   "DTZ",
   # flake8-errmsg
   "EM",
+  # Some todos and some examples; leave this disabled for now
+  "ERA001",
   # don't compare types, use isinstance()
   # sometimes using type(x) == y is deliberately chosen to exclude
   # subclasses

--- a/semantic_release/cli/commands/cli_context.py
+++ b/semantic_release/cli/commands/cli_context.py
@@ -58,7 +58,7 @@ class CliContextObj:
 
         try:
             if was_conf_file_user_provided and not conf_file_exists:
-                raise FileNotFoundError(
+                raise FileNotFoundError(  # noqa: TRY301
                     f"File {self.global_opts.config_file} does not exist"
                 )
 

--- a/semantic_release/cli/commands/version.py
+++ b/semantic_release/cli/commands/version.py
@@ -551,7 +551,7 @@ def version(  # noqa: C901
                 check=True,
                 env=dict(
                     filter(
-                        lambda k_v: k_v[1] is not None,  # type: ignore
+                        lambda k_v: k_v[1] is not None,  # type: ignore # noqa: PGH003
                         {
                             # Common values
                             "PATH": os.getenv("PATH", ""),

--- a/semantic_release/cli/config.py
+++ b/semantic_release/cli/config.py
@@ -145,9 +145,12 @@ class RemoteConfig(BaseModel):
     @model_validator(mode="after")
     def set_default_token(self) -> Self:
         # Set the default token name for the given VCS when no user input is given
-        if not self.token and self.type in _known_hvcs:
-            if env_token := self._get_default_token():
-                self.token = env_token
+        if self.token:
+            return self
+        if self.type not in _known_hvcs:
+            return self
+        if env_token := self._get_default_token():
+            self.token = env_token
         return self
 
     def _get_default_token(self) -> str | None:
@@ -406,7 +409,7 @@ class RuntimeContext:
         return masker
 
     @classmethod
-    def from_raw_config(
+    def from_raw_config(  # noqa: C901
         cls, raw: RawConfig, global_cli_options: GlobalCommandLineOptions
     ) -> RuntimeContext:
         ##

--- a/semantic_release/commit_parser/_base.py
+++ b/semantic_release/commit_parser/_base.py
@@ -77,7 +77,7 @@ class CommitParser(ABC, Generic[_TT, _OPTS]):
     # @staticmethod
     # @abstractmethod
     def get_default_options(self) -> _OPTS:
-        return self.parser_options()  # type: ignore
+        return self.parser_options()  # type: ignore # noqa: PGH003
 
     @abstractmethod
     def parse(self, commit: Commit) -> _TT: ...

--- a/semantic_release/hvcs/bitbucket.py
+++ b/semantic_release/hvcs/bitbucket.py
@@ -59,7 +59,7 @@ class Bitbucket(RemoteHvcsBase):
         hvcs_api_domain: str | None = None,
         token: str | None = None,
         allow_insecure: bool = False,
-        **kwargs: Any,
+        **kwargs: Any,  # noqa: ARG002
     ) -> None:
         super().__init__(remote_url)
         self.token = token

--- a/semantic_release/hvcs/gitea.py
+++ b/semantic_release/hvcs/gitea.py
@@ -43,7 +43,7 @@ class Gitea(RemoteHvcsBase):
         hvcs_domain: str | None = None,
         token: str | None = None,
         allow_insecure: bool = False,
-        **kwargs: Any,
+        **_kwargs: Any,
     ) -> None:
         super().__init__(remote_url)
         self.token = token

--- a/semantic_release/hvcs/github.py
+++ b/semantic_release/hvcs/github.py
@@ -89,7 +89,7 @@ class Github(RemoteHvcsBase):
         hvcs_api_domain: str | None = None,
         token: str | None = None,
         allow_insecure: bool = False,
-        **kwargs: Any,
+        **_kwargs: Any,
     ) -> None:
         super().__init__(remote_url)
         self.token = token

--- a/semantic_release/hvcs/gitlab.py
+++ b/semantic_release/hvcs/gitlab.py
@@ -48,7 +48,7 @@ class Gitlab(RemoteHvcsBase):
         hvcs_domain: str | None = None,
         token: str | None = None,
         allow_insecure: bool = False,
-        **kwargs: Any,
+        **_kwargs: Any,
     ) -> None:
         super().__init__(remote_url)
         self.token = token

--- a/semantic_release/hvcs/remote_hvcs_base.py
+++ b/semantic_release/hvcs/remote_hvcs_base.py
@@ -34,7 +34,7 @@ class RemoteHvcsBase(HvcsBase, metaclass=ABCMeta):
 
     DEFAULT_ENV_TOKEN_NAME = "HVCS_TOKEN"  # noqa: S105
 
-    def __init__(self, remote_url: str, *args: Any, **kwargs: Any) -> None:
+    def __init__(self, remote_url: str, *_args: Any, **_kwargs: Any) -> None:
         super().__init__(remote_url)
         self._hvcs_domain: Url | None = None
         self._api_url: Url | None = None

--- a/semantic_release/version/algorithm.py
+++ b/semantic_release/version/algorithm.py
@@ -431,7 +431,7 @@ def next_version(
     )
     level_bump = max(parsed_levels, default=LevelBump.NO_RELEASE)
     log.info("The type of the next release release is: %s", level_bump)
-    if level_bump is LevelBump.NO_RELEASE:
+    if level_bump is LevelBump.NO_RELEASE:  # noqa: SIM102
         if latest_version.major != 0 or allow_zero_version:
             log.info("No release will be made")
             return latest_version

--- a/tests/command_line/conftest.py
+++ b/tests/command_line/conftest.py
@@ -9,7 +9,7 @@ import pytest
 from click.testing import CliRunner
 from requests_mock import ANY
 
-from semantic_release.cli import config as CliConfigModule
+from semantic_release.cli import config as cli_config_module
 from semantic_release.cli.config import (
     GlobalCommandLineOptions,
     RawConfig,
@@ -57,7 +57,7 @@ def mocked_git_push(monkeypatch: MonkeyPatch) -> MagicMock:
     """Mock the `Repo.git.push()` method in `semantic_release.cli.main`."""
     mocked_push = MagicMock()
     cls = prepare_mocked_git_command_wrapper_type(push=mocked_push)
-    monkeypatch.setattr(CliConfigModule.Repo, "GitCommandWrapperType", cls)
+    monkeypatch.setattr(cli_config_module.Repo, "GitCommandWrapperType", cls)
     return mocked_push
 
 

--- a/tests/command_line/test_changelog.py
+++ b/tests/command_line/test_changelog.py
@@ -60,7 +60,7 @@ if TYPE_CHECKING:
     from tests.fixtures.example_project import ExProjectDir, UseReleaseNotesTemplateFn
 
 
-changelog_subcmd = changelog.name or changelog.__name__  # type: ignore
+changelog_subcmd = changelog.name or changelog.__name__  # type: ignore # noqa: PGH003
 
 
 @pytest.mark.parametrize(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING
 
 import pytest
-from git import Commit
+from git import Commit, Repo
 
 from tests.fixtures import *
 from tests.util import remove_dir_tree
@@ -57,7 +57,7 @@ def netrc_file(
     exception = None
     try:
         yield _netrc_file
-    except Exception as err:
+    except Exception as err:  # noqa: BLE001
         exception = err
     finally:
         for context_manager in entered_context_managers:

--- a/tests/unit/semantic_release/hvcs/test_gitlab.py
+++ b/tests/unit/semantic_release/hvcs/test_gitlab.py
@@ -609,7 +609,7 @@ def test_create_or_update_release_when_create_fails_and_update_fails(
     )
 
     # Execute in mocked environment expecting a GitlabUpdateError to be raised
-    with create_release_patch, edit_release_notes_patch, get_release_by_id_patch:
+    with create_release_patch, edit_release_notes_patch, get_release_by_id_patch:  # noqa: SIM117
         with pytest.raises(gitlab.GitlabUpdateError):
             default_gl_client.create_or_update_release(
                 A_GOOD_TAG, RELEASE_NOTES, prerelease

--- a/tests/util.py
+++ b/tests/util.py
@@ -12,7 +12,7 @@ from pydantic.dataclasses import dataclass
 
 from semantic_release.changelog.context import make_changelog_context
 from semantic_release.changelog.release_history import ReleaseHistory
-from semantic_release.cli import config as cliConfigModule
+from semantic_release.cli import config as cli_config_module
 from semantic_release.commit_parser._base import CommitParser, ParserOptions
 from semantic_release.commit_parser.token import ParsedCommit, ParseResult
 from semantic_release.enums import LevelBump
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
 
     _R = TypeVar("_R")
 
-    GitCommandWrapperType: TypeAlias = cliConfigModule.Repo.GitCommandWrapperType
+    GitCommandWrapperType: TypeAlias = cli_config_module.Repo.GitCommandWrapperType
 
 
 def copy_dir_tree(src_dir: Path | str, dst_dir: Path | str) -> None:
@@ -162,7 +162,7 @@ def prepare_mocked_git_command_wrapper_type(
     >>> mocked_push.assert_called_once()
     """
 
-    class MockGitCommandWrapperType(cliConfigModule.Repo.GitCommandWrapperType):
+    class MockGitCommandWrapperType(cli_config_module.Repo.GitCommandWrapperType):
         def __getattr__(self, name: str) -> Any:
             try:
                 return object.__getattribute__(self, f"mocked_{name}")


### PR DESCRIPTION
Having the `--diff` flag in `ruff check` seems to suppress failures from happening in CI. Remove the `--diff` flag, and then ignore or adjust to resolve the remaining `ruff` failures. This will help prevent new ruff errors from going unnoticed and getting checked in, at the expense of a little bit of clutter in the code.

Note: this can be merged with the two atomic commits, or squashed as one.

We should probably do this after #957 goes in (may require a little conflict resolution on one file)