### PR TITLE
ci(main-wkflow): fix unknown git user before tag creation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -196,6 +196,10 @@ jobs:
       id-token: write
       contents: write
 
+    env:
+      GITHUB_ACTIONS_AUTHOR_NAME: github-actions
+      GITHUB_ACTIONS_AUTHOR_EMAIL: actions@users.noreply.github.com
+
     steps:
       # Note: we need to checkout the repository at the workflow sha in case during the workflow
       # the branch was updated. To keep PSR working with the configured release branches,
@@ -221,6 +225,8 @@ jobs:
         if: steps.release.outputs.released == 'true' && steps.release.outputs.is_prerelease == 'false'
         env:
           FULL_VERSION_TAG: ${{ steps.release.outputs.tag }}
+          GIT_COMMITTER_NAME: ${{ env.GITHUB_ACTIONS_AUTHOR_NAME }}
+          GIT_COMMITTER_EMAIL: ${{ env.GITHUB_ACTIONS_AUTHOR_EMAIL }}
         run: |
           MINOR_VERSION_TAG="$(echo "$FULL_VERSION_TAG" | cut -d. -f1,2)"
           git tag --force --annotate "$MINOR_VERSION_TAG" "${FULL_VERSION_TAG}^{}" -m "$MINOR_VERSION_TAG"
@@ -230,6 +236,8 @@ jobs:
         if: steps.release.outputs.released == 'true' && steps.release.outputs.is_prerelease == 'false'
         env:
           FULL_VERSION_TAG: ${{ steps.release.outputs.tag }}
+          GIT_COMMITTER_NAME: ${{ env.GITHUB_ACTIONS_AUTHOR_NAME }}
+          GIT_COMMITTER_EMAIL: ${{ env.GITHUB_ACTIONS_AUTHOR_EMAIL }}
         run: |
           MAJOR_VERSION_TAG="$(echo "$FULL_VERSION_TAG" | cut -d. -f1)"
           git tag --force --annotate "$MAJOR_VERSION_TAG" "${FULL_VERSION_TAG}^{}" -m "$MAJOR_VERSION_TAG"


### PR DESCRIPTION
<!--
Please do not combine multiple features or fix actions that are not
directly dependent on one another. Please open multiple PRs instead because
one may be merged while the other is denied or has requested changes. This
will slow down the process of merging the accepted changes as reviews are
also more difficult to evaluate for edge cases.
-->

## Purpose
<!-- Reason for the PR (solves an issue/problem, adds a feature, etc) -->

- Correct the mistake I had releasing v9.10.0 where it crashed after semantic-release was completed

## Rationale
<!-- How did you come to this conclusion as the solution? What was your reasoning? What were you trying to do? What problems did you find and avoid? -->

I wanted to have some git commands run after the release to create some moving short reference tags and ends up in the CI git is not configured. Because of that when I tried to do a `git tag` it failed and complained about no name or email.  This corrects that issue by setting the environment variable for the committer information.  I tested this on my own fork and it released successfully.  Oddly enough, I tested just the GIT_AUTHOR_{NAME,EMAIL} vars and it fails but if you have GIT_COMMITTER_{NAME,EMAIL} by itself it is fine.

## How did you test?
<!--
Please explain the methodology for how you verified this solution. It helps to
describe the primary case and the possible edge cases that you considered and
ultimately how you tested them. If you didn't rulled out any edge cases, please
mention the rationale here.
-->

Ran multiple releases on my fork as I could reverse it immediately. I probably should of done that when I initially made the change instead of hoping it would work. ( I was confident in my commands but I forgot about the non-configured git).
