### PR TITLE
fix(changelog): ignore commit exclusion when a commit causes a version bump

### DIFF
--- a/semantic_release/cli/commands/main.py
+++ b/semantic_release/cli/commands/main.py
@@ -19,7 +19,7 @@ from semantic_release.cli.util import rprint
 #     pass
 
 
-FORMAT = "[%(name)s] %(levelname)s %(module)s.%(funcName)s: %(message)s"
+FORMAT = "[%(module)s.%(funcName)s] %(message)s"
 
 
 class Cli(click.MultiCommand):

--- a/semantic_release/commit_parser/angular.py
+++ b/semantic_release/commit_parser/angular.py
@@ -19,11 +19,11 @@ from semantic_release.enums import LevelBump
 if TYPE_CHECKING:
     from git.objects.commit import Commit
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def _logged_parse_error(commit: Commit, error: str) -> ParseError:
-    log.debug(error)
+    logger.debug(error)
     return ParseError(commit, error=error)
 
 
@@ -131,12 +131,15 @@ class AngularCommitParser(CommitParser[ParseResult, AngularParserOptions]):
             level_bump = LevelBump.PATCH
         else:
             level_bump = self.options.default_bump_level
-            log.debug(
+            logger.debug(
                 "commit %s introduces a level bump of %s due to the default_bump_level",
-                commit.hexsha,
+                commit.hexsha[:8],
                 level_bump,
             )
-        log.debug("commit %s introduces a %s level_bump", commit.hexsha, level_bump)
+
+        logger.debug(
+            "commit %s introduces a %s level_bump", commit.hexsha[:8], level_bump
+        )
 
         return ParsedCommit(
             bump=level_bump,

--- a/semantic_release/commit_parser/emoji.py
+++ b/semantic_release/commit_parser/emoji.py
@@ -89,6 +89,13 @@ class EmojiCommitParser(CommitParser[ParseResult, EmojiParserOptions]):
             level_bump = LevelBump.MINOR
         elif primary_emoji in self.options.patch_tags:
             level_bump = LevelBump.PATCH
+        else:
+            level_bump = self.options.default_bump_level
+            logger.debug(
+                "commit %s introduces a level bump of %s due to the default_bump_level",
+                commit.hexsha[:8],
+                level_bump,
+            )
 
         # All emojis will remain part of the returned description
         descriptions = parse_paragraphs(message)

--- a/semantic_release/commit_parser/emoji.py
+++ b/semantic_release/commit_parser/emoji.py
@@ -97,6 +97,10 @@ class EmojiCommitParser(CommitParser[ParseResult, EmojiParserOptions]):
                 level_bump,
             )
 
+        logger.debug(
+            "commit %s introduces a %s level_bump", commit.hexsha[:8], level_bump
+        )
+
         # All emojis will remain part of the returned description
         descriptions = parse_paragraphs(message)
         return ParsedCommit(

--- a/semantic_release/commit_parser/scipy.py
+++ b/semantic_release/commit_parser/scipy.py
@@ -59,11 +59,11 @@ from semantic_release.enums import LevelBump
 if TYPE_CHECKING:
     from git.objects.commit import Commit
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def _logged_parse_error(commit: Commit, error: str) -> ParseError:
-    log.debug(error)
+    logger.debug(error)
     return ParseError(commit, error=error)
 
 
@@ -165,17 +165,19 @@ class ScipyCommitParser(CommitParser[ParseResult, ScipyParserOptions]):
                 level_bump = self.options.tag_to_level.get(
                     tag, self.options.default_level_bump
                 )
-                log.debug(
-                    "commit %s introduces a %s level_bump", commit.hexsha, level_bump
+                logger.debug(
+                    "commit %s introduces a %s level_bump",
+                    commit.hexsha[:8],
+                    level_bump,
                 )
                 break
         else:
             # some commits may not have a tag, e.g. if they belong to a PR that
             # wasn't squashed (for maintainability) ignore them
             section, level_bump = "None", self.options.default_level_bump
-            log.debug(
-                "commit %s introduces a level bump of %s due to the default_bump_level",
-                commit.hexsha,
+            logger.debug(
+                "commit %s introduces a level bump of %s due to the default bump level",
+                commit.hexsha[:8],
                 level_bump,
             )
 
@@ -185,9 +187,9 @@ class ScipyCommitParser(CommitParser[ParseResult, ScipyParserOptions]):
         ]
         if migration_instructions:
             level_bump = LevelBump.MAJOR
-            log.debug(
-                "commit %s upgraded to a %s level_bump due to migration_instructions",
-                commit.hexsha,
+            logger.debug(
+                "commit %s upgraded to a %s level bump due to included migration instructions",
+                commit.hexsha[:8],
                 level_bump,
             )
 

--- a/semantic_release/commit_parser/tag.py
+++ b/semantic_release/commit_parser/tag.py
@@ -11,7 +11,7 @@ from semantic_release.commit_parser.token import ParsedCommit, ParseError, Parse
 from semantic_release.commit_parser.util import breaking_re, parse_paragraphs
 from semantic_release.enums import LevelBump
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 re_parser = re.compile(r"(?P<subject>[^\n]+)" + r"(:?\n\n(?P<text>.+))?", re.DOTALL)
 
@@ -23,7 +23,7 @@ class TagParserOptions(ParserOptions):
 
 
 def _logged_parse_error(commit: Commit, error: str) -> ParseError:
-    log.debug(error)
+    logger.debug(error)
     return ParseError(commit, error=error)
 
 
@@ -87,11 +87,15 @@ class TagCommitParser(CommitParser[ParseResult, TagParserOptions]):
         if breaking_descriptions:
             level = "breaking"
             level_bump = LevelBump.MAJOR
-            log.debug(
-                "commit %s upgraded to a %s level_bump due to breaking_descriptions",
-                commit.hexsha,
+            logger.debug(
+                "commit %s upgraded to a %s level_bump due to included breaking descriptions",
+                commit.hexsha[:8],
                 level_bump,
             )
+
+        logger.debug(
+            "commit %s introduces a %s level_bump", commit.hexsha[:8], level_bump
+        )
 
         return ParsedCommit(
             bump=level_bump,


### PR DESCRIPTION
<!--
Please do not combine multiple features or fix actions that are not
directly dependent on one another. Please open multiple PRs instead because
one may be merged while the other is denied or has requested changes. This
will slow down the process of merging the accepted changes as reviews are
also more difficult to evaluate for edge cases.
-->

## Purpose
<!-- Reason for the PR (solves an issue/problem, adds a feature, etc) -->

- Forces any commits that cause a version bump to always be included in the changelog

## Rationale
<!-- How did you come to this conclusion as the solution? What was your reasoning? What were you trying to do? What problems did you find and avoid? -->

This seems a bit counter intuitive as it goes against what the user has configured but it makes sense to avoid the situation where their is a legitimate breaking change in a different commit type that generally is ignored but because it is breaking then it must be included so that the changelog is not empty.  Example: deprecating support for an older python version.  Generally I categorized that under `refactor` however generally I don't show that in the changelog and it would be filtered out however it came with a breaking change which causes the version bump.  This change forces it to be included otherwise the changelog was empty for the version bump which is definitely not correct. 

At first I only considered breaking change types however I realized that because the types are configurable we should just measure whether or not the commit caused the level bump instead.  Our situation could of happened on a smaller scale rather than just a breaking change.

## How did you test?
<!--
Please explain the methodology for how you verified this solution. It helps to
describe the primary case and the possible edge cases that you considered and
ultimately how you tested them. If you didn't rulled out any edge cases, please
mention the rationale here.
-->

Added an integration test that evaluated the changelog after a fix commit was deliberately added as an ignore pattern.

