### PR TITLE
feat(parser-emoji): ability to define other emoji

### DIFF
--- a/docs/commit-parsing.rst
+++ b/docs/commit-parsing.rst
@@ -116,6 +116,11 @@ The default configuration options for
         ":robot:",
         ":green_apple:",
     ]
+    other_tags = [
+        ":pencil:",
+        ":construction_worker:",
+        ":recycle:",
+    ]
 
 .. _commit-parser-scipy:
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -657,6 +657,9 @@ the expections from ``commit_parser`` value to default options value.
                                  ":apple:", ":penguin:", ":checkered_flag:", ":robot:",
                                  ":green_apple:"
                              ]
+                             other_tags = [
+                                 ":pencil:", ":construction_worker:", ":recycle:"
+                             ]
 
 ``"scipy"``         ->   .. code-block:: toml
 

--- a/semantic_release/commit_parser/emoji.py
+++ b/semantic_release/commit_parser/emoji.py
@@ -41,6 +41,11 @@ class EmojiParserOptions(ParserOptions):
         ":robot:",
         ":green_apple:",
     )
+    other_tags: Tuple[str, ...] = (
+        ":pencil:",
+        ":construction_worker:",
+        ":recycle:",
+    )
     default_bump_level: LevelBump = LevelBump.NO_RELEASE
 
 
@@ -66,7 +71,7 @@ class EmojiCommitParser(CommitParser[ParseResult, EmojiParserOptions]):
 
     def parse(self, commit: Commit) -> ParseResult:
         all_emojis = (
-            self.options.major_tags + self.options.minor_tags + self.options.patch_tags
+            self.options.major_tags + self.options.minor_tags + self.options.patch_tags + self.options.other_tags
         )
 
         message = str(commit.message)

--- a/tests/unit/semantic_release/commit_parser/test_emoji.py
+++ b/tests/unit/semantic_release/commit_parser/test_emoji.py
@@ -40,12 +40,20 @@ if TYPE_CHECKING:
             [":bug: Fixing a bug", "The bug is finally gone!"],
             [],
         ),
-        # No release
+        # No release with specified emoji
         (
             ":pencil: Documentation changes",
             LevelBump.NO_RELEASE,
-            "Other",
+            ":pencil:",
             [":pencil: Documentation changes"],
+            [],
+        ),
+        # No release with random emoji
+        (
+            ":construction: Work in progress",
+            LevelBump.NO_RELEASE,
+            "Other",
+            [":construction: Work in progress"],
             [],
         ),
         # Multiple emojis


### PR DESCRIPTION
I didn't like how using emojis that didn't trigger a release would dump them all together in a generic "Other" category in release notes. 

This simply lets you define `other_emoji` so they appear under their own header. 

Side note: is there a reason the emoji id (like `:construction_worker:`) is used instead of the actual emoji (like 👷) in the default configuration? In my personal configurations I just use the actual emojis and it seems to work fine and I like that it renders the emoji in my IDE. 