### PR TITLE
chore: fix failure to commit doc example version bumps

### DIFF
--- a/docs/automatic-releases/github-actions.rst
+++ b/docs/automatic-releases/github-actions.rst
@@ -53,7 +53,7 @@ Example Workflow
           - name: Python Semantic Release
             # Adjust tag with desired version if applicable. Version shorthand
             # is NOT available, e.g. vX or vX.X will not work.
-            uses: python-semantic-release/python-semantic-release@v9.8.6
+            uses: python-semantic-release/python-semantic-release@v9.8.7
             with:
               github_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/docs/github-action.rst
+++ b/docs/github-action.rst
@@ -131,7 +131,7 @@ provide the following inputs:
    - name: Python Semantic Release
      # Adjust tag with desired version if applicable. Version shorthand
      # is NOT available, e.g. vX or vX.X will not work.
-     uses: python-semantic-release/python-semantic-release@v9.8.6
+     uses: python-semantic-release/python-semantic-release@v9.8.7
      with:
        # ... other options
        force: "patch"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -376,6 +376,7 @@ logging_use_named_masks = true
 commit_parser = "angular"
 build_command = """
     python -m scripts.bump_version_in_docs
+    git add docs/*
     python -m pip install -e .[build]
     python -m build .
 """


### PR DESCRIPTION
## Purpose
<!-- Reason for the PR (solves an issue/problem, adds a feature, etc) -->

- Update the docs' examples to the latest version
- Ensure the docs modifications are included in the version commit

## Rationale
<!-- How did you come to this conclusion as the solution? What was your reasoning? What were you trying to do? What problems did you find and avoid? -->

- Noticed after the #1010 issue that I forgot to add the files into the index to be included after the version was bumped.
- Since the docs weren't updated last version, must include that manually.

## How did you test?
<!--
Please explain the methodology for how you verified this solution. It helps to
describe the primary case and the possible edge cases that you considered and
ultimately how you tested them. If you didn't rulled out any edge cases, please
mention the rationale here.
-->

Ran the version command locally to ensure that when the build command was executed the resulting docs files were staged in the index prior to commit.

## How to Verify
<!-- Please provide a list of steps to validate your solution -->

```sh
semantic-release version --no-commit --no-tag --no-changelog
git status
```
