### PR TITLE
ci(pr): add file type filter to regulate testing jobs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,10 +4,68 @@ name: Checks
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
+
+  eval-changes:
+    name: Evaluate changes
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Evaluate | Check specific file types for changes
+        id: changed-files
+        uses: tj-actions/changed-files@v45.0.2
+        with:
+          files_yaml: |
+            build:
+              - MANIFEST.in
+              - Dockerfile
+              - .dockerignore
+              - scripts/**
+            ci:
+              - .github/workflows/**
+            docs:
+              - docs/**
+              - README.rst
+              - AUTHORS.rst
+              - CONTRIBUTING.rst
+              - CHANGELOG.rst
+            src:
+              - semantic_release/**
+              - pyproject.toml
+            tests:
+              - tests/**
+
+      - name: Evaluate | Detect if any of the combinations of file sets have changed
+        id: all-changes
+        run: |
+          printf '%s\n' "any_changed=false" >> $GITHUB_OUTPUT
+          if [ "${{ steps.changed-files.outputs.build_any_changed }}" == "true" ] || \
+             [ "${{ steps.changed-files.outputs.ci_any_changed }}" == "true" ] || \
+             [ "${{ steps.changed-files.outputs.docs_any_changed }}" == "true" ] || \
+             [ "${{ steps.changed-files.outputs.src_any_changed }}" == "true" ] || \
+             [ "${{ steps.changed-files.outputs.tests_any_changed }}" == "true" ]; then
+             printf '%s\n' "any_changed=true" >> $GITHUB_OUTPUT
+          fi
+
+    outputs:
+      any-file-changes: ${{ steps.all-changes.outputs.any_changed }}
+      build-changes: ${{ steps.changed-files.outputs.build_any_changed }}
+      ci-changes: ${{ steps.changed-files.outputs.ci_any_changed }}
+      doc-changes: ${{ steps.changed-files.outputs.docs_any_changed }}
+      src-changes: ${{ steps.changed-files.outputs.src_any_changed }}
+      test-changes: ${{ steps.changed-files.outputs.tests_any_changed }}
+
+
   test-linux:
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }} tests
     runs-on: ${{ matrix.os }}
+    needs: eval-changes
+    if: ${{ needs.eval-changes.outputs.src-changes == 'true' || needs.eval-changes.outputs.test-changes == 'true' || needs.eval-changes.outputs.ci-changes == 'true' }}
     strategy:
       matrix:
         python-version:
@@ -66,6 +124,8 @@ jobs:
   test-windows:
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }} tests
     runs-on: ${{ matrix.os }}
+    needs: eval-changes
+    if: ${{ needs.eval-changes.outputs.src-changes == 'true' || needs.eval-changes.outputs.test-changes == 'true' || needs.eval-changes.outputs.ci-changes == 'true' }}
     strategy:
       # Since the current test suite takes 10-15 minutes to complete on windows, we are
       # only going to run it on the oldest version of python we support. The older version
@@ -122,7 +182,10 @@ jobs:
           report_paths: ./tests/reports/*.xml
           annotate_only: true
 
+
   lint:
+    needs: eval-changes
+    if: ${{ needs.eval-changes.outputs.any-file-changes == 'true' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -146,6 +209,7 @@ jobs:
 
       - name: mypy
         run: python -m mypy --ignore-missing-imports semantic_release
+
 
   commitlint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--
Please do not combine multiple features or fix actions that are not
directly dependent on one another. Please open multiple PRs instead because
one may be merged while the other is denied or has requested changes. This
will slow down the process of merging the accepted changes as reviews are
also more difficult to evaluate for edge cases.
-->

## Purpose
<!-- Reason for the PR (solves an issue/problem, adds a feature, etc) -->

- Limit the amount of unimportant jobs the CI does

## Rationale
<!-- How did you come to this conclusion as the solution? What was your reasoning? What were you trying to do? What problems did you find and avoid? -->

I was able to use a file changes detection action that would distinguish what files changed on a PR and subsequently use conditional statements to turn off the long testing jobs (windows) when it was not relevant.  This is obvious when you have a bunch of documentation changes but then the CI would run the entire test suite even though no source code or test code was touched.

I determined to break up the parts of the repository into a few categories: build, ci, doc, src, & test.  A less than obvious choice I made but the rationale was to include `pyproject.toml` in the list of source code files because this is the file in which the dependencies are defined.  The dependencies might as well be a part of the source as it will be when at runtime.  Furthermore this ensures that all Dependabot PRs will execute the test suite which is super important. It is unfortunate that all other project setting changes will cause tests to run as I cannot isolate just the dependency list itself.

Secondly I used the file-change results to enable the lint job upon any of the file categories but it will not run when files outside of any categories are changed.  Testing jobs will execute if there is a source code change, a test code change, or CI reconfigurations.  Commitlint job will always run because it is irrelevant to what files were changed but always needs to be enforced.

## How did you test?
<!--
Please explain the methodology for how you verified this solution. It helps to
describe the primary case and the possible edge cases that you considered and
ultimately how you tested them. If you didn't rulled out any edge cases, please
mention the rationale here.
-->

I opened up PRs on my fork with this PR already in main.  I used 3 PRs which had different file changes to make sure each set of jobs executed as expected.  codejedi365/python-semantic-release#2 used non-categorized changes which only ran evaluate-changes and commitlint jobs as expected.  codejedi365/python-semantic-release#3 evaluated that document changes would only add the lint job to the set of jobs of the workflow but not tests.  codejedi365/python-semantic-release#4 evaluated that when the source code changed all the tests executed with the rest of the jobs previously required.


## How to Verify
<!-- Please provide a list of steps to validate your solution -->

Review the pipeline actions or manually re execute the steps described above to open PRs that fit the criteria and ensure that the workflows act as intended.

As you can also see from this PR itself is that the CI file changes were detected and ensured that the test suites were executed along with lint & commitlint.