### PR TITLE
docs(build_command): Add newline to fix table rendering

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -208,6 +208,7 @@ VIRTUAL_ENV               Pass-through ``VIRTUAL_ENV`` if exists in process env,
 ========================  ======================================================================
 
 In addition, on windows systems these environment variables are passed:
+
 ========================  ======================================================================
 Variable Name             Description
 ========================  ======================================================================


### PR DESCRIPTION
<!--
Please do not combine multiple features or fix actions that are not
directly dependent on one another. Please open multiple PRs instead because
one may be merged while the other is denied or has requested changes. This
will slow down the process of merging the accepted changes as reviews are
also more difficult to evaluate for edge cases.
-->

## Purpose
<!-- Reason for the PR (solves an issue/problem, adds a feature, etc) -->
While reading the [configuration](https://python-semantic-release.readthedocs.io/en/latest/configuration.html) page in the docs, I was reading the [build_command](https://python-semantic-release.readthedocs.io/en/latest/configuration.html#build-command) section and noticed that the table describing the the environment variables on Windows systems was corrupted.

This PR fixes that issue so that the table is rendered correctly.


## Rationale
<!-- How did you come to this conclusion as the solution? What was your reasoning? What were you trying to do? What problems did you find and avoid? -->
I suspected it was likely a whitespace / newline issue, because reStructuredText depends on delineation between elements for the parser to identify those elements.  When I located the source for this content I expected to find a paragraph element with the text `In addition, on windows systems these environment variables are passed:` followed by the markup for a table, but no newline separating the two elements.


## How did you test?
<!--
Please explain the methodology for how you verified this solution. It helps to
describe the primary case and the possible edge cases that you considered and
ultimately how you tested them. If you didn't rulled out any edge cases, please
mention the rationale here.
-->
I cloned the repo and built the docs to verify that the issue existed in my local version of the docs.  Then I found source file and added a newline between the text and table markup.  Finally, I re-built the documentation and verified that the table rendered correctly.


## How to Verify
<!-- Please provide a list of steps to validate your solution -->
1. Notice that the [latest version of the docs](https://python-semantic-release.readthedocs.io/en/latest/configuration.html#build-command) demonstrates the corrupted table (or at `HEAD` on `origin/main` of the PSR repo).
2. Clone or sync your local copy of the code with this PR or the forked repo.
3. Build the documentation locally.
4. Open the docs you just compiled, navigate to the `configuration` page and then down to the `build_command` section. 
 Verify that the table is now rendered correctly.
