### PR TITLE
chore: set `ignore-without-code` for mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,7 +65,6 @@ repos:
     hooks:
       # - id: python-use-type-annotations
       - id: python-check-blanket-noqa
-      - id: python-check-blanket-type-ignore
       - id: python-check-mock-methods
       - id: python-no-eval
       - id: python-no-log-warn

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -237,6 +237,8 @@ ignore = [
   "INP001",
   # Errors should end with "Error"
   "N818",
+  # mypy prevents blanket-type-ignore
+  "PGH003",
   # Fixtures that do not return a value need an underscore prefix.  The rule
   # does not handle generators.
   "PT004",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,6 +156,7 @@ show_error_context = true
 pretty = true
 error_summary = true
 follow_imports = "normal"
+enable_error_code = ["ignore-without-code"]
 ignore_missing_imports = true   # gitpython is very dynamic
 disallow_untyped_calls = true
 # warn_return_any = true

--- a/semantic_release/cli/commands/version.py
+++ b/semantic_release/cli/commands/version.py
@@ -551,7 +551,7 @@ def version(  # noqa: C901
                 check=True,
                 env=dict(
                     filter(
-                        lambda k_v: k_v[1] is not None,  # type: ignore[arg-type] # noqa: PGH003
+                        lambda k_v: k_v[1] is not None,  # type: ignore[arg-type]
                         {
                             # Common values
                             "PATH": os.getenv("PATH", ""),

--- a/semantic_release/commit_parser/_base.py
+++ b/semantic_release/commit_parser/_base.py
@@ -78,7 +78,7 @@ class CommitParser(ABC, Generic[_TT, _OPTS]):
     # @staticmethod
     # @abstractmethod
     def get_default_options(self) -> _OPTS:
-        return self.parser_options()  # type: ignore[return-value] # noqa: PGH003
+        return self.parser_options()  # type: ignore[return-value]
 
     @abstractmethod
     def parse(self, commit: Commit) -> _TT: ...

--- a/tests/command_line/test_changelog.py
+++ b/tests/command_line/test_changelog.py
@@ -60,7 +60,7 @@ if TYPE_CHECKING:
     from tests.fixtures.example_project import ExProjectDir, UseReleaseNotesTemplateFn
 
 
-changelog_subcmd = changelog.name or changelog.__name__  # type: ignore[attr-defined] # noqa: PGH003
+changelog_subcmd = changelog.name or changelog.__name__  # type: ignore[attr-defined]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
As discussed in https://github.com/python-semantic-release/python-semantic-release/pull/964#issuecomment-2208080852, this will check for explicit error types in type ignores.

- Set `ignore-without-code` in mypy settings 

    - https://mypy.readthedocs.io/en/stable/error_codes.html#requiring-error-codes
    - https://docs.astral.sh/ruff/rules/blanket-type-ignore/

- Remove `pygrep` rule in pre-commit config to avoid flagging it twice locally (since there's a mypy pre-commit config already)

Tested locally that this should flag the case where the error type is not set.