### PR TITLE
Implement $CI_JOB_TOKEN support in releases

### DIFF
--- a/docs/configuration/configuration.rst
+++ b/docs/configuration/configuration.rst
@@ -1125,6 +1125,14 @@ default token value will be for each remote type.
 **Default:** ``{ env = "<envvar name>" }``, where ``<envvar name>`` depends on
 :ref:`remote.type <config-remote-type>` as indicated above.
 
+A special case is the GitLab CI environment variable ``"CI_JOB_TOKEN"``. If this variable is set,
+it will be used as the job token for the GitLab API. This is useful for accessing the Gitlab Releases
+API in the CI environment.
+
+.. warning::
+    The value of ``"GITLAB_TOKEN"`` takes precedence over ``"CI_JOB_TOKEN"``. If both are set to the
+    same value, it is assumed to be a job token, not a personal access token.
+
 ----
 
 .. _config-remote-type:

--- a/src/semantic_release/hvcs/gitlab.py
+++ b/src/semantic_release/hvcs/gitlab.py
@@ -22,9 +22,13 @@ from semantic_release.hvcs.remote_hvcs_base import RemoteHvcsBase
 from semantic_release.hvcs.util import suppress_not_found
 
 if TYPE_CHECKING:  # pragma: no cover
-    from typing import Any, Callable
+    from typing import Any, Callable, TypedDict
 
     from gitlab.v4.objects import Project as GitLabProject
+
+    class TokenArgs(TypedDict):
+        private_token: str | None
+        job_token: str | None
 
 
 class Gitlab(RemoteHvcsBase):
@@ -49,6 +53,7 @@ class Gitlab(RemoteHvcsBase):
         super().__init__(remote_url)
         self.project_namespace = f"{self.owner}/{self.repo_name}"
         self._project: GitLabProject | None = None
+        self.is_ci = bool(str(os.getenv("CI", "")).lower() == str(True).lower())
 
         domain_url = self._normalize_url(
             hvcs_domain
@@ -67,22 +72,7 @@ class Gitlab(RemoteHvcsBase):
             ).url.rstrip("/")
         )
 
-        private_token = token
-        job_token = os.getenv("CI_JOB_TOKEN")
-
-        self.token = private_token
-        if job_token:
-            if job_token == private_token or not private_token:
-                # Disable private_token if it's actually the CI_JOB_TOKEN
-                private_token = None
-                self.token = job_token
-            else:
-                # Private token should be prioritized over CI_JOB_TOKEN
-                job_token = None
-
-        self._client = gitlab.Gitlab(
-            self.hvcs_domain.url, private_token=private_token, job_token=job_token
-        )
+        self._client = self._create_client(token)
         self._api_url = parse_url(self._client.api_url)
 
     @property
@@ -90,6 +80,52 @@ class Gitlab(RemoteHvcsBase):
         if self._project is None:
             self._project = self._client.projects.get(self.project_namespace)
         return self._project
+
+    @property
+    def token(self) -> str:
+        return [
+            *filter(
+                None,
+                [
+                    self._client.private_token,
+                    self._client.oauth_token,
+                    self._client.job_token,
+                ],
+            ),
+            "",  # default to empty string if no token is found
+        ].pop(0)
+
+    @staticmethod
+    def get_gitlab_server_version() -> tuple[int, ...]:
+        main_ver_str = os.getenv("CI_SERVER_VERSION", "0.0.0").split("-", maxsplit=1)[0]
+        try:
+            return tuple(map(int, main_ver_str.split(".")))
+        except ValueError:
+            return 0, 0, 0
+
+    def _create_client(self, configured_token: str | None = None) -> gitlab.Gitlab:
+        """
+        Creates a Gitlab client
+
+        A configured private token is prioritized over CI_JOB_TOKEN, if both are available
+        """
+        token_args: TokenArgs = {
+            "private_token": configured_token,  # assumed to be a personal access token
+            "job_token": None,
+        }
+
+        # GitLab Server version 17.2 enabled CI_JOB_TOKEN to write to repository
+        if self.get_gitlab_server_version()[:2] >= (17, 2):
+            job_token = os.getenv("CI_JOB_TOKEN", "")
+
+            if job_token and job_token == configured_token:
+                # Swap to only use job token if the configured_token is actually the CI_JOB_TOKEN
+                token_args = {
+                    "private_token": None,
+                    "job_token": job_token,
+                }
+
+        return gitlab.Gitlab(url=self.hvcs_domain.url, **token_args)
 
     @lru_cache(maxsize=1)
     def _get_repository_owner_and_name(self) -> tuple[str, str]:

