### PR TITLE
docs: use pinned version for GHA examples

### DIFF
--- a/docs/automatic-releases/github-actions.rst
+++ b/docs/automatic-releases/github-actions.rst
@@ -30,32 +30,32 @@ Example Workflow
 
 .. code:: yaml
 
-   name: Semantic Release
+    name: Semantic Release
 
-   on:
-     push:
-       branches:
-         - master
+    on:
+      push:
+        branches:
+          - master
 
-   jobs:
-     release:
-       runs-on: ubuntu-latest
-       concurrency: release
-       permissions:
-         id-token: write
-         contents: write
+    jobs:
+      release:
+        runs-on: ubuntu-latest
+        concurrency: release
+        permissions:
+          id-token: write
+          contents: write
 
-       steps:
-       - uses: actions/checkout@v3
-         with:
-           fetch-depth: 0
+        steps:
+          - uses: actions/checkout@v3
+            with:
+              fetch-depth: 0
 
-       - name: Python Semantic Release
-	 # Replace with desired / current version. Currently, there is no
-	 # moving major tag, e.g., v9 will not work.
-         uses: python-semantic-release/python-semantic-release@v9.8.6
-         with:
-           github_token: ${{ secrets.GITHUB_TOKEN }}
+          - name: Python Semantic Release
+            # Adjust tag with desired version if applicable. Version shorthand
+            # is NOT available, e.g. vX or vX.X will not work.
+            uses: python-semantic-release/python-semantic-release@v9.8.6
+            with:
+              github_token: ${{ secrets.GITHUB_TOKEN }}
 
 ``concurrency`` is a
 `beta feature of GitHub Actions <https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idconcurrency>`_

--- a/docs/automatic-releases/github-actions.rst
+++ b/docs/automatic-releases/github-actions.rst
@@ -51,7 +51,9 @@ Example Workflow
            fetch-depth: 0
 
        - name: Python Semantic Release
-         uses: python-semantic-release/python-semantic-release@master
+	 # Replace with desired / current version. Currently, there is no
+	 # moving major tag, e.g., v9 will not work.
+         uses: python-semantic-release/python-semantic-release@v9.8.6
          with:
            github_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -92,13 +94,13 @@ multiple projects.
 .. code:: yaml
 
    - name: Release Project 1
-     uses: python-semantic-release/python-semantic-release@master
+     uses: python-semantic-release/python-semantic-release@v9.8.6
      with:
        directory: ./project1
        github_token: ${{ secrets.GITHUB_TOKEN }}
 
    - name: Release Project 2
-     uses: python-semantic-release/python-semantic-release@master
+     uses: python-semantic-release/python-semantic-release@v9.8.6
      with:
        directory: ./project2
        github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/automatic-releases/github-actions.rst
+++ b/docs/automatic-releases/github-actions.rst
@@ -57,15 +57,15 @@ Example Workflow
             with:
               github_token: ${{ secrets.GITHUB_TOKEN }}
 
-``concurrency`` is a
-`beta feature of GitHub Actions <https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idconcurrency>`_
-which disallows two or more release jobs to run in parallel. This prevents race
-conditions if there are multiple pushes in a short period of time.
+``concurrency`` is a `beta feature of GitHub Actions`_ which disallows two or more
+release jobs to run in parallel. This prevents race conditions if there are multiple
+pushes in a short period of time.
 
 If you would like to use Python Semantic Release to create GitHub Releases against
 your repository, you will need to allow the additional ``contents: write`` permission.
 More information can be found in the `permissions for GitHub Apps documentation`_
 
+.. _beta feature of GitHub Actions: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idconcurrency
 .. _permissions for GitHub Apps documentation: https://docs.github.com/en/rest/overview/permissions-required-for-github-apps?apiVersion=2022-11-28#contents
 
 .. warning::

--- a/docs/github-action.rst
+++ b/docs/github-action.rst
@@ -129,7 +129,9 @@ provide the following inputs:
 
    # ... the rest of the workflow
    - name: Python Semantic Release
-     uses: python-semantic-release/python-semantic-release@v8.0.0
+     # Replace with desired / current version. Currently, there is no moving
+     # major tag, e.g., v9 will not work.
+     uses: python-semantic-release/python-semantic-release@v9.8.6
      with:
        # ... other options
        force: "patch"

--- a/docs/github-action.rst
+++ b/docs/github-action.rst
@@ -129,8 +129,8 @@ provide the following inputs:
 
    # ... the rest of the workflow
    - name: Python Semantic Release
-     # Replace with desired / current version. Currently, there is no moving
-     # major tag, e.g., v9 will not work.
+     # Adjust tag with desired version if applicable. Version shorthand
+     # is NOT available, e.g. vX or vX.X will not work.
      uses: python-semantic-release/python-semantic-release@v9.8.6
      with:
        # ... other options

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -375,6 +375,7 @@ ignore_names = ["change_to_ex_proj_dir", "init_example_project"]
 logging_use_named_masks = true
 commit_parser = "angular"
 build_command = """
+    python -m scripts.bump_version_in_docs
     python -m pip install -e .[build]
     python -m build .
 """

--- a/scripts/bump_version_in_docs.py
+++ b/scripts/bump_version_in_docs.py
@@ -1,0 +1,36 @@
+# ruff: noqa: T201, allow print statements in non-prod scripts
+from __future__ import annotations
+
+from os import getenv
+from pathlib import Path
+from re import compile as RegExp  # noqa: N812
+
+PROJ_DIR = Path(__file__).resolve().parent.parent
+DOCS_DIR = PROJ_DIR / "docs"
+
+def update_github_actions_example(filepath: Path, new_version: str) -> None:
+    psr_regex = RegExp(r"(uses:.*python-semantic-release)@v\d+\.\d+\.\d+")
+    file_content_lines = filepath.read_text().splitlines()
+
+    for regex in [psr_regex]:
+        file_content_lines = list(map(
+            lambda line, regex=regex: regex.sub(r'\1@v'+new_version, line),
+            file_content_lines
+        ))
+
+    print(f"Bumping version in {filepath} to", new_version)
+    filepath.write_text(str.join("\n", file_content_lines) + '\n')
+
+
+if __name__ == "__main__":
+    new_version = getenv("NEW_VERSION")
+
+    if not new_version:
+        print("NEW_VERSION environment variable is not set")
+        exit(1)
+
+    update_github_actions_example(DOCS_DIR / "github-action.rst", new_version)
+    update_github_actions_example(
+        DOCS_DIR / "automatic-releases" / "github-actions.rst",
+        new_version
+    )


### PR DESCRIPTION
## Purpose

It's generally a good practice to anchor / pin GHA workflows. This updates the existing examples to make that more clear.

Fixes #1003