### PR TITLE
chore(stalebot): add `info` tag that is exempt from being stale or needing updates

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -37,7 +37,7 @@ jobs:
           stale-issue-label: stale
           days-before-issue-stale: ${{ env.STALE_ISSUE_WARNING_DAYS }}
           days-before-issue-close: ${{ env.STALE_ISSUE_CLOSURE_DAYS }}
-          exempt-issue-labels: confirmed, help-wanted
+          exempt-issue-labels: confirmed, help-wanted, info
           stale-issue-message: >
             This issue is stale because it has not been confirmed or planned by the maintainers
             and has been open ${{ env.STALE_ISSUE_WARNING_DAYS }} days with no recent activity.


### PR DESCRIPTION
<!--
Please do not combine multiple features or fix actions that are not
directly dependent on one another. Please open multiple PRs instead because
one may be merged while the other is denied or has requested changes. This
will slow down the process of merging the accepted changes as reviews are
also more difficult to evaluate for edge cases.
-->

## Purpose
<!-- Reason for the PR (solves an issue/problem, adds a feature, etc) -->

- Add an additional tag that is exempt from stalebot stale labels or needing updates as `confirmed` doesn't make sense for these

## Rationale
<!-- How did you come to this conclusion as the solution? What was your reasoning? What were you trying to do? What problems did you find and avoid? -->

Issues like the next breaking version or long term issues/announcements (like python 3.7/3.8 deprecation annoucements) should not be closed for being stale or require periodic updates.  They will last for a long time likely more than the 2-3 months allotted in those categories.
