### PR TITLE
build(deps): restrict `python-gitlab` dependency due to broken release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
   "click ~= 8.0",
   "click-option-group ~= 0.5",
   "gitpython ~= 3.0",
+  "httpx ~=0.27",
   "requests ~= 2.25",
   "jinja2 ~= 3.1",
   "python-gitlab ~= 4.0",


### PR DESCRIPTION
The `python-gitlab` package depends on `httpx` starting from v4.11.0

<!--
Please do not combine multiple features or fix actions that are not
directly dependent on one another. Please open multiple PRs instead because
one may be merged while the other is denied or has requested changes. This
will slow down the process of merging the accepted changes as reviews are
also more difficult to evaluate for edge cases.
-->

## Purpose
<!-- Reason for the PR (solves an issue/problem, adds a feature, etc) -->

I believe this fixes https://github.com/python-semantic-release/python-semantic-release/issues/1023
Not sure if this is the right way to approach this though.

## Rationale
<!-- How did you come to this conclusion as the solution? What was your reasoning? What were you trying to do? What problems did you find and avoid? -->



## How did you test?
<!--
Please explain the methodology for how you verified this solution. It helps to
describe the primary case and the possible edge cases that you considered and
ultimately how you tested them. If you didn't rulled out any edge cases, please
mention the rationale here.
-->



## How to Verify
<!-- Please provide a list of steps to validate your solution -->

