### PR TITLE
Fix/handle tracebacks gracefully

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,8 @@ dependencies = [
 ]
 
 [project.scripts]
-semantic-release = "semantic_release.cli.commands.main:main"
-psr = "semantic_release.cli.commands.main:main"
+semantic-release = "semantic_release.__main__:main"
+psr = "semantic_release.__main__:main"
 
 [project.urls]
 changelog = "https://github.com/python-semantic-release/python-semantic-release/blob/master/CHANGELOG.md"

--- a/src/semantic_release/__main__.py
+++ b/src/semantic_release/__main__.py
@@ -1,6 +1,42 @@
-import sys
+"""Entrypoint for the `semantic-release` module."""
+# ruff: noqa: T201, print statements are fine here as this is for cli entry only
 
-from semantic_release.cli.commands.main import main
+from __future__ import annotations
+
+import sys
+from traceback import format_exception
+
+from semantic_release import globals
+from semantic_release.cli.commands.main import main as cli_main
+
+
+def main() -> None:
+    try:
+        cli_main(args=sys.argv[1:])
+        print("semantic-release completed successfully.", file=sys.stderr)
+    except KeyboardInterrupt:
+        print("\n-- User Abort! --", file=sys.stderr)
+        sys.exit(127)
+    except Exception as err:  # noqa: BLE001, graceful error handling across application
+        if globals.debug:
+            print(f"{err.__class__.__name__}: {err}\n", file=sys.stderr)
+            etype, value, traceback = sys.exc_info()
+            print(
+                str.join(
+                    "",
+                    format_exception(
+                        etype,
+                        value,
+                        traceback,
+                        limit=None,
+                        chain=True,
+                    )[:-1],
+                ),
+                file=sys.stderr,
+            )
+        print(f"::ERROR:: {err}", file=sys.stderr)
+        sys.exit(1)
+
 
 if __name__ == "__main__":
-    main(args=sys.argv[1:])
+    main()

--- a/src/semantic_release/cli/commands/main.py
+++ b/src/semantic_release/cli/commands/main.py
@@ -10,6 +10,7 @@ from rich.console import Console
 from rich.logging import RichHandler
 
 import semantic_release
+from semantic_release import globals
 from semantic_release.cli.cli_context import CliContextObj
 from semantic_release.cli.config import GlobalCommandLineOptions
 from semantic_release.cli.const import DEFAULT_CONFIG_FILE
@@ -121,6 +122,9 @@ def main(
 
     logger = logging.getLogger(__name__)
     logger.debug("logging level set to: %s", logging.getLevelName(log_level))
+
+    if log_level == logging.DEBUG:
+        globals.debug = True
 
     if noop:
         rprint(

--- a/src/semantic_release/globals.py
+++ b/src/semantic_release/globals.py
@@ -1,0 +1,6 @@
+"""Semantic Release Global Variables."""
+
+from __future__ import annotations
+
+debug: bool = False
+"""bool: Enable debug level logging and runtime actions."""


### PR DESCRIPTION
<!--
Please do not combine multiple features or fix actions that are not
directly dependent on one another. Please open multiple PRs instead because
one may be merged while the other is denied or has requested changes. This
will slow down the process of merging the accepted changes as reviews are
also more difficult to evaluate for edge cases.
-->

## Purpose
<!-- Reason for the PR (solves an issue/problem, adds a feature, etc) -->

- Improve the default exit & exception handling

## Rationale
<!-- How did you come to this conclusion as the solution? What was your reasoning? What were you trying to do? What problems did you find and avoid? -->

To improve the user experience, hide the default python behavior of barfing a massive traceback to the user for uncaught exceptions.  Instead provide just the basic error message unless they request it via the (`-vv`) very verbose logging mode.

With this ensure that the module execution entrypoint and the automatically installed entrypoints go to the same start point of the project.

## How did you test?
<!--
Please explain the methodology for how you verified this solution. It helps to
describe the primary case and the possible edge cases that you considered and
ultimately how you tested them. If you didn't rulled out any edge cases, please
mention the rationale here.
-->

This is was primarily done manually. I would throw an exception in the main function of click and be able to see the output change based on if I used very verbose mode versus normal mode.

