### PR TITLE
chore: switch to ruff doc formatting and add ignore types

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,12 +29,6 @@ repos:
       - id: mixed-line-ending
       - id: check-ast
 
-  - repo: https://github.com/adamchainz/blacken-docs
-    rev: 1.16.0
-    hooks:
-      - id: blacken-docs
-        additional_dependencies: ["black==23.10.1"]
-
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.16.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -287,9 +287,10 @@ external = ["V"]
 task-tags = ["NOTE", "TODO", "FIXME", "XXX"]
 
 [tool.ruff.format]
-quote-style = "double"
+docstring-code-format = true
 indent-style = "space"
 line-ending = "lf"
+quote-style = "double"
 
 [tool.ruff.lint.per-file-ignores]
 # Imported but unused

--- a/semantic_release/cli/commands/version.py
+++ b/semantic_release/cli/commands/version.py
@@ -551,7 +551,7 @@ def version(  # noqa: C901
                 check=True,
                 env=dict(
                     filter(
-                        lambda k_v: k_v[1] is not None,  # type: ignore # noqa: PGH003
+                        lambda k_v: k_v[1] is not None,  # type: ignore[arg-type] # noqa: PGH003
                         {
                             # Common values
                             "PATH": os.getenv("PATH", ""),

--- a/semantic_release/commit_parser/_base.py
+++ b/semantic_release/commit_parser/_base.py
@@ -22,6 +22,7 @@ class ParserOptions(dict):
 
     >>> class MyCommitParser(AbstractCommitParser):
     ...     parser_options = MyParserOptions
+    ...
     ...     def parse(self, Commit):
     ...         print(self.options.prefix)
     ...         ...
@@ -77,7 +78,7 @@ class CommitParser(ABC, Generic[_TT, _OPTS]):
     # @staticmethod
     # @abstractmethod
     def get_default_options(self) -> _OPTS:
-        return self.parser_options()  # type: ignore # noqa: PGH003
+        return self.parser_options()  # type: ignore[return-value] # noqa: PGH003
 
     @abstractmethod
     def parse(self, commit: Commit) -> _TT: ...

--- a/semantic_release/commit_parser/scipy.py
+++ b/semantic_release/commit_parser/scipy.py
@@ -25,7 +25,16 @@ from the broken behavior to the new behavior. It will be added to the
 
 Supported Tags::
 
-    API, DEP, ENH, REV, BUG, MAINT, BENCH, BLD,
+    (
+        API,
+        DEP,
+        ENH,
+        REV,
+        BUG,
+        MAINT,
+        BENCH,
+        BLD,
+    )
     DEV, DOC, STY, TST, REL, FEAT, TEST
 
 Supported Changelog Sections::

--- a/tests/command_line/test_changelog.py
+++ b/tests/command_line/test_changelog.py
@@ -60,7 +60,7 @@ if TYPE_CHECKING:
     from tests.fixtures.example_project import ExProjectDir, UseReleaseNotesTemplateFn
 
 
-changelog_subcmd = changelog.name or changelog.__name__  # type: ignore # noqa: PGH003
+changelog_subcmd = changelog.name or changelog.__name__  # type: ignore[attr-defined] # noqa: PGH003
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Here's another small one; let me know what you think:

- Remove `blacken-docs` in pre-commit config.
- Set `docstring-code-format` to `true` for ruff.
- Resolve `blanket-type-ignore` pre-commit check by adding types to mypy type ignores

Basically, [this](https://github.com/astral-sh/ruff/pull/8854) replaces what `blacken-docs` would have done.

Note: if you don't care about the type ignores, I can remove that check (`python-check-blanket-type-ignore` from https://github.com/pre-commit/pygrep-hooks, with or without reverting those annotations). Note: that check will run for users who have pre-commit setup / installed, but not for other users, so it's not enforced in CI, which is probably part of how these 3 ended up here.