### PR TITLE
ci(main-workflow): change `upload-to-gh-release` action to `publish-action@v9.9.0`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -247,11 +247,10 @@ jobs:
 
       - name: Publish package distributions to GitHub Releases
         id: github-release
-
         # NOTE: DO NOT wrap the conditional in ${{ }} as it will always evaluate to true.
         # See https://github.com/actions/runner/issues/1173
         if: steps.release.outputs.released == 'true'
-        uses: python-semantic-release/upload-to-gh-release@main
+        uses: python-semantic-release/publish-action@v9.9.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ steps.release.outputs.tag }}


### PR DESCRIPTION
<!--
Please do not combine multiple features or fix actions that are not
directly dependent on one another. Please open multiple PRs instead because
one may be merged while the other is denied or has requested changes. This
will slow down the process of merging the accepted changes as reviews are
also more difficult to evaluate for edge cases.
-->

## Purpose
<!-- Reason for the PR (solves an issue/problem, adds a feature, etc) -->

- Update this project to be inline with our documentation
- Remove the deprecated action

## Rationale
<!-- How did you come to this conclusion as the solution? What was your reasoning? What were you trying to do? What problems did you find and avoid? -->

Because we renamed the action we needed to update the implementation in our project as well.  As many people will use our project as a reference.  

Not merging this immediately until after the next release is also a slight test for making sure that our warning annotation works for `upload-to-gh-release` as we should see it in our Actions summary.  Then we will change it over to the new action version.

## How did you test?
<!--
Please explain the methodology for how you verified this solution. It helps to
describe the primary case and the possible edge cases that you considered and
ultimately how you tested them. If you didn't rulled out any edge cases, please
mention the rationale here.
-->

Just considered that the name change doesn't need testing.  I can confirm that the GitHub Actions VSCode plugin successfully located the new name and since it is the same code base, it just work out the box.