### PR TITLE
fix(cmd-version): force tag timestamp to be same time as release commit

### DIFF
--- a/src/semantic_release/cli/commands/version.py
+++ b/src/semantic_release/cli/commands/version.py
@@ -653,6 +653,7 @@ def version(  # noqa: C901
         project.git_tag(
             tag_name=new_version.as_tag(),
             message=new_version.as_tag(),
+            isotimestamp=commit_date.isoformat(),
             noop=opts.noop,
         )
 


### PR DESCRIPTION
<!--
Please do not combine multiple features or fix actions that are not
directly dependent on one another. Please open multiple PRs instead because
one may be merged while the other is denied or has requested changes. This
will slow down the process of merging the accepted changes as reviews are
also more difficult to evaluate for edge cases.
-->

## Purpose
<!-- Reason for the PR (solves an issue/problem, adds a feature, etc) -->

- Controls date that is defined by the release tag

## Rationale
<!-- How did you come to this conclusion as the solution? What was your reasoning? What were you trying to do? What problems did you find and avoid? -->

Ultimately this is more to just control the datetime of a tag deliberately as we are doing the same for the commit action.  This also very much helps testing as we can control the datetime from within the test cases as well which is very necessary to ensure changelogs and stable dates for whenever the automated pipelines execute.

