### PR TITLE
docs: clarify changelog file usage

### DIFF
--- a/docs/changelog_templates.rst
+++ b/docs/changelog_templates.rst
@@ -3,22 +3,16 @@
 Changelog Templates
 ===================
 
-.. warning::
-    If you have an existing changelog in the location you have configured with
-    the :ref:`changelog_file <config-changelog-changelog_file>` setting,
-    or if you have a template inside your :ref:`template directory <config-changelog-template_dir>`
-    which will render to the location of an existing file, Python Semantic Release will
-    overwrite the contents of this file.
 
-    Please make sure to refer to :ref:`changelog-templates-migrating-existing-changelog`.
+By default, Python Semantic Release (PSR) will generate a changelog for your project. In the default
+configuration, PSR will use a built-in template files to render the changelog at the file location
+defined by the :ref:`changelog_file <config-changelog-changelog_file>` setting.
 
-Python Semantic Release can write a changelog for your project. By default, it uses an
-in-built template; once rendered this will be written to the location you configure with the
-:ref:`changelog_file <config-changelog-changelog_file>` setting.
-
-However, Python Semantic Release is also capable of rendering an entire directory tree
-of templates during the changelog generation process. This directory is specified
-using the :ref:`template directory <config-changelog-template_dir>` setting.
+However, you can customize the appearance and file structure of the changelog generation process
+by creating your own template files. This option is available by setting the
+:ref:`template_dir <config-changelog-template_dir>` configuration and populating the directory
+with your custom template files. It will render the an entire directory tree of templates
+as desired if they exist within the template directory.
 
 Python Semantic Release uses `Jinja`_ as its template engine, so you should refer to the
 `Template Designer Documentation`_ for guidance on how to customize the appearance of
@@ -31,6 +25,15 @@ You can disable changelog generation entirely during the :ref:`cmd-version` comm
 providing the :ref:`--no-changelog <cmd-version-option-changelog>` command-line option.
 
 The changelog template is re-rendered on each release.
+
+.. warning::
+    If you have an existing changelog in the location you have configured with
+    the :ref:`changelog_file <config-changelog-changelog_file>` setting,
+    or if you have a template inside your :ref:`template directory <config-changelog-template_dir>`
+    which will render to the location of an existing file, Python Semantic Release will
+    overwrite the contents of this file.
+
+    Please make sure to refer to :ref:`changelog-templates-migrating-existing-changelog`.
 
 .. _Jinja: https://jinja.palletsprojects.com/en/3.1.x/
 .. _Template Designer Documentation: https://jinja.palletsprojects.com/en/3.1.x/templates/

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -292,7 +292,12 @@ This section outlines the configuration options available that modify changelog 
 
 **Type:** ``str``
 
-Specify the name of the changelog file (after template rendering has taken place).
+Specify the name of the changelog file that will be created. This file will be created
+or overwritten (if it previously exists) with the rendered default template included
+with Python Semantic Release.
+
+If you are using the ``template_dir`` setting for providing customized templates,
+this setting is not used. See :ref:`config-changelog-template_dir` for more information.
 
 **Default:** ``"CHANGELOG.md"``
 
@@ -309,14 +314,13 @@ Specify the name of the changelog file (after template rendering has taken place
    passed directly to the `jinja2.Environment`_ constructor, and further
    documentation one these parameters can be found there.
 
-.. _`jinja2.Environment`: https://jinja.palletsprojects.com/en/3.1.x/api/#jinja2.Environment
-
-.. note::
     **pyproject.toml:** ``[tool.semantic_release.changelog.environment]``
 
     **releaserc.toml:** ``[semantic_release.changelog.environment]``
 
     **releaserc.json:** ``{ "semantic_release": { "changelog": { "environment": {} } } }``
+
+.. _`jinja2.Environment`: https://jinja.palletsprojects.com/en/3.1.x/api/#jinja2.Environment
 
 ----
 
@@ -540,8 +544,14 @@ The patterns in this list are treated as regular expressions.
 
 **Type:** ``str``
 
-If given, specifies a directory of templates that will be rendered during creation
-of the changelog. If not given, the default changelog template will be used.
+When files exist within the specified directory, they will be used as templates for
+the changelog rendering process. Regardless if the directory includes a changelog file,
+the provided directory will be rendered and files placed relative to the root of the
+project directory.
+
+No default changelog template or release notes template will be used when this directory
+exists and the directory is not empty. If the directory is empty, the default changelog
+template will be used.
 
 This option is discussed in more detail at :ref:`changelog-templates`
 


### PR DESCRIPTION
## Purpose

Improve clarity of documentation after more than one proposed bug related to `changelog_file` vs `template_dir` unexpected results.