### PR TITLE
fix: Validate branch config regex matches and allow plain wildcards

### DIFF
--- a/semantic_release/cli/config.py
+++ b/semantic_release/cli/config.py
@@ -143,6 +143,19 @@ class BranchConfig(BaseModel):
     prerelease_token: str = "rc"  # noqa: S105
     prerelease: bool = False
 
+    @field_validator("match", mode="after")
+    @classmethod
+    def validate_match(cls, match: str) -> str:
+        # Allow the special case of a plain wildcard although it's not a valid regex
+        if match == "*":
+            return ".*"
+
+        try:
+            re.compile(match)
+        except re.error as err:
+            raise ValueError(f"Invalid regex {match!r}") from err
+        return match
+
 
 class RemoteConfig(BaseModel):
     name: str = "origin"

--- a/tests/unit/semantic_release/cli/test_config.py
+++ b/tests/unit/semantic_release/cli/test_config.py
@@ -10,6 +10,7 @@ from pydantic import RootModel, ValidationError
 
 import semantic_release
 from semantic_release.cli.config import (
+    BranchConfig,
     GlobalCommandLineOptions,
     HvcsClient,
     RawConfig,
@@ -277,4 +278,28 @@ def test_load_invalid_custom_parser(
         RuntimeContext.from_raw_config(
             RawConfig.model_validate(load_raw_config_file(example_pyproject_toml)),
             global_cli_options=GlobalCommandLineOptions(),
+        )
+
+
+def test_branch_config_with_plain_wildcard():
+    branch_config = BranchConfig(
+        match="*",
+    )
+    assert branch_config.match == ".*"
+
+
+@pytest.mark.parametrize(
+    "invalid_regex",
+    [
+        "*abc",
+        "[a-z",
+        "(.+",
+        "{2,3}",
+        "a{3,2}",
+    ],
+)
+def test_branch_config_with_invalid_regex(invalid_regex: str):
+    with pytest.raises(ValidationError):
+        BranchConfig(
+            match=invalid_regex,
         )


### PR DESCRIPTION
<!--
Please do not combine multiple features or fix actions that are not
directly dependent on one another. Please open multiple PRs instead because
one may be merged while the other is denied or has requested changes. This
will slow down the process of merging the accepted changes as reviews are
also more difficult to evaluate for edge cases.
-->

## Purpose
<!-- Reason for the PR (solves an issue/problem, adds a feature, etc) -->
Resolves #931 

No regex validation is currently done in branch configs, causing an obscure error from the `re` library when the regex fails to compile. This is not obvious to the user what the error is, nor does it give any indication of how to fix it.

This is especially a problem when `match="*"`, which a user would expect to match all branches, but fails to match anything and throws this error because the plain wildcard is not a valid regex.


## Rationale
<!-- How did you come to this conclusion as the solution? What was your reasoning? What were you trying to do? What problems did you find and avoid? -->

Pydantic field validation is often the correct place to validate inputs because it keeps logic simpler in other places. 

Validating a regex is easiest by trying to compile it and catching any exceptions, hence that check.

The plain wild card `"*"` is common enough an idiom where although it is not a valid regex, its intent is clear, and supporting it is simple, by adapting it into the correct regex `.*`. Additionally, in #931, some appetite for this change is expressed.


## How did you test?
<!--
Please explain the methodology for how you verified this solution. It helps to
describe the primary case and the possible edge cases that you considered and
ultimately how you tested them. If you didn't rulled out any edge cases, please
mention the rationale here.
-->

I added two unit tests for these two validations. One where `*` is turned into `.*`, and one on a series of invalid regexes (other than the plain wildcard).

## How to Verify
<!-- Please provide a list of steps to validate your solution -->
This can be verified by modifying a branch configuration in `pyproject.toml` to `match=*` or to an invalid regex.
