### PR TITLE
ci(main-workflow): add steps to update partial version reference tags

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -205,6 +205,24 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           root_options: "-vv"
 
+      - name: Update Minor Release Tag Reference
+        if: steps.release.outputs.released == 'true' && steps.release.outputs.is_prerelease == 'false'
+        env:
+          FULL_VERSION_TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          MINOR_VERSION_TAG="$(echo "$FULL_VERSION_TAG" | cut -d. -f1,2)"
+          git tag --force --annotate "$MINOR_VERSION_TAG" "${FULL_VERSION_TAG}^{}" -m "$MINOR_VERSION_TAG"
+          git push -u origin "$MINOR_VERSION_TAG" --force
+
+      - name: Update Major Release Tag Reference
+        if: steps.release.outputs.released == 'true' && steps.release.outputs.is_prerelease == 'false'
+        env:
+          FULL_VERSION_TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          MAJOR_VERSION_TAG="$(echo "$FULL_VERSION_TAG" | cut -d. -f1)"
+          git tag --force --annotate "$MAJOR_VERSION_TAG" "${FULL_VERSION_TAG}^{}" -m "$MAJOR_VERSION_TAG"
+          git push -u origin "$MAJOR_VERSION_TAG" --force
+
       # see https://docs.pypi.org/trusted-publishers/
       - name: Publish package distributions to PyPI
         id: pypi-publish


### PR DESCRIPTION
<!--
Please do not combine multiple features or fix actions that are not
directly dependent on one another. Please open multiple PRs instead because
one may be merged while the other is denied or has requested changes. This
will slow down the process of merging the accepted changes as reviews are
also more difficult to evaluate for edge cases.
-->

## Purpose
<!-- Reason for the PR (solves an issue/problem, adds a feature, etc) -->

- Adds moving partial version reference tags automatically upon release

## Rationale
<!-- How did you come to this conclusion as the solution? What was your reasoning? What were you trying to do? What problems did you find and avoid? -->

In order to have GitHub Actions auto update an action, there needs to be a partial version tag.  These two steps will automatically update a partial minor version and also a partial major tag as python-semantic-release creates a release.

ex. `v9.8.9` is released, and then the `v9.8` and a `v9` tag are moved to reference the same release.

## How did you test?
<!--
Please explain the methodology for how you verified this solution. It helps to
describe the primary case and the possible edge cases that you considered and
ultimately how you tested them. If you didn't rulled out any edge cases, please
mention the rationale here.
-->

I ran the script code locally in a script file. I used the same global variables that would exist in the CI.  The script I used is below.

## How to Verify
<!-- Please provide a list of steps to validate your solution -->

```bash
#!/bin/bash

set -e

FULL_VERSION_TAG="$(git tag --list --sort=-v:refname | head -n1)"
echo "Last version tag: $FULL_VERSION_TAG"

MINOR_VERSION_TAG="$(echo "$FULL_VERSION_TAG" | cut -d. -f1,2)"
echo "Minor version tag: $MINOR_VERSION_TAG"

git tag --force --annotate "$MINOR_VERSION_TAG" "${FULL_VERSION_TAG}^{}" -m "$MINOR_VERSION_TAG"
git push -u origin "$MINOR_VERSION_TAG" --force


MAJOR_VERSION_TAG="$(echo "$FULL_VERSION_TAG" | cut -d. -f1)"
echo "Major version tag: $MAJOR_VERSION_TAG"

git tag --force --annotate "$MAJOR_VERSION_TAG" "${FULL_VERSION_TAG}^{}" -m "$MAJOR_VERSION_TAG"
git push -u origin "$MAJOR_VERSION_TAG" --force
```