### PR TITLE
ci(main-wkflow): ensure file changes are only detected from last push to current HEAD

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,11 +16,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 50 # Must at least retrieve a set of commits to compare changes
+          # primarily because of any 'Rebase and Merge' PR action in GitHub
 
       - name: Evaluate | Check specific file types for changes
         id: changed-files
         uses: tj-actions/changed-files@v45.0.2
         with:
+          base_sha: ${{ github.event.push.before }}
           files_yaml: |
             build:
               - MANIFEST.in


### PR DESCRIPTION
<!--
Please do not combine multiple features or fix actions that are not
directly dependent on one another. Please open multiple PRs instead because
one may be merged while the other is denied or has requested changes. This
will slow down the process of merging the accepted changes as reviews are
also more difficult to evaluate for edge cases.
-->

## Purpose
<!-- Reason for the PR (solves an issue/problem, adds a feature, etc) -->

- Ensures that file changes look at previous push to current head

## Rationale
<!-- How did you come to this conclusion as the solution? What was your reasoning? What were you trying to do? What problems did you find and avoid? -->

I had to review the github action again to make sure how the push event would be handled as opposed to the PR event.  I needed to make sure that first the commit would exist with the different fetch depth but then also make sure that we specified the base sha of where it was prior to this latest push.  You can't just do a fetch depth of 2 in the case you used the GitHub PR resolution `Rebase and Merge` as it may be more than 1 commit that is all pushed at once.

## How I tested

Unfortunately, not much to test other than doing it live as its hard to replicate the environment within github actions