### PR TITLE
docs: update docstrings to resolve sphinx failures

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,6 +16,8 @@ extensions = [
     "sphinxcontrib.apidoc",
 ]
 
+autodoc_default_options = {"ignore-module-all": True}
+
 templates_path = ["_templates"]
 source_suffix = ".rst"
 master_doc = "index"

--- a/semantic_release/cli/commands/version.py
+++ b/semantic_release/cli/commands/version.py
@@ -219,19 +219,12 @@ def build_distributions(
     """
     Run the build command to build the distributions.
 
-    Arguments:
-    ---------
-        build_command: str | None
-            The build command to run
-        build_command_env: Mapping[str, str] | None
-            The environment variables to use when running the build command
-        noop: bool
-            Whether or not to run the build command
+    :param build_command: The build command to run.
+    :param build_command_env: The environment variables to use when running the
+        build command.
+    :param noop: Whether or not to run the build command.
 
-    Raises:
-    ------
-        BuildDistributionsError: if the build command fails
-
+    :raises: BuildDistributionsError: if the build command fails
     """
     if not build_command:
         rprint("[green]No build command specified, skipping")

--- a/semantic_release/hvcs/gitea.py
+++ b/semantic_release/hvcs/gitea.py
@@ -95,11 +95,9 @@ class Gitea(RemoteHvcsBase):
         Ref: https://gitea.com/api/swagger#/repository/repoCreateRelease
 
         :param tag: Tag to create release for
-
         :param release_notes: The release notes for this version
-
         :param prerelease: Whether or not this release should be specified as a
-        prerelease
+            prerelease
 
         :return: Whether the request succeeded
         """
@@ -181,6 +179,7 @@ class Gitea(RemoteHvcsBase):
         Get a release by its tag name
         https://gitea.com/api/swagger#/repository/repoGetReleaseByTag
         :param tag: Tag to get release for
+
         :return: ID of found release
         """
         tag_endpoint = self.create_api_url(
@@ -206,6 +205,7 @@ class Gitea(RemoteHvcsBase):
         https://gitea.com/api/swagger#/repository/repoEditRelease
         :param id: ID of release to update
         :param release_notes: The release notes for this version
+
         :return: The ID of the release that was edited
         """
         log.info("Updating release %s", release_id)
@@ -231,6 +231,7 @@ class Gitea(RemoteHvcsBase):
         Post release changelog
         :param version: The version number
         :param changelog: The release notes for this version
+
         :return: The status of the request
         """
         log.info("Creating release for %s", tag)
@@ -274,6 +275,7 @@ class Gitea(RemoteHvcsBase):
         :param release_id: ID of the release to upload to
         :param file: Path of the file to upload
         :param label: this parameter has no effect
+
         :return: The status of the request
         """
         url = self.asset_upload_url(release_id)
@@ -312,6 +314,7 @@ class Gitea(RemoteHvcsBase):
         Upload distributions to a release
         :param tag: Tag to upload for
         :param path: Path to the dist directory
+
         :return: The number of distributions successfully uploaded
         """
         # Find the release corresponding to this tag

--- a/semantic_release/hvcs/gitlab.py
+++ b/semantic_release/hvcs/gitlab.py
@@ -106,23 +106,16 @@ class Gitlab(RemoteHvcsBase):
         """
         Create a release in a remote VCS, adding any release notes and assets to it
 
-        Arguments:
-        ---------
-            tag(str): The tag to create the release for
-            release_notes(str): The changelog description for this version only
-            prerelease(bool): This parameter has no effect in GitLab
-            assets(list[str]): A list of paths to files to upload as assets (TODO: not implemented)
-            noop(bool): If True, do not perform any actions, only log intents
+        :param tag: The tag to create the release for
+        :param release_notes: The changelog description for this version only
+        :param prerelease: This parameter has no effect in GitLab
+        :param assets: A list of paths to files to upload as assets (TODO: not implemented)
+        :param noop: If True, do not perform any actions, only log intents
 
-        Returns:
-        -------
-            str: The tag of the release
+        :return: The tag of the release
 
-        Raises:
-        ------
-            GitlabAuthenticationError: If authentication is not correct
-            GitlabCreateError: If the server cannot perform the request
-
+        :raises: GitlabAuthenticationError: If authentication is not correct
+        :raises: GitlabCreateError: If the server cannot perform the request
         """
         if noop:
             noop_report(f"would have created a release for tag {tag}")
@@ -145,20 +138,13 @@ class Gitlab(RemoteHvcsBase):
     @suppress_not_found
     def get_release_by_tag(self, tag: str) -> gitlab.v4.objects.ProjectRelease | None:
         """
-        Get a release by its tag name
+        Get a release by its tag name.
 
-        Arguments:
-        ---------
-            tag(str): The tag name to get the release for
+        :param tag: The tag name to get the release for
 
-        Returns:
-        -------
-            gitlab.v4.objects.ProjectRelease | None: The release object or None if not found
+        :return: gitlab.v4.objects.ProjectRelease or None if not found
 
-        Raises:
-        ------
-            gitlab.exceptions.GitlabAuthenticationError: If the user is not authenticated
-
+        :raises: gitlab.exceptions.GitlabAuthenticationError: If the user is not authenticated
         """
         try:
             return self.project.releases.get(tag)
@@ -175,21 +161,15 @@ class Gitlab(RemoteHvcsBase):
         release_notes: str,
     ) -> str:
         """
-        Update the release notes for a given release
+        Update the release notes for a given release.
 
-        Arguments:
-        ---------
-            release(gitlab.v4.objects.ProjectRelease): The release object to update
-            release_notes(str): The new release notes
+        :param release: The release object to update
+        :param release_notes: The new release notes
 
-        Returns:
-        -------
-            str: The release id
+        :return: The release id
 
-        Raises:
-        ------
-            GitlabAuthenticationError: If authentication is not correct
-            GitlabUpdateError: If the server cannot perform the request
+        :raises: GitlabAuthenticationError: If authentication is not correct
+        :raises: GitlabUpdateError: If the server cannot perform the request
 
         """
         log.info(
@@ -206,24 +186,17 @@ class Gitlab(RemoteHvcsBase):
         self, tag: str, release_notes: str, prerelease: bool = False
     ) -> str:
         """
-        Create or update a release for the given tag in a remote VCS
+        Create or update a release for the given tag in a remote VCS.
 
-        Arguments:
-        ---------
-            tag(str): The tag to create or update the release for
-            release_notes(str): The changelog description for this version only
-            prerelease(bool): This parameter has no effect in GitLab
+        :param tag: The tag to create or update the release for
+        :param release_notes: The changelog description for this version only
+        :param prerelease: This parameter has no effect in GitLab
 
-        Returns:
-        -------
-            str: The release id
+        :return: The release id
 
-        Raises:
-        ------
-            ValueError: If the release could not be created or updated
-            gitlab.exceptions.GitlabAuthenticationError: If the user is not authenticated
-            GitlabUpdateError: If the server cannot perform the request
-
+        :raises ValueError: If the release could not be created or updated
+        :raises gitlab.exceptions.GitlabAuthenticationError: If the user is not authenticated
+        :raises GitlabUpdateError: If the server cannot perform the request
         """
         try:
             return self.create_release(

--- a/semantic_release/hvcs/util.py
+++ b/semantic_release/hvcs/util.py
@@ -21,12 +21,14 @@ def build_requests_session(
 ) -> Session:
     """
     Create a requests session.
+
     :param raise_for_status: If True, a hook to invoke raise_for_status be installed
     :param retry: If true, it will use default Retry configuration. if an integer, it
-                  will use default Retry configuration with given integer as total retry
-                  count. if Retry instance, it will use this instance.
+        will use default Retry configuration with given integer as total retry
+        count. if Retry instance, it will use this instance.
     :param auth: Optional TokenAuth instance to be used to provide the Authorization
-                 header to the session
+        header to the session
+
     :return: configured requests Session
     """
     session = Session()


### PR DESCRIPTION
## Purpose
- set `ignore-module-all` for `autodoc_default_options` to resolve some Sphinx errors about duplicate / ambiguous references https://github.com/sphinx-doc/sphinx/issues/4961#issuecomment-1543858623
- Standardize some non-standard (Google-ish) docstrings to Sphinx format, to avoid ruff and Sphinx arguing about underline length.
- Fix indents and other minor whitespace / formatting changes.

Fixes #1029

## Rationale
Happy to do this differently, but Sphinx style seemed to match most of what we had in the codebase

Pros:
* Types are inferred automagically
* A bit easier for machine parsing
* Slightly smaller footprint

Cons: 
* A bit harder to read directly in the code (no types, etc.)
* [No ruff support](https://github.com/astral-sh/ruff/issues/6606) for setting `pydocstyle` to `sphinx`.

## How did you test?
Generated locally and spot-checked that at least type inferences etc. seemed to work Ok.

Note: references to errors raised / types from other libraries aren't automagically linked; I assume that's Ok.

## How to Verify
Build docs following docs in contributing guidelines, and view in browser