### PR TITLE
ci: remove beautify but enforce formatting standards via lint

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,75 +89,42 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.8
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.12
 
       - name: Install mypy & dev packages
         run: |
           python -m pip install --upgrade pip setuptools wheel
-          python -m pip install ".[dev, mypy]"
+          python -m pip install .[dev,mypy]
 
-      - name: ruff
+      - name: Lint | Ruff Evaluation
+        id: lint
         run: |
-          python -m ruff check . \
+          python -m ruff check \
             --config pyproject.toml \
             --output-format=full \
             --exit-non-zero-on-fix
 
-      - name: mypy
+      - name: Type-Check | MyPy Evaluation
+        id: type-check
+        if: ${{ always() && steps.lint.outcome != 'skipped' }}
         run: |
           python -m mypy --ignore-missing-imports semantic_release
 
-  beautify:
-    name: Beautify
-    runs-on: ubuntu-latest
-    concurrency: push
-    needs: [test, lint]
-    outputs:
-      new_sha: ${{ steps.sha.outputs.SHA }}
-    permissions:
-      id-token: write
-      contents: write
-
-    steps:
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.9
-
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Install Ruff
+      - name: Format-Check | Ruff Evaluation
+        id: format-check
+        if: ${{ always() && steps.type-check.outcome != 'skipped' }}
         run: |
-          python -m pip install --upgrade pip setuptools wheel
-          python -m pip install ".[dev]"
+          python -m ruff format --check --config pyproject.toml
 
-      - name: Format
-        run: |
-          python -m ruff format .
-
-      - name: Commit and push changes
-        uses: github-actions-x/commit@v2.9
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "style: beautify ${{ github.sha }}"
-          name: github-actions
-          email: action@github.com
-
-      - name: Get new SHA
-        id: sha
-        run: |
-          new_sha=$(git rev-parse HEAD)
-          echo "SHA=$new_sha" >> $GITHUB_OUTPUT
 
   release:
     name: Semantic Release
     runs-on: ubuntu-latest
     concurrency: push
-    needs: [test, lint, beautify]
+    needs: [test, lint]
     if: github.repository == 'python-semantic-release/python-semantic-release'
     environment:
       name: pypi

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -191,24 +191,35 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.8
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.12
 
       - name: Install mypy & dev packages
         run: |
           python -m pip install --upgrade pip setuptools wheel
-          python -m pip install ".[dev, mypy]"
+          python -m pip install .[dev,mypy]
 
-      - name: ruff
+      - name: Lint | Ruff Evaluation
+        id: lint
         run: |
-          python -m ruff check . \
+          python -m ruff check \
+            --config pyproject.toml \
             --output-format=full \
             --exit-non-zero-on-fix
 
-      - name: mypy
-        run: python -m mypy --ignore-missing-imports semantic_release
+      - name: Type-Check | MyPy Evaluation
+        id: type-check
+        if: ${{ always() && steps.lint.outcome != 'skipped' }}
+        run: |
+          python -m mypy --ignore-missing-imports semantic_release
+
+      - name: Format-Check | Ruff Evaluation
+        id: format-check
+        if: ${{ always() && steps.type-check.outcome != 'skipped' }}
+        run: |
+          python -m ruff format --check --config pyproject.toml
 
 
   commitlint:


### PR DESCRIPTION
<!--
Please do not combine multiple features or fix actions that are not
directly dependent on one another. Please open multiple PRs instead because
one may be merged while the other is denied or has requested changes. This
will slow down the process of merging the accepted changes as reviews are
also more difficult to evaluate for edge cases.
-->

## Purpose
<!-- Reason for the PR (solves an issue/problem, adds a feature, etc) -->

- Removes beautify job & enforces standards via lint job instead

## Rationale
<!-- How did you come to this conclusion as the solution? What was your reasoning? What were you trying to do? What problems did you find and avoid? -->

The main problem here is that if you merge two PRs to main too quickly (now that tests run 15min) it will cause beautify
to fail in the first job which could prevent a release if it was intended to be released.  We shouldn't be reformatting
the code automatically in the pipeline anyway (as you should limit the amount of automatic writes to the repository) so
instead use the pipeline as a check which will eliminate the concurrency problem.

## How did you test?
<!--
Please explain the methodology for how you verified this solution. It helps to
describe the primary case and the possible edge cases that you considered and
ultimately how you tested them. If you didn't rulled out any edge cases, please
mention the rationale here.
-->



## How to Verify
<!-- Please provide a list of steps to validate your solution -->

