### PR TITLE
fix/parser issue urls

### DIFF
--- a/docs/changelog_templates.rst
+++ b/docs/changelog_templates.rst
@@ -694,10 +694,12 @@ The filters provided vary based on the VCS configured and available features:
 
       https://example.com/example/repo/compare/v1.0.0...v1.1.0
 
-* ``issue_url (Callable[[IssueNumStr | IssueNumInt], UrlStr])``: given an issue number, return
-  a URL to the issue on the remote vcs.
+* ``issue_url (Callable[[IssueNumStr | IssueNumInt], UrlStr])``: given an issue
+  number, return a URL to the issue on the remote vcs. In v9.12.2, this filter
+  was updated to handle a string that has leading prefix symbols (ex. ``#29``)
+  and will strip the prefix before generating the URL.
 
-  *Introduced in v9.6.0.*
+  *Introduced in v9.6.0, Modified in v9.12.2.*
 
   **Example Usage:**
 
@@ -712,9 +714,11 @@ The filters provided vary based on the VCS configured and available features:
 * ``merge_request_url (Callable[[MergeReqStr | MergeReqInt], UrlStr])``: given a
   merge request number, return a URL to the merge request in the remote. This is
   an alias to the ``pull_request_url`` but only available for the VCS that uses
-  the merge request terminology.
+  the merge request terminology. In v9.12.2, this filter was updated to handle
+  a string that has leading prefix symbols (ex. ``#29``) and will strip the prefix
+  before generating the URL.
 
-  *Introduced in v9.6.0.*
+  *Introduced in v9.6.0, Modified in v9.12.2.*
 
   **Example Usage:**
 
@@ -729,9 +733,11 @@ The filters provided vary based on the VCS configured and available features:
 * ``pull_request_url (Callable[[PullReqStr | PullReqInt], UrlStr])``: given a pull
   request number, return a URL to the pull request in the remote. For remote vcs'
   that use merge request terminology, this filter is an alias to the
-  ``merge_request_url`` filter function.
+  ``merge_request_url`` filter function. In v9.12.2, this filter was updated to
+  handle a string that has leading prefix symbols (ex. ``#29``) and will strip
+  the prefix before generating the URL.
 
-  *Introduced in v9.6.0.*
+  *Introduced in v9.6.0, Modified in v9.12.2.*
 
   **Example Usage:**
 

--- a/src/semantic_release/hvcs/bitbucket.py
+++ b/src/semantic_release/hvcs/bitbucket.py
@@ -202,13 +202,14 @@ class Bitbucket(RemoteHvcsBase):
         return self.create_repo_url(repo_path=f"/commits/{commit_hash}")
 
     def pull_request_url(self, pr_number: str | int) -> str:
-        if isinstance(pr_number, str):
-            # Strips off any character prefix like '#' that usually exists
-            if match := regexp(r'(\d+)$').search(pr_number):
-                try:
-                    pr_number = int(match.group(1))
-                except ValueError:
-                    return ""
+        # Strips off any character prefix like '#' that usually exists
+        if isinstance(pr_number, str) and (
+            match := regexp(r"(\d+)$").search(pr_number)
+        ):
+            try:
+                pr_number = int(match.group(1))
+            except ValueError:
+                return ""
 
         if isinstance(pr_number, int):
             return self.create_repo_url(repo_path=f"/pull-requests/{pr_number}")

--- a/src/semantic_release/hvcs/gitea.py
+++ b/src/semantic_release/hvcs/gitea.py
@@ -6,6 +6,7 @@ import glob
 import logging
 import os
 from pathlib import PurePosixPath
+from re import compile as regexp
 from typing import TYPE_CHECKING
 
 from requests import HTTPError, JSONDecodeError
@@ -350,7 +351,18 @@ class Gitea(RemoteHvcsBase):
         return self.create_repo_url(repo_path=f"/commit/{commit_hash}")
 
     def issue_url(self, issue_num: str | int) -> str:
-        return self.create_repo_url(repo_path=f"/issues/{issue_num}")
+        if isinstance(issue_num, str):
+            # Strips off any character prefix like '#' that usually exists
+            if match := regexp(r'(\d+)$').search(issue_num):
+                try:
+                    issue_num = int(match.group(1))
+                except ValueError:
+                    return ""
+
+        if isinstance(issue_num, int):
+            return self.create_repo_url(repo_path=f"/issues/{issue_num}")
+
+        return ""
 
     def pull_request_url(self, pr_number: str | int) -> str:
         return self.create_repo_url(repo_path=f"/pulls/{pr_number}")

--- a/src/semantic_release/hvcs/gitea.py
+++ b/src/semantic_release/hvcs/gitea.py
@@ -351,13 +351,14 @@ class Gitea(RemoteHvcsBase):
         return self.create_repo_url(repo_path=f"/commit/{commit_hash}")
 
     def issue_url(self, issue_num: str | int) -> str:
-        if isinstance(issue_num, str):
-            # Strips off any character prefix like '#' that usually exists
-            if match := regexp(r'(\d+)$').search(issue_num):
-                try:
-                    issue_num = int(match.group(1))
-                except ValueError:
-                    return ""
+        # Strips off any character prefix like '#' that usually exists
+        if isinstance(issue_num, str) and (
+            match := regexp(r"(\d+)$").search(issue_num)
+        ):
+            try:
+                issue_num = int(match.group(1))
+            except ValueError:
+                return ""
 
         if isinstance(issue_num, int):
             return self.create_repo_url(repo_path=f"/issues/{issue_num}")
@@ -365,13 +366,14 @@ class Gitea(RemoteHvcsBase):
         return ""
 
     def pull_request_url(self, pr_number: str | int) -> str:
-        if isinstance(pr_number, str):
-            # Strips off any character prefix like '#' that usually exists
-            if match := regexp(r'(\d+)$').search(pr_number):
-                try:
-                    pr_number = int(match.group(1))
-                except ValueError:
-                    return ""
+        # Strips off any character prefix like '#' that usually exists
+        if isinstance(pr_number, str) and (
+            match := regexp(r"(\d+)$").search(pr_number)
+        ):
+            try:
+                pr_number = int(match.group(1))
+            except ValueError:
+                return ""
 
         if isinstance(pr_number, int):
             return self.create_repo_url(repo_path=f"/pulls/{pr_number}")

--- a/src/semantic_release/hvcs/gitea.py
+++ b/src/semantic_release/hvcs/gitea.py
@@ -365,7 +365,18 @@ class Gitea(RemoteHvcsBase):
         return ""
 
     def pull_request_url(self, pr_number: str | int) -> str:
-        return self.create_repo_url(repo_path=f"/pulls/{pr_number}")
+        if isinstance(pr_number, str):
+            # Strips off any character prefix like '#' that usually exists
+            if match := regexp(r'(\d+)$').search(pr_number):
+                try:
+                    pr_number = int(match.group(1))
+                except ValueError:
+                    return ""
+
+        if isinstance(pr_number, int):
+            return self.create_repo_url(repo_path=f"/pulls/{pr_number}")
+
+        return ""
 
     def get_changelog_context_filters(self) -> tuple[Callable[..., Any], ...]:
         return (

--- a/src/semantic_release/hvcs/github.py
+++ b/src/semantic_release/hvcs/github.py
@@ -516,7 +516,18 @@ class Github(RemoteHvcsBase):
         return ""
 
     def pull_request_url(self, pr_number: str | int) -> str:
-        return self.create_repo_url(repo_path=f"/pull/{pr_number}")
+        if isinstance(pr_number, str):
+            # Strips off any character prefix like '#' that usually exists
+            if match := regexp(r'(\d+)$').search(pr_number):
+                try:
+                    pr_number = int(match.group(1))
+                except ValueError:
+                    return ""
+
+        if isinstance(pr_number, int):
+            return self.create_repo_url(repo_path=f"/pull/{pr_number}")
+
+        return ""
 
     def get_changelog_context_filters(self) -> tuple[Callable[..., Any], ...]:
         return (

--- a/src/semantic_release/hvcs/github.py
+++ b/src/semantic_release/hvcs/github.py
@@ -8,6 +8,7 @@ import mimetypes
 import os
 from functools import lru_cache
 from pathlib import PurePosixPath
+from re import compile as regexp
 from typing import TYPE_CHECKING
 
 from requests import HTTPError, JSONDecodeError
@@ -501,7 +502,18 @@ class Github(RemoteHvcsBase):
         return self.create_repo_url(repo_path=f"/commit/{commit_hash}")
 
     def issue_url(self, issue_num: str | int) -> str:
-        return self.create_repo_url(repo_path=f"/issues/{issue_num}")
+        if isinstance(issue_num, str):
+            # Strips off any character prefix like '#' that usually exists
+            if match := regexp(r'(\d+)$').search(issue_num):
+                try:
+                    issue_num = int(match.group(1))
+                except ValueError:
+                    return ""
+
+        if isinstance(issue_num, int):
+            return self.create_repo_url(repo_path=f"/issues/{issue_num}")
+
+        return ""
 
     def pull_request_url(self, pr_number: str | int) -> str:
         return self.create_repo_url(repo_path=f"/pull/{pr_number}")

--- a/src/semantic_release/hvcs/github.py
+++ b/src/semantic_release/hvcs/github.py
@@ -502,13 +502,14 @@ class Github(RemoteHvcsBase):
         return self.create_repo_url(repo_path=f"/commit/{commit_hash}")
 
     def issue_url(self, issue_num: str | int) -> str:
-        if isinstance(issue_num, str):
-            # Strips off any character prefix like '#' that usually exists
-            if match := regexp(r'(\d+)$').search(issue_num):
-                try:
-                    issue_num = int(match.group(1))
-                except ValueError:
-                    return ""
+        # Strips off any character prefix like '#' that usually exists
+        if isinstance(issue_num, str) and (
+            match := regexp(r"(\d+)$").search(issue_num)
+        ):
+            try:
+                issue_num = int(match.group(1))
+            except ValueError:
+                return ""
 
         if isinstance(issue_num, int):
             return self.create_repo_url(repo_path=f"/issues/{issue_num}")
@@ -516,13 +517,14 @@ class Github(RemoteHvcsBase):
         return ""
 
     def pull_request_url(self, pr_number: str | int) -> str:
-        if isinstance(pr_number, str):
-            # Strips off any character prefix like '#' that usually exists
-            if match := regexp(r'(\d+)$').search(pr_number):
-                try:
-                    pr_number = int(match.group(1))
-                except ValueError:
-                    return ""
+        # Strips off any character prefix like '#' that usually exists
+        if isinstance(pr_number, str) and (
+            match := regexp(r"(\d+)$").search(pr_number)
+        ):
+            try:
+                pr_number = int(match.group(1))
+            except ValueError:
+                return ""
 
         if isinstance(pr_number, int):
             return self.create_repo_url(repo_path=f"/pull/{pr_number}")

--- a/src/semantic_release/hvcs/gitlab.py
+++ b/src/semantic_release/hvcs/gitlab.py
@@ -241,13 +241,14 @@ class Gitlab(RemoteHvcsBase):
         return self.create_repo_url(repo_path=f"/-/commit/{commit_hash}")
 
     def issue_url(self, issue_num: str | int) -> str:
-        if isinstance(issue_num, str):
-            # Strips off any character prefix like '#' that usually exists
-            if match := regexp(r'(\d+)$').search(issue_num):
-                try:
-                    issue_num = int(match.group(1))
-                except ValueError:
-                    return ""
+        # Strips off any character prefix like '#' that usually exists
+        if isinstance(issue_num, str) and (
+            match := regexp(r"(\d+)$").search(issue_num)
+        ):
+            try:
+                issue_num = int(match.group(1))
+            except ValueError:
+                return ""
 
         if isinstance(issue_num, int):
             return self.create_repo_url(repo_path=f"/-/issues/{issue_num}")
@@ -255,13 +256,14 @@ class Gitlab(RemoteHvcsBase):
         return ""
 
     def merge_request_url(self, mr_number: str | int) -> str:
-        if isinstance(mr_number, str):
-            # Strips off any character prefix like '!' that usually exists
-            if match := regexp(r'(\d+)$').search(mr_number):
-                try:
-                    mr_number = int(match.group(1))
-                except ValueError:
-                    return ""
+        # Strips off any character prefix like '!' that usually exists
+        if isinstance(mr_number, str) and (
+            match := regexp(r"(\d+)$").search(mr_number)
+        ):
+            try:
+                mr_number = int(match.group(1))
+            except ValueError:
+                return ""
 
         if isinstance(mr_number, int):
             return self.create_repo_url(repo_path=f"/-/merge_requests/{mr_number}")

--- a/src/semantic_release/hvcs/gitlab.py
+++ b/src/semantic_release/hvcs/gitlab.py
@@ -255,10 +255,20 @@ class Gitlab(RemoteHvcsBase):
         return ""
 
     def merge_request_url(self, mr_number: str | int) -> str:
-        return self.create_repo_url(repo_path=f"/-/merge_requests/{mr_number}")
+        if isinstance(mr_number, str):
+            # Strips off any character prefix like '!' that usually exists
+            if match := regexp(r'(\d+)$').search(mr_number):
+                try:
+                    mr_number = int(match.group(1))
+                except ValueError:
+                    return ""
+
+        if isinstance(mr_number, int):
+            return self.create_repo_url(repo_path=f"/-/merge_requests/{mr_number}")
+
+        return ""
 
     def pull_request_url(self, pr_number: str | int) -> str:
-        # TODO: deprecate in v11, add warning in v10
         return self.merge_request_url(mr_number=pr_number)
 
     def upload_dists(self, tag: str, dist_glob: str) -> int:

--- a/src/semantic_release/hvcs/gitlab.py
+++ b/src/semantic_release/hvcs/gitlab.py
@@ -6,6 +6,7 @@ import logging
 import os
 from functools import lru_cache
 from pathlib import PurePosixPath
+from re import compile as regexp
 from typing import TYPE_CHECKING
 
 import gitlab
@@ -239,8 +240,19 @@ class Gitlab(RemoteHvcsBase):
     def commit_hash_url(self, commit_hash: str) -> str:
         return self.create_repo_url(repo_path=f"/-/commit/{commit_hash}")
 
-    def issue_url(self, issue_number: str | int) -> str:
-        return self.create_repo_url(repo_path=f"/-/issues/{issue_number}")
+    def issue_url(self, issue_num: str | int) -> str:
+        if isinstance(issue_num, str):
+            # Strips off any character prefix like '#' that usually exists
+            if match := regexp(r'(\d+)$').search(issue_num):
+                try:
+                    issue_num = int(match.group(1))
+                except ValueError:
+                    return ""
+
+        if isinstance(issue_num, int):
+            return self.create_repo_url(repo_path=f"/-/issues/{issue_num}")
+
+        return ""
 
     def merge_request_url(self, mr_number: str | int) -> str:
         return self.create_repo_url(repo_path=f"/-/merge_requests/{mr_number}")

--- a/tests/unit/semantic_release/hvcs/test_bitbucket.py
+++ b/tests/unit/semantic_release/hvcs/test_bitbucket.py
@@ -301,13 +301,13 @@ def test_commit_hash_url(default_bitbucket_client: Bitbucket):
     assert expected_url == default_bitbucket_client.commit_hash_url(sha)
 
 
-@pytest.mark.parametrize("pr_number", (420, "420"))
+@pytest.mark.parametrize("pr_number", (666, "666", "#666"))
 def test_pull_request_url(default_bitbucket_client: Bitbucket, pr_number: int | str):
     expected_url = "{server}/{owner}/{repo}/pull-requests/{pr_number}".format(
         server=default_bitbucket_client.hvcs_domain,
         owner=default_bitbucket_client.owner,
         repo=default_bitbucket_client.repo_name,
-        pr_number=pr_number,
+        pr_number=str(pr_number).lstrip("#"),
     )
     actual_url = default_bitbucket_client.pull_request_url(pr_number=pr_number)
     assert expected_url == actual_url

--- a/tests/unit/semantic_release/hvcs/test_gitea.py
+++ b/tests/unit/semantic_release/hvcs/test_gitea.py
@@ -203,24 +203,24 @@ def test_commit_hash_url(default_gitea_client: Gitea):
     assert expected_url == default_gitea_client.commit_hash_url(sha)
 
 
-@pytest.mark.parametrize("issue_number", (420, "420"))
+@pytest.mark.parametrize("issue_number", (666, "666", "#666"))
 def test_issue_url(default_gitea_client: Gitea, issue_number: int | str):
     expected_url = "{server}/{owner}/{repo}/issues/{issue_number}".format(
         server=default_gitea_client.hvcs_domain.url,
         owner=default_gitea_client.owner,
         repo=default_gitea_client.repo_name,
-        issue_number=issue_number,
+        issue_number=str(issue_number).lstrip("#"),
     )
     assert expected_url == default_gitea_client.issue_url(issue_num=issue_number)
 
 
-@pytest.mark.parametrize("pr_number", (420, "420"))
+@pytest.mark.parametrize("pr_number", (666, "666", "#666"))
 def test_pull_request_url(default_gitea_client: Gitea, pr_number: int | str):
     expected_url = "{server}/{owner}/{repo}/pulls/{pr_number}".format(
         server=default_gitea_client.hvcs_domain.url,
         owner=default_gitea_client.owner,
         repo=default_gitea_client.repo_name,
-        pr_number=pr_number,
+        pr_number=str(pr_number).lstrip("#"),
     )
     actual_url = default_gitea_client.pull_request_url(pr_number=pr_number)
     assert expected_url == actual_url

--- a/tests/unit/semantic_release/hvcs/test_github.py
+++ b/tests/unit/semantic_release/hvcs/test_github.py
@@ -375,24 +375,24 @@ def test_commit_hash_url(default_gh_client: Github):
     assert expected_url == default_gh_client.commit_hash_url(sha)
 
 
-@pytest.mark.parametrize("issue_number", (420, "420"))
+@pytest.mark.parametrize("issue_number", (666, "666", "#666"))
 def test_issue_url(default_gh_client: Github, issue_number: str | int):
     expected_url = "{server}/{owner}/{repo}/issues/{issue_num}".format(
         server=default_gh_client.hvcs_domain.url,
         owner=default_gh_client.owner,
         repo=default_gh_client.repo_name,
-        issue_num=issue_number,
+        issue_num=str(issue_number).lstrip("#"),
     )
     assert expected_url == default_gh_client.issue_url(issue_num=issue_number)
 
 
-@pytest.mark.parametrize("pr_number", (420, "420"))
+@pytest.mark.parametrize("pr_number", (666, "666", "#666"))
 def test_pull_request_url(default_gh_client: Github, pr_number: int | str):
     expected_url = "{server}/{owner}/{repo}/pull/{pr_number}".format(
         server=default_gh_client.hvcs_domain,
         owner=default_gh_client.owner,
         repo=default_gh_client.repo_name,
-        pr_number=pr_number,
+        pr_number=str(pr_number).lstrip("#"),
     )
     actual_url = default_gh_client.pull_request_url(pr_number=pr_number)
     assert expected_url == actual_url

--- a/tests/unit/semantic_release/hvcs/test_gitlab.py
+++ b/tests/unit/semantic_release/hvcs/test_gitlab.py
@@ -368,25 +368,25 @@ def test_commit_hash_url(default_gl_client: Gitlab):
     assert expected_url == default_gl_client.commit_hash_url(REF)
 
 
-@pytest.mark.parametrize("issue_number", (420, "420"))
+@pytest.mark.parametrize("issue_number", (666, "666", "#666"))
 def test_issue_url(default_gl_client: Gitlab, issue_number: int | str):
     expected_url = "{server}/{owner}/{repo}/-/issues/{issue_num}".format(
         server=default_gl_client.hvcs_domain.url,
         owner=default_gl_client.owner,
         repo=default_gl_client.repo_name,
-        issue_num=issue_number,
+        issue_num=str(issue_number).lstrip("#"),
     )
     actual_url = default_gl_client.issue_url(issue_num=issue_number)
     assert expected_url == actual_url
 
 
-@pytest.mark.parametrize("pr_number", (420, "420"))
+@pytest.mark.parametrize("pr_number", (666, "666", "!666"))
 def test_pull_request_url(default_gl_client: Gitlab, pr_number: int | str):
     expected_url = "{server}/{owner}/{repo}/-/merge_requests/{pr_number}".format(
         server=default_gl_client.hvcs_domain.url,
         owner=default_gl_client.owner,
         repo=default_gl_client.repo_name,
-        pr_number=pr_number,
+        pr_number=str(pr_number).lstrip("!"),
     )
     actual_url = default_gl_client.pull_request_url(pr_number=pr_number)
     assert expected_url == actual_url

--- a/tests/unit/semantic_release/hvcs/test_gitlab.py
+++ b/tests/unit/semantic_release/hvcs/test_gitlab.py
@@ -376,7 +376,7 @@ def test_issue_url(default_gl_client: Gitlab, issue_number: int | str):
         repo=default_gl_client.repo_name,
         issue_num=issue_number,
     )
-    actual_url = default_gl_client.issue_url(issue_number=issue_number)
+    actual_url = default_gl_client.issue_url(issue_num=issue_number)
     assert expected_url == actual_url
 
 


### PR DESCRIPTION
<!--
Please do not combine multiple features or fix actions that are not
directly dependent on one another. Please open multiple PRs instead because
one may be merged while the other is denied or has requested changes. This
will slow down the process of merging the accepted changes as reviews are
also more difficult to evaluate for edge cases.
-->

## Purpose
<!-- Reason for the PR (solves an issue/problem, adds a feature, etc) -->

- Increase the flexibility of the `issue_url` and/or `pull_request_url` jinja filters

## Rationale
<!-- How did you come to this conclusion as the solution? What was your reasoning? What were you trying to do? What problems did you find and avoid? -->

When exploring new default changelog designs I found that it was better if the filters would extract the number with a regular expression rather than expect a number. This way the issue prefix like `#` will not cause an error when creating the url.

## How did you test?
<!--
Please explain the methodology for how you verified this solution. It helps to
describe the primary case and the possible edge cases that you considered and
ultimately how you tested them. If you didn't rulled out any edge cases, please
mention the rationale here.
-->

I added an additional variation to the current unit tests that included a prefix. When trying to support Jira issue numbers in the future, this will likely be an issue.

