### PR TITLE
fix(cli): add error message of how to gather full error output

### DIFF
--- a/src/semantic_release/__main__.py
+++ b/src/semantic_release/__main__.py
@@ -34,7 +34,15 @@ def main() -> None:
                 ),
                 file=sys.stderr,
             )
+
         print(f"::ERROR:: {err}", file=sys.stderr)
+
+        if not globals.debug:
+            print(
+                "Run semantic-release in very verbose mode (-vv) to see the full traceback.",
+                file=sys.stderr,
+            )
+
         sys.exit(1)
 
 


### PR DESCRIPTION
<!--
Please do not combine multiple features or fix actions that are not
directly dependent on one another. Please open multiple PRs instead because
one may be merged while the other is denied or has requested changes. This
will slow down the process of merging the accepted changes as reviews are
also more difficult to evaluate for edge cases.
-->

## Purpose
<!-- Reason for the PR (solves an issue/problem, adds a feature, etc) -->

- Adds a helpful debug message when fatal errors occur

## Rationale
<!-- How did you come to this conclusion as the solution? What was your reasoning? What were you trying to do? What problems did you find and avoid? -->

Ever since I added the exception catch and display of an error message I felt that people might not know what to do instead without me telling them to when they report the issue.  This helps elevate that.

## How did you test?
<!--
Please explain the methodology for how you verified this solution. It helps to
describe the primary case and the possible edge cases that you considered and
ultimately how you tested them. If you didn't rulled out any edge cases, please
mention the rationale here.
-->

Manually validated the message returns correctly via the steps to verify. I did not think it was necessary to automate this piece as we don't mess with the `__main__.py` very much.

## How to Verify
<!-- Please provide a list of steps to validate your solution -->

1. Check out this PR
2. Modify src/semantic_release/cli/commands/main.py and add `raise Exception` at the bottom of the file.
3. Execute `semantic-release changelog` and you will see the error and a recommendation
4. Execute `semantic-release -vv changelog` and you will see the stacktrace and error without any recommendation.