--- a/tests/e2e/cmd_version/test_version_gitlab_auth.py
+++ b/tests/e2e/cmd_version/test_version_gitlab_auth.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+from unittest import mock
+
+import pytest
+
+from semantic_release.cli.commands.main import main
+
+from tests.const import MAIN_PROG_NAME, VERSION_SUBCMD
+from tests.util import assert_successful_exit_code
+
+if TYPE_CHECKING:
+    from unittest.mock import MagicMock
+
+    from click.testing import CliRunner
+    from git.repo import Repo
+    from requests_mock import Mocker
+
+    from tests.e2e.conftest import RetrieveRuntimeContextFn
+    from tests.fixtures.example_project import UseHvcsFn, UseReleaseNotesTemplateFn
+
+
+@pytest.mark.parametrize(
+    "tokens",
+    [
+        ("gitlab-token", "gitlab-private-token"),
+        ("gitlab-token", "gitlab-token"),
+        ("", "gitlab-token"),
+        ("gitlab-token", None),
+        ("gitlab-token", ""),
+        (None, "gitlab-private-token"),
+        (None, None),
+    ],
+)
+def test_gitlab_release_tokens(
+    cli_runner: CliRunner,
+    use_release_notes_template: UseReleaseNotesTemplateFn,
+    retrieve_runtime_context: RetrieveRuntimeContextFn,
+    mocked_git_push: MagicMock,
+    requests_mock: Mocker,
+    use_gitlab_hvcs: UseHvcsFn,
+    tokens: tuple[str, str],
+    repo_w_no_tags_angular_commits: Repo,
+) -> None:
+    """Verify that gitlab tokens are used correctly."""
+    # Setup
+    private_token, job_token = tokens
+    use_gitlab_hvcs()
+    requests_mock.register_uri(
+        "POST",
+        "https://example.com/api/v4/projects/999/releases",
+        json={"id": 999},
+        headers={"Content-Type": "application/json"},
+    )
+    requests_mock.register_uri(
+        "GET",
+        "https://example.com/api/v4/projects/example_owner%2Fexample_repo",
+        json={"id": 999},
+        headers={"Content-Type": "application/json"},
+    )
+
+    env_dict = {}
+    if private_token is not None:
+        env_dict["GITLAB_TOKEN"] = private_token
+    if job_token is not None:
+        env_dict["CI_JOB_TOKEN"] = job_token
+    with mock.patch.dict(os.environ, env_dict):
+        # Act
+        cli_cmd = [MAIN_PROG_NAME, VERSION_SUBCMD, "--vcs-release"]
+        result = cli_runner.invoke(main, cli_cmd[1:])
+
+    # Assert
+    assert_successful_exit_code(result, cli_cmd)
+    assert mocked_git_push.call_count == 2  # 1 for commit, 1 for tag
+    assert requests_mock.call_count == 2
+    assert requests_mock.last_request is not None
+    assert requests_mock.request_history[0].method == "GET"
+    assert requests_mock.request_history[1].method == "POST"
+
+    job_token_header = "JOB-TOKEN"
+    private_token_header = "PRIVATE-TOKEN"
+    for request in requests_mock.request_history:
+        if private_token and private_token != job_token:
+            assert request._request.headers[private_token_header] == private_token
+            assert job_token_header not in request._request.headers
+        elif job_token:
+            assert request._request.headers[job_token_header] == job_token
+            assert private_token_header not in request._request.headers
+        else:
+            assert private_token_header not in request._request.headers
+            assert job_token_header not in request._request.headers


### PR DESCRIPTION
<!--
Please do not combine multiple features or fix actions that are not
directly dependent on one another. Please open multiple PRs instead because
one may be merged while the other is denied or has requested changes. This
will slow down the process of merging the accepted changes as reviews are
also more difficult to evaluate for edge cases.
-->

## Purpose
<!-- Reason for the PR (solves an issue/problem, adds a feature, etc) -->

Implement support for the `CI_JOB_TOKEN` variable in Gitlab CI.

`CI_JOB_TOKEN`s can now be used to push to repositories, and using them is both safer and easier.


## Rationale
<!-- How did you come to this conclusion as the solution? What was your reasoning? What were you trying to do? What problems did you find and avoid? -->

The `CI_JOB_TOKEN` should only complement the usage of `GITLAB_TOKEN` and respect its' value when used. When the values of `GITLAB_TOKEN` and `CI_JOB_TOKEN` match, or the remote token env name is set to `CI_JOB_TOKEN`, it is considered to be a job token. When `GITLAB_TOKEN` is not specified, the `CI_JOB_TOKEN`'s value is used.

## How did you test?
<!--
Please explain the methodology for how you verified this solution. It helps to
describe the primary case and the possible edge cases that you considered and
ultimately how you tested them. If you didn't rulled out any edge cases, please
mention the rationale here.
-->

I added some parameters to the existing GitLab unit test that checks the usage of the environment variable. I also created an e2e test case that checks various combinations of personal token and job token usage in requests to the GitLab API.


## How to Verify
<!-- Please provide a list of steps to validate your solution -->

1. Enable usage of job tokens for pushing in the Gitlab repository configuration
2. Set the `tool.semantic_release.remote.token` to `{ env = "CI_JOB_TOKEN" }` or assign `export GITLAB_TOKEN = $CI_JOB_TOKEN` in a GitLab CI configuration.
3. Trigger a release/version job in the pipeline
