### PR TITLE
build(deps-dev): update dev dependencies and pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
 
   # Linters and validation
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.5.0
+    rev: v0.6.3
     hooks:
       - id: ruff
         name: ruff (lint)
@@ -50,7 +50,7 @@ repos:
         name: ruff (format)
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.10.0"
+    rev: "v1.11.2"
     hooks:
       - id: mypy
         additional_dependencies:
@@ -98,7 +98,7 @@ repos:
 
   # GHA linting
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: "0.28.0"
+    rev: "0.29.1"
     hooks:
       - id: check-github-workflows
       - id: check-readthedocs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,10 +73,10 @@ test = [
 dev = [
   "pre-commit ~= 3.5",
   "tox ~= 4.11",
-  "ruff == 0.5.0"
+  "ruff == 0.6.3"
 ]
 mypy = [
-  "mypy == 1.10.1",
+  "mypy == 1.11.2",
   "types-requests ~= 2.32.0",
 ]
 


### PR DESCRIPTION
## Purpose
- Update ruff to v0.6.3
- Update mypy to v1.11.2
- Update some pre-commit hooks

Looked at updating `pre-commit` itself in dev dependencies, however, looks like Python 3.8 (which checks still run on) doesn't support anything after ~ 3.5.

#1009  and #1006 would likely auto-close after this.

## Rationale
<!-- How did you come to this conclusion as the solution? What was your reasoning? What were you trying to do? What problems did you find and avoid? -->



## How did you test?
<!--
Please explain the methodology for how you verified this solution. It helps to
describe the primary case and the possible edge cases that you considered and
ultimately how you tested them. If you didn't rulled out any edge cases, please
mention the rationale here.
-->



## How to Verify
<!-- Please provide a list of steps to validate your solution -->

