### PR TITLE
feat(release-notes): add tag comparison link to release notes when supported

### DIFF
--- a/src/semantic_release/data/templates/angular/md/.release_notes.md.j2
+++ b/src/semantic_release/data/templates/angular/md/.release_notes.md.j2
@@ -1,7 +1,36 @@
-{#    # Set line width to 1000 to avoid wrapping as GitHub will handle it
+{#  EXAMPLE:
+
+### Features
+
+- Add new feature ([#10](https://domain.com/namespace/repo/pull/10),
+  [`abcdef0`](https://domain.com/namespace/repo/commit/HASH))
+
+- **scope**: Add new feature
+  ([`abcdef0`](https://domain.com/namespace/repo/commit/HASH))
+
+### Bug Fixes
+
+- Fix bug (#11, [`abcdef1`](https://domain.com/namespace/repo/commit/HASH))
+
+---
+
+**Detailed Changes**: [vX.X.X...vX.X.X](https://domain.com/namespace/repo/compare/vX.X.X...vX.X.X)
+
+#}{#  # Set line width to 1000 to avoid wrapping as GitHub will handle it
 #}{%  set max_line_width = max_line_width | default(1000)
 %}{%  set hanging_indent = hanging_indent | default(2)
-%}{%  set releases = context.history.released.items() | list
+%}{%  set releases = context.history.released.values() | list
+%}{%  set curr_release_index = releases.index(release)
+%}{%  set prev_release_index = curr_release_index + 1
+%}{#
+#}{%  if 'compare_url' is filter and prev_release_index < releases | length
+%}{%    set prev_version_tag = releases[prev_release_index].version.as_tag()
+%}{%    set new_version_tag = release.version.as_tag()
+%}{%    set version_compare_url = prev_version_tag | compare_url(new_version_tag)
+%}{%    set detailed_changes_link = '[{}...{}]({})'.format(
+          prev_version_tag, new_version_tag, version_compare_url
+        )
+%}{%  endif
 %}{#
 #}{%  if releases | length == 1 and mask_initial_release
 %}{#    # On a first release, generate our special message
@@ -9,5 +38,12 @@
 %}{%  else
 %}{#    # Not the first release so generate notes normally
 #}{%    include ".components/versioned_changes.md.j2"
+-%}{#
+#}{%    if detailed_changes_link is defined
+%}{{      "\n"
+}}{{      "---\n"
+}}{{      "\n"
+}}{{      "**Detailed Changes**: %s" | format(detailed_changes_link)
+}}{%    endif
 %}{%  endif
 %}

--- a/tests/e2e/cmd_changelog/test_changelog.py
+++ b/tests/e2e/cmd_changelog/test_changelog.py
@@ -1024,7 +1024,14 @@ def test_changelog_release_tag_not_in_history(
 
 
 @pytest.mark.usefixtures(repo_w_trunk_only_n_prereleases_angular_commits.__name__)
-@pytest.mark.parametrize("args", [("--post-to-release-tag", "v0.1.0")])
+@pytest.mark.parametrize(
+    "args",
+    [
+        ("--post-to-release-tag", "v0.1.0"),  #      first release
+        ("--post-to-release-tag", "v0.1.1-rc.1"),  # second release
+        ("--post-to-release-tag", "v0.2.0"),  #      latest release
+    ],
+)
 def test_changelog_post_to_release(args: list[str], cli_runner: CliRunner):
     # Set up a requests HTTP session so we can catch the HTTP calls and ensure they're
     # made

--- a/tests/unit/semantic_release/changelog/test_release_notes.py
+++ b/tests/unit/semantic_release/changelog/test_release_notes.py
@@ -41,7 +41,9 @@ def test_default_release_notes_template(
 
     Scenarios are better suited for all the variations (commit types).
     """
-    version = next(iter(artificial_release_history.released.keys()))
+    released_versions = iter(artificial_release_history.released.keys())
+    version = next(released_versions)
+    prev_version = next(released_versions)
     hvcs = hvcs_client(example_git_https_url)
     release = artificial_release_history.released[version]
 
@@ -85,6 +87,24 @@ def test_default_release_notes_template(
             "",
         ],
     )
+
+    if not isinstance(hvcs, Gitea):
+        expected_content += str.join(
+            os.linesep,
+            [
+                "",
+                "---",
+                "",
+                "**Detailed Changes**: [{prev_version}...{new_version}]({version_compare_url})".format(
+                    prev_version=prev_version.as_tag(),
+                    new_version=version.as_tag(),
+                    version_compare_url=hvcs.compare_url(
+                        prev_version.as_tag(), version.as_tag()
+                    ),
+                ),
+                "",
+            ],
+        )
 
     actual_content = generate_release_notes(
         hvcs_client=hvcs_client(remote_url=example_git_https_url),


### PR DESCRIPTION
<!--
Please do not combine multiple features or fix actions that are not
directly dependent on one another. Please open multiple PRs instead because
one may be merged while the other is denied or has requested changes. This
will slow down the process of merging the accepted changes as reviews are
also more difficult to evaluate for edge cases.
-->

## Purpose
<!-- Reason for the PR (solves an issue/problem, adds a feature, etc) -->

- Automatically adds a comparison URL to the release notes

## Rationale
<!-- How did you come to this conclusion as the solution? What was your reasoning? What were you trying to do? What problems did you find and avoid? -->

Its a common item to add to the release notes is a comparison URL to the previous version that was released. This adds it to the default release notes template.

## How did you test?
<!--
Please explain the methodology for how you verified this solution. It helps to
describe the primary case and the possible edge cases that you considered and
ultimately how you tested them. If you didn't rulled out any edge cases, please
mention the rationale here.
-->

Updated the release notes template unit test which has more than one release tested.  It also is tested through the changelog command with the `--post-to-release-tag` option and luckily it caught the edge case of when you are trying to use PSR to update the release notes of an earlier release and it happens to be the very first one.  
