### PR TITLE
build(deps-build): update setuptools requirement from ~=69.0 to ~=75.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # Ref: https://packaging.python.org/en/latest/specifications/declaring-project-metadata/
 # and https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html
 [build-system]
-requires = ["setuptools ~= 69.0", "wheel ~= 0.42"]
+requires = ["setuptools ~= 75.3.0", "wheel ~= 0.42"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
<!--
Please do not combine multiple features or fix actions that are not
directly dependent on one another. Please open multiple PRs instead because
one may be merged while the other is denied or has requested changes. This
will slow down the process of merging the accepted changes as reviews are
also more difficult to evaluate for edge cases.
-->

## Purpose
<!-- Reason for the PR (solves an issue/problem, adds a feature, etc) -->

- Update the build dependencies

## Rationale
<!-- How did you come to this conclusion as the solution? What was your reasoning? What were you trying to do? What problems did you find and avoid? -->

Bumping setuptools up to the latest version before they removed support for `python 3.8`. Since we still support `3.8` for the meantime, this is as high as we go.  
