### PR TITLE
ci(pr-workflow): limit which workflow files trigger full testing

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,7 +27,7 @@ jobs:
               - .dockerignore
               - scripts/**
             ci:
-              - .github/workflows/**
+              - .github/workflows/pr.yml
             docs:
               - docs/**
               - README.rst


### PR DESCRIPTION
<!--
Please do not combine multiple features or fix actions that are not
directly dependent on one another. Please open multiple PRs instead because
one may be merged while the other is denied or has requested changes. This
will slow down the process of merging the accepted changes as reviews are
also more difficult to evaluate for edge cases.
-->

## Purpose
<!-- Reason for the PR (solves an issue/problem, adds a feature, etc) -->

- Further minimize unnecessary pipeline delays & actions consumption

## Rationale
<!-- How did you come to this conclusion as the solution? What was your reasoning? What were you trying to do? What problems did you find and avoid? -->

I realized that using the glob syntax actually would cause a change in the `stale.yml` or the `main.yml` workflows would cause a PR to execute everything. That doesn't make sense so I limited it to just the `pr.yml` workflow scope.
