### PR TITLE
feat(changelog): alphabetize commit summaries & scopes in default templates

### DIFF
--- a/src/semantic_release/data/templates/angular/md/.components/changes.md.j2
+++ b/src/semantic_release/data/templates/angular/md/.components/changes.md.j2
@@ -1,4 +1,5 @@
-{%   from 'macros.md.j2' import format_commit_summary_line
+{%    from 'macros.md.j2' import apply_alphabetical_ordering_by_descriptions
+%}{%  from 'macros.md.j2' import format_commit_summary_line
 %}{#
 EXAMPLE:
 
@@ -19,8 +20,12 @@ EXAMPLE:
 %}{#
 #}{%  for type_, commits in commit_objects if type_ != "unknown"
 %}{#    PREPROCESS COMMITS (order by description & format description line)
+#}{%    set ns = namespace(commits=commits)
+%}{{    apply_alphabetical_ordering_by_descriptions(ns) | default("", true)
+}}{#
 #}{%    set commit_descriptions = []
-%}{%    for commit in commits
+%}{#
+#}{%    for commit in ns.commits
 %}{#      # Update the first line with reference links and if commit description
           # has more than one line, add the rest of the lines
           # NOTE: This is specifically to make sure to not hide contents
@@ -39,6 +44,6 @@ EXAMPLE:
 #}{{    "\n"
 }}{{    "### %s\n" | format(type_ | title)
 }}{{    "\n"
-}}{{    "%s\n" | format(commit_descriptions | unique | sort | join("\n\n"))
+}}{{    "%s\n" | format(commit_descriptions | unique | join("\n\n"))
 }}{%  endfor
 %}

--- a/src/semantic_release/data/templates/angular/md/.components/macros.md.j2
+++ b/src/semantic_release/data/templates/angular/md/.components/macros.md.j2
@@ -67,3 +67,31 @@
 }}{%    endif
 %}{%  endmacro
 %}
+
+
+{#
+  MACRO: apply smart ordering of commits objects based on alphabetized summaries and then scopes
+  - Commits are sorted based on the commit type and the commit message
+  - Commits are grouped by the commit type
+  - parameter: ns (namespace) object with a commits list
+  - returns None but modifies the ns.commits list in place
+#}{%  macro apply_alphabetical_ordering_by_descriptions(ns)
+%}{%    set ordered_commits = []
+%}{#
+   #    # Eliminate any ParseError commits from input set
+#}{%    set filtered_commits = ns.commits | rejectattr("error", "defined") | list
+%}{#
+   #    # grab all commits with no scope and sort alphabetically by the first line of the commit message
+#}{%    for commit in filtered_commits | rejectattr("scope") | sort(attribute='descriptions.0')
+%}{{      ordered_commits.append(commit) | default("", true)
+}}{%     endfor
+%}{#
+   #    # grab all commits with a scope and sort alphabetically by the scope and then the first line of the commit message
+#}{%    for commit in filtered_commits | selectattr("scope") | sort(attribute='scope,descriptions.0')
+%}{{      ordered_commits.append(commit) | default("", true)
+}}{%    endfor
+%}{#
+   #    # Return the ordered commits
+#}{%    set ns.commits = ordered_commits
+%}{%  endmacro
+%}

