### PR TITLE
fix: provide `context.history` global in release notes templates

### DIFF
--- a/semantic_release/cli/changelog_writer.py
+++ b/semantic_release/cli/changelog_writer.py
@@ -149,6 +149,7 @@ def generate_release_notes(
     hvcs_client: HvcsBase,
     release: Release,
     template_dir: Path,
+    history: ReleaseHistory,
 ) -> str:
     release_notes_env = ReleaseNotesContext(
         repo_name=hvcs_client.repo_name,
@@ -162,6 +163,11 @@ def generate_release_notes(
         # not user-configurable at the moment
         environment(template_dir=template_dir)
     )
+
+    # TODO: Remove in v10
+    release_notes_env.globals["context"] = {
+        "history": history,
+    }
 
     return render_release_notes(
         release_notes_template=get_release_notes_template(template_dir),

--- a/semantic_release/cli/commands/changelog.py
+++ b/semantic_release/cli/commands/changelog.py
@@ -112,7 +112,8 @@ def changelog(cli_ctx: CliContextObj, release_tag: str | None) -> None:
     release_notes = generate_release_notes(
         hvcs_client,
         release,
-        template_dir=runtime.template_dir,
+        runtime.template_dir,
+        release_history,
     )
 
     try:

--- a/semantic_release/cli/commands/changelog.py
+++ b/semantic_release/cli/commands/changelog.py
@@ -34,7 +34,9 @@ def post_release_notes(
                 "\n",
                 [
                     f"would have posted the following release notes for tag {release_tag}:",
-                    release_notes,
+                    # Escape square brackets to ensure all content is displayed in the console
+                    # (i.e. prevent interpretation of ansi escape sequences that is valid markdown)
+                    release_notes.replace("[", "\\["),
                 ],
             )
         )

--- a/semantic_release/cli/commands/version.py
+++ b/semantic_release/cli/commands/version.py
@@ -711,7 +711,8 @@ def version(  # noqa: C901
     release_notes = generate_release_notes(
         hvcs_client,
         release_history.released[new_version],
-        template_dir=runtime.template_dir,
+        runtime.template_dir,
+        history=release_history,
     )
 
     exception: Exception | None = None


### PR DESCRIPTION
## Purpose
<!-- Reason for the PR (solves an issue/problem, adds a feature, etc) -->

- Provide the `context.history` variable to release notes generation
- Resolves: #984

## Rationale

Temporarily return the `context.history` variable to release notes generation as many users are using it in their release documentation. It was never intended to be provided and will be removed in the future.

Context was removed in `v9.8.3` during a refactor and condensing of changelog and release notes functionality. Ends up the context was provided accidentally because of variable re-use rather than explicit definition which is why it broke upon refactor.

## How did you test?
<!--
Please explain the methodology for how you verified this solution. It helps to
describe the primary case and the possible edge cases that you considered and
ultimately how you tested them. If you didn't rulled out any edge cases, please
mention the rationale here.
-->

Performed some manual testing with a custom template upon the PSR repository.  See the commands below for replication. The importance is that the release notes was printed to the console using `--noop` mode so we are sure that the formatting and use was working.

## How to Verify
<!-- Please provide a list of steps to validate your solution -->

1. Add the following file to PSR repository:

    ```j2
    {# file: templates/.release_notes.md.j2 #}
    {%   set releases = context.history.released.items() | list
    %}{% set prev_version_tag = releases[1][0].as_tag()
    %}{% set new_version_tag = version.as_tag()
    %}{% set version_compare_url = prev_version_tag | compare_url(new_version_tag)
    %}{% set detailed_changes_link = '[{}...{}]({})'.format(prev_version_tag, new_version_tag, version_compare_url)
    %}
    ---

    **Detailed Changes**: {{ detailed_changes_link }}
    ```

2. Execute `semantic-release --noop changelog --post-to-release-tag v9.8.6`
