### PR TITLE
ci: fix release on moved main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -193,10 +193,18 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      # Note: we need to checkout the repository at the workflow sha in case during the workflow
+      # the branch was updated. To keep PSR working with the configured release branches,
+      # we force a checkout of the desired release branch but at the workflow sha HEAD.
+      - name: Setup | Checkout Repository at workflow sha
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.ref_name }}
+          ref: ${{ github.sha }}
+
+      - name: Setup | Force correct release branch on workflow sha
+        run: |
+          git checkout -B ${{ github.ref_name }}
 
       - name: Python Semantic Release
         id: release

--- a/docs/automatic-releases/github-actions.rst
+++ b/docs/automatic-releases/github-actions.rst
@@ -643,9 +643,18 @@ to the GitHub Release Assets as well.
           contents: write
 
         steps:
-          - uses: actions/checkout@v4
+          # Note: we need to checkout the repository at the workflow sha in case during the workflow
+          # the branch was updated. To keep PSR working with the configured release branches,
+          # we force a checkout of the desired release branch but at the workflow sha HEAD.
+          - name: Setup | Checkout Repository at workflow sha
+            uses: actions/checkout@v4
             with:
               fetch-depth: 0
+              ref: ${{ github.sha }}
+
+          - name: Setup | Force correct release branch on workflow sha
+            run: |
+              git checkout -B ${{ github.ref_name }} ${{ github.sha }}
 
           - name: Action | Semantic Version Release
             id: release


### PR DESCRIPTION
<!--
Please do not combine multiple features or fix actions that are not
directly dependent on one another. Please open multiple PRs instead because
one may be merged while the other is denied or has requested changes. This
will slow down the process of merging the accepted changes as reviews are
also more difficult to evaluate for edge cases.
-->

## Purpose
<!-- Reason for the PR (solves an issue/problem, adds a feature, etc) -->

- Resolves release when workflows are backed up and might release on a new HEAD of main not tested
- Updated the example docs to prevent others having this issue

## Rationale
<!-- How did you come to this conclusion as the solution? What was your reasoning? What were you trying to do? What problems did you find and avoid? -->

This happened for the release of `v9.9.0`.  I merged 3 PRs within a short time and since the tests were still running I thought I prevented the actual release commit pipeline from running but then the previous pipeline released the new code anyway because it pulled from the branch when the branch had moved during the workflow execution.

## How did you test?
<!--
Please explain the methodology for how you verified this solution. It helps to
describe the primary case and the possible edge cases that you considered and
ultimately how you tested them. If you didn't rulled out any edge cases, please
mention the rationale here.
-->

Unfortunately I won't be able to test this until it happens again.  This should fix any issues as it is what I would do manually.