--- a/src/semantic_release/data/templates/angular/rst/.components/changes.rst.j2
+++ b/src/semantic_release/data/templates/angular/rst/.components/changes.rst.j2
@@ -1,5 +1,7 @@
-{%   from 'macros.rst.j2' import extract_pr_link_reference, format_link_reference
-%}{% from 'macros.rst.j2' import format_commit_summary_line, generate_heading_underline
+{%   from 'macros.rst.j2' import apply_alphabetical_ordering_by_descriptions
+%}{% from 'macros.rst.j2' import extract_pr_link_reference
+%}{% from 'macros.rst.j2' import format_commit_summary_line, format_link_reference
+%}{% from 'macros.rst.j2' import generate_heading_underline
 %}{#
 
 Features
@@ -25,12 +27,16 @@ Fixes
 #}{%  set post_paragraph_links = []
 %}{#
 #}{%  for type_, commits in commit_objects if type_ != "unknown"
-%}{#    PREPARE SECTION HEADER
+%}{#    # PREPARE SECTION HEADER
 #}{%    set section_header = "%s" | format(type_ | title)
-%}{#    PREPROCESS COMMITS
+%}{#
+   #    # PREPROCESS COMMITS
+#}{%    set ns = namespace(commits=commits)
+%}{{    apply_alphabetical_ordering_by_descriptions(ns) | default("", true)
+}}{#
 #}{%    set commit_descriptions = []
 %}{#
-#}{%    for commit in commits
+#}{%    for commit in ns.commits
 %}{#      # Extract PR/MR reference if it exists and store it for later
 #}{%      set pr_link_reference = extract_pr_link_reference(commit) | default("", true)
 %}{%      if pr_link_reference != ""
@@ -65,7 +71,7 @@ Fixes
 }}{{    section_header ~ "\n"
 }}{{    generate_heading_underline(section_header, '-') ~ "\n"
 }}{{
-        "\n%s\n" | format(commit_descriptions | unique | sort | join("\n\n"))
+        "\n%s\n" | format(commit_descriptions | unique | join("\n\n"))
 
 }}{%  endfor
 %}{#

--- a/src/semantic_release/data/templates/angular/rst/.components/macros.rst.j2
+++ b/src/semantic_release/data/templates/angular/rst/.components/macros.rst.j2
@@ -95,3 +95,31 @@
 #}{{    header_underline | join
 }}{%  endmacro
 %}
+
+
+{#
+  MACRO: apply smart ordering of commits objects based on alphabetized summaries and then scopes
+  - Commits are sorted based on the commit type and the commit message
+  - Commits are grouped by the commit type
+  - parameter: ns (namespace) object with a commits list
+  - returns None but modifies the ns.commits list in place
+#}{%  macro apply_alphabetical_ordering_by_descriptions(ns)
+%}{%    set ordered_commits = []
+%}{#
+   #    # Eliminate any ParseError commits from input set
+#}{%    set filtered_commits = ns.commits | rejectattr("error", "defined") | list
+%}{#
+   #    # grab all commits with no scope and sort alphabetically by the first line of the commit message
+#}{%    for commit in filtered_commits | rejectattr("scope") | sort(attribute='descriptions.0')
+%}{{      ordered_commits.append(commit) | default("", true)
+}}{%     endfor
+%}{#
+   #    # grab all commits with a scope and sort alphabetically by the scope and then the first line of the commit message
+#}{%    for commit in filtered_commits | selectattr("scope") | sort(attribute='scope,descriptions.0')
+%}{{      ordered_commits.append(commit) | default("", true)
+}}{%    endfor
+%}{#
+   #    # Return the ordered commits
+#}{%    set ns.commits = ordered_commits
+%}{%  endmacro
+%}

--- a/tests/unit/semantic_release/changelog/conftest.py
+++ b/tests/unit/semantic_release/changelog/conftest.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections import defaultdict
 from datetime import timedelta
 from typing import TYPE_CHECKING
 
@@ -45,6 +44,44 @@ def artificial_release_history(
         commit=fix_commit,
     )
 
+    fix_commit_2_subject = "alphabetically first to solve a non-scoped problem"
+    fix_commit_2_type = "fix"
+    fix_commit_2_scope = ""
+
+    fix_commit_2 = Commit(
+        Repo("."),
+        Object.NULL_HEX_SHA[:20].encode("utf-8"),
+        message=f"{fix_commit_2_type}: {fix_commit_2_subject}",
+    )
+
+    fix_commit_2_parsed = ParsedCommit(
+        bump=LevelBump.PATCH,
+        type="fix",
+        scope=fix_commit_2_scope,
+        descriptions=[fix_commit_2_subject],
+        breaking_descriptions=[],
+        commit=fix_commit_2,
+    )
+
+    fix_commit_3_subject = "alphabetically first to solve a scoped problem"
+    fix_commit_3_type = "fix"
+    fix_commit_3_scope = "cli"
+
+    fix_commit_3 = Commit(
+        Repo("."),
+        Object.NULL_HEX_SHA[:20].encode("utf-8"),
+        message=f"{fix_commit_3_type}({fix_commit_3_scope}): {fix_commit_3_subject}",
+    )
+
+    fix_commit_3_parsed = ParsedCommit(
+        bump=LevelBump.PATCH,
+        type="fix",
+        scope=fix_commit_3_scope,
+        descriptions=[fix_commit_3_subject],
+        breaking_descriptions=[],
+        commit=fix_commit_3,
+    )
+
     feat_commit_subject = "add a new feature"
     feat_commit_type = "feat"
     feat_commit_scope = "cli"
