### PR TITLE
replace pytest_lazyfixture with pytest_lazy_fixtures.lazy_fixture

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,13 +63,12 @@ test = [
   "pytest-env ~= 1.0",
   "pytest-xdist ~= 3.0",
   "pytest-mock ~= 3.0",
-  "pytest-lazy-fixture ~= 0.6.3",
+  "pytest-lazy-fixtures ~= 1.1.1",
   "pytest-cov ~= 5.0",
   "pytest-pretty ~= 1.2",
   "pytest-clarity ~= 1.0",
   "responses ~= 0.25.0",
   "requests-mock ~= 1.10",
-  "types-pytest-lazy-fixture ~= 0.6.3",
 ]
 dev = [
   "pre-commit ~= 3.5",

--- a/tests/command_line/test_changelog.py
+++ b/tests/command_line/test_changelog.py
@@ -8,7 +8,7 @@ from unittest import mock
 
 import pytest
 import requests_mock
-from pytest_lazyfixture import lazy_fixture
+from pytest_lazy_fixtures.lazy_fixture import lf as lazy_fixture
 from requests import Session
 
 from semantic_release.cli.commands.main import main

--- a/tests/command_line/test_version.py
+++ b/tests/command_line/test_version.py
@@ -13,7 +13,7 @@ from unittest import mock
 
 import pytest
 import tomlkit
-from pytest_lazyfixture import lazy_fixture
+from pytest_lazy_fixtures.lazy_fixture import lf as lazy_fixture
 
 from semantic_release.cli.commands.main import main
 from semantic_release.hvcs.github import Github

--- a/tests/scenario/test_next_version.py
+++ b/tests/scenario/test_next_version.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 # Limitation in pytest-lazy-fixture - see https://stackoverflow.com/a/69884019
-from pytest_lazyfixture import lazy_fixture
+from pytest_lazy_fixtures.lazy_fixture import lf as lazy_fixture
 
 from semantic_release.version.algorithm import next_version
 from semantic_release.version.translator import VersionTranslator

--- a/tests/scenario/test_release_history.py
+++ b/tests/scenario/test_release_history.py
@@ -5,7 +5,7 @@ from typing import NamedTuple
 
 import pytest
 from git import Actor
-from pytest_lazyfixture import lazy_fixture
+from pytest_lazy_fixtures.lazy_fixture import lf as lazy_fixture
 
 from semantic_release.changelog.release_history import ReleaseHistory
 from semantic_release.version.translator import VersionTranslator

--- a/tests/unit/semantic_release/cli/test_util.py
+++ b/tests/unit/semantic_release/cli/test_util.py
@@ -4,7 +4,7 @@ import json
 from textwrap import dedent
 
 import pytest
-from pytest_lazyfixture import lazy_fixture
+from pytest_lazy_fixtures.lazy_fixture import lf as lazy_fixture
 
 from semantic_release.cli.util import load_raw_config_file, parse_toml
 from semantic_release.errors import InvalidConfiguration

--- a/tests/unit/semantic_release/hvcs/test__base.py
+++ b/tests/unit/semantic_release/hvcs/test__base.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytest
-from pytest_lazyfixture import lazy_fixture
+from pytest_lazy_fixtures.lazy_fixture import lf as lazy_fixture
 
 from semantic_release.hvcs._base import HvcsBase
 

--- a/tests/unit/semantic_release/version/test_declaration.py
+++ b/tests/unit/semantic_release/version/test_declaration.py
@@ -4,7 +4,7 @@ from textwrap import dedent
 from unittest import mock
 
 import pytest
-from pytest_lazyfixture import lazy_fixture
+from pytest_lazy_fixtures.lazy_fixture import lf as lazy_fixture
 
 from semantic_release.version.declaration import (
     PatternVersionDeclaration,


### PR DESCRIPTION
pytest_lazyfixture is unmaintained and not compatible with Pytest 8

it is being removed from distributions

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1076459

## How did you test?

I packaged this for Debian right now.

https://salsa.debian.org/python-team/packages/python-semantic-release/-/pipelines/705005