### PR TITLE
perf: improve git history processing for changelog generation

### DIFF
--- a/semantic_release/changelog/release_history.py
+++ b/semantic_release/changelog/release_history.py
@@ -61,7 +61,7 @@ class ReleaseHistory:
         is_commit_released = False
         the_version: Version | None = None
 
-        for commit in repo.iter_commits():
+        for commit in repo.iter_commits("HEAD", topo_order=True):
             # mypy will be happy if we make this an explicit string
             commit_message = str(commit.message)
 

--- a/semantic_release/changelog/release_history.py
+++ b/semantic_release/changelog/release_history.py
@@ -41,6 +41,13 @@ class ReleaseHistory:
         unreleased: dict[str, list[ParseResult]] = defaultdict(list)
         released: dict[Version, Release] = {}
 
+        # Performance optimization: create a mapping of tag sha to version
+        # so we can quickly look up the version for a given commit based on sha
+        tag_sha_2_version_lookup = {
+            tag.commit.hexsha: (tag, version)
+            for tag, version in all_git_tags_and_versions
+        }
+
         # Strategy:
         # Loop through commits in history, parsing as we go.
         # Add these commits to `unreleased` as a key-value mapping
@@ -64,46 +71,44 @@ class ReleaseHistory:
             )
             log.debug("commit has type %s", commit_type)
 
-            for tag, version in all_git_tags_and_versions:
-                if tag.commit == commit:
-                    # we have found the latest commit introduced by this tag
-                    # so we create a new Release entry
-                    log.debug("found commit %s for tag %s", commit.hexsha, tag.name)
-                    is_commit_released = True
-                    the_version = version
+            log.debug("checking if commit %s matches any tags", commit.hexsha)
+            t_v = tag_sha_2_version_lookup.get(commit.hexsha, None)
 
-                    # tag.object is a Commit if the tag is lightweight, otherwise
-                    # it is a TagObject with additional metadata about the tag
-                    if isinstance(tag.object, TagObject):
-                        tagger = tag.object.tagger
-                        committer = tag.object.tagger.committer()
-                        _tz = timezone(
-                            timedelta(seconds=-1 * tag.object.tagger_tz_offset)
-                        )
-                        tagged_date = datetime.fromtimestamp(
-                            tag.object.tagged_date, tz=_tz
-                        )
-                    else:
-                        # For some reason, sometimes tag.object is a Commit
-                        tagger = tag.object.author
-                        committer = tag.object.author
-                        _tz = timezone(
-                            timedelta(seconds=-1 * tag.object.author_tz_offset)
-                        )
-                        tagged_date = datetime.fromtimestamp(
-                            tag.object.committed_date, tz=_tz
-                        )
+            if t_v is None:
+                log.debug("no tags correspond to commit %s", commit.hexsha)
+            else:
+                # Unpack the tuple (overriding the current version)
+                tag, the_version = t_v
+                # we have found the latest commit introduced by this tag
+                # so we create a new Release entry
+                log.debug("found commit %s for tag %s", commit.hexsha, tag.name)
+                is_commit_released = True
 
-                    release = Release(
-                        tagger=tagger,
-                        committer=committer,
-                        tagged_date=tagged_date,
-                        elements=defaultdict(list),
-                        version=the_version,
+                # tag.object is a Commit if the tag is lightweight, otherwise
+                # it is a TagObject with additional metadata about the tag
+                if isinstance(tag.object, TagObject):
+                    tagger = tag.object.tagger
+                    committer = tag.object.tagger.committer()
+                    _tz = timezone(timedelta(seconds=-1 * tag.object.tagger_tz_offset))
+                    tagged_date = datetime.fromtimestamp(tag.object.tagged_date, tz=_tz)
+                else:
+                    # For some reason, sometimes tag.object is a Commit
+                    tagger = tag.object.author
+                    committer = tag.object.author
+                    _tz = timezone(timedelta(seconds=-1 * tag.object.author_tz_offset))
+                    tagged_date = datetime.fromtimestamp(
+                        tag.object.committed_date, tz=_tz
                     )
 
-                    released.setdefault(the_version, release)
-                    break
+                release = Release(
+                    tagger=tagger,
+                    committer=committer,
+                    tagged_date=tagged_date,
+                    elements=defaultdict(list),
+                    version=the_version,
+                )
+
+                released.setdefault(the_version, release)
 
             if any(pat.match(commit_message) for pat in exclude_commit_patterns):
                 log.debug(


### PR DESCRIPTION
## Purpose

- Improve performance of PSR when working on large git repositories
- Prevent ordering issues that arise from automated commit messages within milliseconds

## Rationale

Refactoring comparison data into a lookup datastructure allows for `O(1)` time lookups rather than `O(n)` searches on repositories with lots of tags.

## How I tested

Manually through the evaluation of logs, where many logs were not printed and it was noticable the number of iterations in the loops.  I did not do a benchmark datapoint though.

## How to verify

Run on PSR itself as it has enough tags to cause a slowdown and many irrelevant log entries.

```sh
semantic-release changelog
```
