### PR TITLE
ci(cicd-wkflow): separate deployment from release job to enable job re-runs

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -85,15 +85,10 @@ jobs:
     name: Semantic Release
     runs-on: ubuntu-latest
     concurrency: push
-    needs:
-      - validate
-    if: ${{ needs.validate.outputs.new-release-detected && github.repository == 'python-semantic-release/python-semantic-release' }}
-    environment:
-      name: pypi
-      url: https://pypi.org/project/python-semantic-release/
+    needs: validate
+    if: ${{ needs.validate.outputs.new-release-detected == 'true' }}
+
     permissions:
-      # https://docs.github.com/en/rest/overview/permissions-required-for-github-apps?apiVersion=2022-11-28#metadata
-      id-token: write
       contents: write
 
     env:
@@ -121,7 +116,7 @@ jobs:
           name: ${{ needs.validate.outputs.distribution-artifacts }}
           path: dist
 
-      - name: Python Semantic Release
+      - name: Release | Python Semantic Release
         id: release
         uses: ./
         with:
@@ -129,7 +124,13 @@ jobs:
           root_options: "-v"
           build: false
 
-      - name: Update Minor Release Tag Reference
+      - name: Release | Add distribution artifacts to GitHub Release Assets
+        uses: python-semantic-release/publish-action@v9.12.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ steps.release.outputs.tag }}
+
+      - name: Release | Update Minor Release Tag Reference
         if: steps.release.outputs.released == 'true' && steps.release.outputs.is_prerelease == 'false'
         env:
           FULL_VERSION_TAG: ${{ steps.release.outputs.tag }}
@@ -140,7 +141,7 @@ jobs:
           git tag --force --annotate "$MINOR_VERSION_TAG" "${FULL_VERSION_TAG}^{}" -m "$MINOR_VERSION_TAG"
           git push -u origin "$MINOR_VERSION_TAG" --force
 
-      - name: Update Major Release Tag Reference
+      - name: Release | Update Major Release Tag Reference
         if: steps.release.outputs.released == 'true' && steps.release.outputs.is_prerelease == 'false'
         env:
           FULL_VERSION_TAG: ${{ steps.release.outputs.tag }}
@@ -151,22 +152,51 @@ jobs:
           git tag --force --annotate "$MAJOR_VERSION_TAG" "${FULL_VERSION_TAG}^{}" -m "$MAJOR_VERSION_TAG"
           git push -u origin "$MAJOR_VERSION_TAG" --force
 
+    outputs:
+      released: ${{ steps.release.outputs.released }}
+      tag: ${{ steps.release.outputs.tag }}
+
+
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    if: ${{ needs.release.outputs.released == 'true' && github.repository == 'python-semantic-release/python-semantic-release' }}
+    needs:
+      - validate
+      - release
+
+    environment:
+      name: pypi
+      url: https://pypi.org/project/python-semantic-release/
+
+    permissions:
+      # https://docs.github.com/en/rest/overview/permissions-required-for-github-apps?apiVersion=2022-11-28#metadata
+      id-token: write  # needed for PyPI upload
+
+    steps:
+      # Note: we need to checkout the repository at the workflow sha in case during the workflow
+      # the branch was updated. To keep PSR working with the configured release branches,
+      # we force a checkout of the desired release branch but at the workflow sha HEAD.
+      - name: Setup | Checkout Repository at workflow sha
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          ref: ${{ github.sha }}
+
+      - name: Setup | Force correct release branch on workflow sha
+        run: |
+          git checkout -B ${{ github.ref_name }}
+
+      - name: Setup | Download Build Artifacts
+        uses: actions/download-artifact@v4
+        id: artifact-download
+        with:
+          name: ${{ needs.validate.outputs.distribution-artifacts }}
+          path: dist
+
       # see https://docs.pypi.org/trusted-publishers/
       - name: Publish package distributions to PyPI
         id: pypi-publish
-        # NOTE: DO NOT wrap the conditional in ${{ }} as it will always evaluate to true.
-        # See https://github.com/actions/runner/issues/1173
-        if: steps.release.outputs.released == 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           verbose: true
-
-      - name: Publish package distributions to GitHub Releases
-        id: github-release
-        # NOTE: DO NOT wrap the conditional in ${{ }} as it will always evaluate to true.
-        # See https://github.com/actions/runner/issues/1173
-        if: steps.release.outputs.released == 'true'
-        uses: python-semantic-release/publish-action@v9.12.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ steps.release.outputs.tag }}


### PR DESCRIPTION
<!--
Please do not combine multiple features or fix actions that are not
directly dependent on one another. Please open multiple PRs instead because
one may be merged while the other is denied or has requested changes. This
will slow down the process of merging the accepted changes as reviews are
also more difficult to evaluate for edge cases.
-->

## Purpose
<!-- Reason for the PR (solves an issue/problem, adds a feature, etc) -->

- Separate out deployment from release jobs in pipeline

## Rationale
<!-- How did you come to this conclusion as the solution? What was your reasoning? What were you trying to do? What problems did you find and avoid? -->

It is better design to have a separate deploy job rather than one job to release and deploy because if your deployment fails for some reason (auth token or other mishap) then you have a release tag on the repository but no distribution artifact. Normally you might just update the auth token but this time you have to reverse most of the release job to do it again rather than just re-running the deployment.  I have also found this reigns true if you have multiple deployment locations. You should have each deployment location as a separate job so they can independently fail (and not prevent others) and you can re-deploy (via job re-run) them individually if needed.  It can be difficult to republish as most registries will fail if it has already an existing artifact of the same version.

## How did you test?
<!--
Please explain the methodology for how you verified this solution. It helps to
describe the primary case and the possible edge cases that you considered and
ultimately how you tested them. If you didn't rulled out any edge cases, please
mention the rationale here.
-->



## How to Verify
<!-- Please provide a list of steps to validate your solution -->

