### PR TITLE
test(repos): adjust git config in example repos to prevent autosigning

### DIFF
--- a/tests/command_line/test_main.py
+++ b/tests/command_line/test_main.py
@@ -207,6 +207,8 @@ def test_uses_default_config_when_no_config_file_found(
             config.set_value("user", "name", "semantic release testing")
             config.set_value("user", "email", "not_a_real@email.com")
             config.set_value("commit", "gpgsign", False)
+            config.set_value("tag", "gpgsign", False)
+
         repo.create_remote(name="origin", url="foo@barvcs.com:user/repo.git")
         repo.git.commit("-m", "feat: initial commit", "--allow-empty")
 

--- a/tests/fixtures/git_repo.py
+++ b/tests/fixtures/git_repo.py
@@ -231,6 +231,7 @@ def cached_example_git_project(
             config.set_value("user", "name", commit_author.name)
             config.set_value("user", "email", commit_author.email)
             config.set_value("commit", "gpgsign", False)
+            config.set_value("tag", "gpgsign", False)
 
         repo.create_remote(name="origin", url=example_git_https_url)
 


### PR DESCRIPTION
<!--
Please do not combine multiple features or fix actions that are not
directly dependent on one another. Please open multiple PRs instead because
one may be merged while the other is denied or has requested changes. This
will slow down the process of merging the accepted changes as reviews are
also more difficult to evaluate for edge cases.
-->

## Purpose
<!-- Reason for the PR (solves an issue/problem, adds a feature, etc) -->

- Update testing configurations since git also supports tag signing configs

## Rationale
<!-- How did you come to this conclusion as the solution? What was your reasoning? What were you trying to do? What problems did you find and avoid? -->

While working on another repository, I realized that you can not only set `commit.gpgsign = true` but you can also set `tag.gpgsign = true`.  We previously identified in this project during testing these cause errors not only in the CI but locally as you can't provide a password if this feature is tripped.  Therefore in all of our example environments we must turn off the `gpgsign` configuration explicitly.  

This PR adds the configuration to turn off tag signing in the local repository.

## How did you test?
<!--
Please explain the methodology for how you verified this solution. It helps to
describe the primary case and the possible edge cases that you considered and
ultimately how you tested them. If you didn't rulled out any edge cases, please
mention the rationale here.
-->

Set your global configuration to have all tags automatically signed and then try to run the test suite. Since the test suite pulls from your global git configuration as the default, the local repo will try to sign tags during the example repo construction which will cause it to fail.

## How to Verify
<!-- Please provide a list of steps to validate your solution -->

```sh
# try this prior to this PR
git config --global tag.gpgsign true
pytest
# will fail

# checkout this PR and re-run pytest which will succeed
```