### PR TITLE
fix(changelog): ensure user rendered files are trimmed to only a single ending newline

### DIFF
--- a/src/semantic_release/changelog/template.py
+++ b/src/semantic_release/changelog/template.py
@@ -124,9 +124,9 @@ def recursive_render(
             # is used for inserting into a current changelog. When using stream rendering
             # of the same file, it always came back empty
             log.debug("rendering %s to %s", src_file_path, output_file_path)
-            rendered_file = environment.get_template(src_file_path).render()
+            rendered_file = environment.get_template(src_file_path).render().rstrip()
             with open(output_file_path, "w", encoding="utf-8") as output_file:
-                output_file.write(rendered_file)
+                output_file.write(f"{rendered_file}\n")
 
             rendered_paths.append(output_file_path)
         else:


### PR DESCRIPTION
<!--
Please do not combine multiple features or fix actions that are not
directly dependent on one another. Please open multiple PRs instead because
one may be merged while the other is denied or has requested changes. This
will slow down the process of merging the accepted changes as reviews are
also more difficult to evaluate for edge cases.
-->

## Purpose
<!-- Reason for the PR (solves an issue/problem, adds a feature, etc) -->

- Trims the resulting templates to a single newline at end of a file

## Rationale
<!-- How did you come to this conclusion as the solution? What was your reasoning? What were you trying to do? What problems did you find and avoid? -->

I came across this problem when doing some testing of the rebuild repo tests where the changelog would have a random extra newline.  This resolves that.

## How did you test?
<!--
Please explain the methodology for how you verified this solution. It helps to
describe the primary case and the possible edge cases that you considered and
ultimately how you tested them. If you didn't rulled out any edge cases, please
mention the rationale here.
-->

The new rebuild tests will validate this when the tests actually work because the changelogs that are generated match the changelog build through the test code.