@@ -65,42 +102,29 @@ def artificial_release_history(
     )
 
     return ReleaseHistory(
-        unreleased=defaultdict(
-            list,
-            [
-                (
-                    "feature",
-                    [feat_commit_parsed],
-                )
-            ],
-        ),
+        unreleased={"feature": [feat_commit_parsed]},
         released={
             second_version: Release(
                 tagger=commit_author,
                 committer=commit_author,
                 tagged_date=current_datetime,
-                elements=defaultdict(
-                    list,
-                    [
-                        ("feature", [feat_commit_parsed]),
-                        ("fix", [fix_commit_parsed]),
+                elements={
+                    # Purposefully inserted out of order, should be dictsorted in templates
+                    "fix": [
+                        # Purposefully inserted out of alphabetical order, should be sorted in templates
+                        fix_commit_parsed,
+                        fix_commit_2_parsed,  # has no scope
+                        fix_commit_3_parsed,  # has same scope as 1
                     ],
-                ),
+                    "feature": [feat_commit_parsed],
+                },
                 version=second_version,
             ),
             first_version: Release(
                 tagger=commit_author,
                 committer=commit_author,
                 tagged_date=current_datetime - timedelta(minutes=1),
-                elements=defaultdict(
-                    list,
-                    [
-                        (
-                            "feature",
-                            [feat_commit_parsed],
-                        )
-                    ],
-                ),
+                elements={"feature": [feat_commit_parsed]},
                 version=first_version,
             ),
         },

--- a/tests/unit/semantic_release/changelog/test_default_changelog.py
+++ b/tests/unit/semantic_release/changelog/test_default_changelog.py
@@ -45,15 +45,25 @@ def test_default_changelog_template(
     first_version = list(artificial_release_history.released.keys())[-1]
 
     feat_commit_obj = latest_release["elements"]["feature"][0]
-    fix_commit_obj = latest_release["elements"]["fix"][0]
+    fix_commit_obj_1 = latest_release["elements"]["fix"][0]
+    fix_commit_obj_2 = latest_release["elements"]["fix"][1]
+    fix_commit_obj_3 = latest_release["elements"]["fix"][2]
     assert isinstance(feat_commit_obj, ParsedCommit)
-    assert isinstance(fix_commit_obj, ParsedCommit)
+    assert isinstance(fix_commit_obj_1, ParsedCommit)
+    assert isinstance(fix_commit_obj_2, ParsedCommit)
+    assert isinstance(fix_commit_obj_3, ParsedCommit)
 
     feat_commit_url = hvcs.commit_hash_url(feat_commit_obj.commit.hexsha)
     feat_description = str.join("\n", feat_commit_obj.descriptions)
 
-    fix_commit_url = hvcs.commit_hash_url(fix_commit_obj.commit.hexsha)
-    fix_description = str.join("\n", fix_commit_obj.descriptions)
+    fix_commit_1_url = hvcs.commit_hash_url(fix_commit_obj_1.commit.hexsha)
+    fix_commit_1_description = str.join("\n", fix_commit_obj_1.descriptions)
+
+    fix_commit_2_url = hvcs.commit_hash_url(fix_commit_obj_2.commit.hexsha)
+    fix_commit_2_description = str.join("\n", fix_commit_obj_2.descriptions)
+
+    fix_commit_3_url = hvcs.commit_hash_url(fix_commit_obj_3.commit.hexsha)
+    fix_commit_3_description = str.join("\n", fix_commit_obj_3.descriptions)
 
     expected_changelog = str.join(
         "\n",
@@ -71,9 +81,19 @@ def test_default_changelog_template(
             "",
             "### Fix",
             "",
+            # Commit 2 is first because it has no scope
             # Due to the 100 character limit, hash url will be on the second line
-            f"- **{fix_commit_obj.scope}**: {fix_description.capitalize()}",
-            f"  ([`{fix_commit_obj.commit.hexsha[:7]}`]({fix_commit_url}))",
+            f"- {fix_commit_2_description.capitalize()}",
+            f"  ([`{fix_commit_obj_2.commit.hexsha[:7]}`]({fix_commit_2_url}))",
+            "",
+            # Commit 3 is second because it starts with an A even though it has the same scope as 1
+            # Due to the 100 character limit, hash url will be on the second line
+            f"- **{fix_commit_obj_3.scope}**: {fix_commit_3_description.capitalize()}",
+            f"  ([`{fix_commit_obj_3.commit.hexsha[:7]}`]({fix_commit_3_url}))",
+            "",
+            # Due to the 100 character limit, hash url will be on the second line
+            f"- **{fix_commit_obj_1.scope}**: {fix_commit_1_description.capitalize()}",
+            f"  ([`{fix_commit_obj_1.commit.hexsha[:7]}`]({fix_commit_1_url}))",
             "",
             "",
             f"## v{first_version} ({today_date_str})",
@@ -115,15 +135,25 @@ def test_default_changelog_template_no_initial_release_mask(
     first_version = list(artificial_release_history.released.keys())[-1]
 
     feat_commit_obj = latest_release["elements"]["feature"][0]
-    fix_commit_obj = latest_release["elements"]["fix"][0]
+    fix_commit_obj_1 = latest_release["elements"]["fix"][0]
+    fix_commit_obj_2 = latest_release["elements"]["fix"][1]
+    fix_commit_obj_3 = latest_release["elements"]["fix"][2]
     assert isinstance(feat_commit_obj, ParsedCommit)
-    assert isinstance(fix_commit_obj, ParsedCommit)
+    assert isinstance(fix_commit_obj_1, ParsedCommit)
+    assert isinstance(fix_commit_obj_2, ParsedCommit)
+    assert isinstance(fix_commit_obj_3, ParsedCommit)
 
     feat_commit_url = hvcs.commit_hash_url(feat_commit_obj.commit.hexsha)
     feat_description = str.join("\n", feat_commit_obj.descriptions)
 
-    fix_commit_url = hvcs.commit_hash_url(fix_commit_obj.commit.hexsha)
-    fix_description = str.join("\n", fix_commit_obj.descriptions)
+    fix_commit_1_url = hvcs.commit_hash_url(fix_commit_obj_1.commit.hexsha)
+    fix_commit_1_description = str.join("\n", fix_commit_obj_1.descriptions)
+
+    fix_commit_2_url = hvcs.commit_hash_url(fix_commit_obj_2.commit.hexsha)
+    fix_commit_2_description = str.join("\n", fix_commit_obj_2.descriptions)
+
+    fix_commit_3_url = hvcs.commit_hash_url(fix_commit_obj_3.commit.hexsha)
+    fix_commit_3_description = str.join("\n", fix_commit_obj_3.descriptions)
 
     expected_changelog = str.join(
         "\n",
@@ -141,9 +171,19 @@ def test_default_changelog_template_no_initial_release_mask(
             "",
             "### Fix",
             "",
+            # Commit 2 is first because it has no scope
             # Due to the 100 character limit, hash url will be on the second line
-            f"- **{fix_commit_obj.scope}**: {fix_description.capitalize()}",
-            f"  ([`{fix_commit_obj.commit.hexsha[:7]}`]({fix_commit_url}))",
+            f"- {fix_commit_2_description.capitalize()}",
+            f"  ([`{fix_commit_obj_2.commit.hexsha[:7]}`]({fix_commit_2_url}))",
+            "",
+            # Commit 3 is second because it starts with an A even though it has the same scope as 1
+            # Due to the 100 character limit, hash url will be on the second line
+            f"- **{fix_commit_obj_3.scope}**: {fix_commit_3_description.capitalize()}",
+            f"  ([`{fix_commit_obj_3.commit.hexsha[:7]}`]({fix_commit_3_url}))",
+            "",
+            # Due to the 100 character limit, hash url will be on the second line
+            f"- **{fix_commit_obj_1.scope}**: {fix_commit_1_description.capitalize()}",
+            f"  ([`{fix_commit_obj_1.commit.hexsha[:7]}`]({fix_commit_1_url}))",
             "",
             "",
             f"## v{first_version} ({today_date_str})",
@@ -188,15 +228,25 @@ def test_default_changelog_template_w_unreleased_changes(
     first_version = list(artificial_release_history.released.keys())[-1]
 
     feat_commit_obj = latest_release["elements"]["feature"][0]
-    fix_commit_obj = latest_release["elements"]["fix"][0]
+    fix_commit_obj_1 = latest_release["elements"]["fix"][0]
+    fix_commit_obj_2 = latest_release["elements"]["fix"][1]
+    fix_commit_obj_3 = latest_release["elements"]["fix"][2]
     assert isinstance(feat_commit_obj, ParsedCommit)
-    assert isinstance(fix_commit_obj, ParsedCommit)
+    assert isinstance(fix_commit_obj_1, ParsedCommit)
+    assert isinstance(fix_commit_obj_2, ParsedCommit)
+    assert isinstance(fix_commit_obj_3, ParsedCommit)
 
     feat_commit_url = hvcs.commit_hash_url(feat_commit_obj.commit.hexsha)
     feat_description = str.join("\n", feat_commit_obj.descriptions)
 
-    fix_commit_url = hvcs.commit_hash_url(fix_commit_obj.commit.hexsha)
-    fix_description = str.join("\n", fix_commit_obj.descriptions)
+    fix_commit_1_url = hvcs.commit_hash_url(fix_commit_obj_1.commit.hexsha)
+    fix_commit_1_description = str.join("\n", fix_commit_obj_1.descriptions)
+
+    fix_commit_2_url = hvcs.commit_hash_url(fix_commit_obj_2.commit.hexsha)
+    fix_commit_2_description = str.join("\n", fix_commit_obj_2.descriptions)
+
+    fix_commit_3_url = hvcs.commit_hash_url(fix_commit_obj_3.commit.hexsha)
+    fix_commit_3_description = str.join("\n", fix_commit_obj_3.descriptions)
 
     expected_changelog = str.join(
         "\n",
@@ -222,9 +272,19 @@ def test_default_changelog_template_w_unreleased_changes(
             "",
             "### Fix",
             "",
+            # Commit 2 is first because it has no scope
             # Due to the 100 character limit, hash url will be on the second line
-            f"- **{feat_commit_obj.scope}**: {fix_description[0].capitalize()}{fix_description[1:]}",
-            f"  ([`{fix_commit_obj.commit.hexsha[:7]}`]({fix_commit_url}))",
+            f"- {fix_commit_2_description.capitalize()}",
+            f"  ([`{fix_commit_obj_2.commit.hexsha[:7]}`]({fix_commit_2_url}))",
+            "",
+            # Commit 3 is second because it starts with an A even though it has the same scope as 1
+            # Due to the 100 character limit, hash url will be on the second line
+            f"- **{fix_commit_obj_3.scope}**: {fix_commit_3_description.capitalize()}",
+            f"  ([`{fix_commit_obj_3.commit.hexsha[:7]}`]({fix_commit_3_url}))",
+            "",
+            # Due to the 100 character limit, hash url will be on the second line
+            f"- **{fix_commit_obj_1.scope}**: {fix_commit_1_description.capitalize()}",
+            f"  ([`{fix_commit_obj_1.commit.hexsha[:7]}`]({fix_commit_1_url}))",
             "",
             "",
             f"## v{first_version} ({today_date_str})",

--- a/tests/unit/semantic_release/changelog/test_release_notes.py
+++ b/tests/unit/semantic_release/changelog/test_release_notes.py
@@ -48,15 +48,25 @@ def test_default_release_notes_template(
     release = artificial_release_history.released[version]
 
     feat_commit_obj = release["elements"]["feature"][0]
-    fix_commit_obj = release["elements"]["fix"][0]
+    fix_commit_obj_1 = release["elements"]["fix"][0]
+    fix_commit_obj_2 = release["elements"]["fix"][1]
+    fix_commit_obj_3 = release["elements"]["fix"][2]
     assert isinstance(feat_commit_obj, ParsedCommit)
-    assert isinstance(fix_commit_obj, ParsedCommit)
+    assert isinstance(fix_commit_obj_1, ParsedCommit)
+    assert isinstance(fix_commit_obj_2, ParsedCommit)
+    assert isinstance(fix_commit_obj_3, ParsedCommit)
 
     feat_commit_url = hvcs.commit_hash_url(feat_commit_obj.commit.hexsha)
     feat_description = str.join("\n", feat_commit_obj.descriptions)
 
-    fix_commit_url = hvcs.commit_hash_url(fix_commit_obj.commit.hexsha)
-    fix_description = str.join("\n", fix_commit_obj.descriptions)
+    fix_commit_1_url = hvcs.commit_hash_url(fix_commit_obj_1.commit.hexsha)
+    fix_commit_1_description = str.join("\n", fix_commit_obj_1.descriptions)
+
+    fix_commit_2_url = hvcs.commit_hash_url(fix_commit_obj_2.commit.hexsha)
+    fix_commit_2_description = str.join("\n", fix_commit_obj_2.descriptions)
+
+    fix_commit_3_url = hvcs.commit_hash_url(fix_commit_obj_3.commit.hexsha)
+    fix_commit_3_description = str.join("\n", fix_commit_obj_3.descriptions)
 
     expected_content = str.join(
         os.linesep,
@@ -76,13 +86,34 @@ def test_default_release_notes_template(
             "",
             "### Fix",
             "",
+            # Commit 2 is first because it has no scope
             "- {commit_scope}{commit_desc} ([`{short_hash}`]({url}))".format(
                 commit_scope=(
-                    f"**{fix_commit_obj.scope}**: " if fix_commit_obj.scope else ""
+                    f"**{fix_commit_obj_2.scope}**: " if fix_commit_obj_2.scope else ""
                 ),
-                commit_desc=fix_description.capitalize(),
-                short_hash=fix_commit_obj.commit.hexsha[:7],
-                url=fix_commit_url,
+                commit_desc=fix_commit_2_description.capitalize(),
+                short_hash=fix_commit_obj_2.commit.hexsha[:7],
+                url=fix_commit_2_url,
+            ),
+            "",
+            # Commit 3 is second because it starts with an A even though it has the same scope as 1
+            "- {commit_scope}{commit_desc} ([`{short_hash}`]({url}))".format(
+                commit_scope=(
+                    f"**{fix_commit_obj_3.scope}**: " if fix_commit_obj_3.scope else ""
+                ),
+                commit_desc=fix_commit_3_description.capitalize(),
+                short_hash=fix_commit_obj_3.commit.hexsha[:7],
+                url=fix_commit_3_url,
+            ),
+            "",
+            # Commit 1 is last
+            "- {commit_scope}{commit_desc} ([`{short_hash}`]({url}))".format(
+                commit_scope=(
+                    f"**{fix_commit_obj_1.scope}**: " if fix_commit_obj_1.scope else ""
+                ),
+                commit_desc=fix_commit_1_description.capitalize(),
+                short_hash=fix_commit_obj_1.commit.hexsha[:7],
+                url=fix_commit_1_url,
             ),
             "",
         ],


### PR DESCRIPTION
<!--
Please do not combine multiple features or fix actions that are not
directly dependent on one another. Please open multiple PRs instead because
one may be merged while the other is denied or has requested changes. This
will slow down the process of merging the accepted changes as reviews are
also more difficult to evaluate for edge cases.
-->

## Purpose
<!-- Reason for the PR (solves an issue/problem, adds a feature, etc) -->

- Improve ease of reading changelog with many adjustments

## Rationale
<!-- How did you come to this conclusion as the solution? What was your reasoning? What were you trying to do? What problems did you find and avoid? -->

This is more of an aesthetic component to make the changelog easier to read. When run an alphabetical sort on the different changes then it automatically will group like values together. This is very helpful when people use pre-defined or common scope values which consolidates those updates.  Conversely if you have a mixture of scoped and non-scoped commits, it will lay out all the non-scoped commits first (which generally mean they cover a larger subset of the project) before the smaller more specific changes are listed.

## How did you test?
<!--
Please explain the methodology for how you verified this solution. It helps to
describe the primary case and the possible edge cases that you considered and
ultimately how you tested them. If you didn't rulled out any edge cases, please
mention the rationale here.
-->

Adjusted the fake release history fixtures to provide a non-alphabetical ordering to commits and then force it to comply with the resulting test that is in a set order.  This ensures the commits were in fact sorted first by scope and secondly by alphabetical descriptions

## How to Verify
<!-- Please provide a list of steps to validate your solution -->

1. Checkout this pr
2. Reset by 2 commits to remove the fix
3. Run pytest to see the failures where the commits are not in alphabetical order or in scoped order
4. Fast foward merge to the latest commit of this pr
5. Run pytest again to see it is fixed.