### PR TITLE
fix(config): ensure default config loads on network mounted windows environments

### DIFF
--- a/src/semantic_release/cli/config.py
+++ b/src/semantic_release/cli/config.py
@@ -360,9 +360,12 @@ class RawConfig(BaseModel):
         try:
             # Check for repository & walk up parent directories
             with Repo(str(dir_path), search_parent_directories=True) as git_repo:
-                found_path = Path(
-                    git_repo.working_tree_dir or git_repo.working_dir
-                ).absolute()
+                found_path = (
+                    Path(git_repo.working_tree_dir or git_repo.working_dir)
+                    .expanduser()
+                    .absolute()
+                )
+
         except InvalidGitRepositoryError as err:
             raise InvalidGitRepositoryError("No valid git repository found!") from err
 
@@ -370,7 +373,8 @@ class RawConfig(BaseModel):
             logging.warning(
                 "Found .git/ in higher parent directory rather than provided in configuration."
             )
-        return found_path
+
+        return found_path.resolve()
 
     @field_validator("commit_parser", mode="after")
     @classmethod

--- a/tests/e2e/cmd_config/test_generate_config.py
+++ b/tests/e2e/cmd_config/test_generate_config.py
@@ -9,13 +9,17 @@ import tomlkit
 from semantic_release.cli.commands.main import main
 from semantic_release.cli.config import RawConfig
 
-from tests.const import GENERATE_CONFIG_SUBCMD, MAIN_PROG_NAME
+from tests.const import GENERATE_CONFIG_SUBCMD, MAIN_PROG_NAME, VERSION_SUBCMD
+from tests.fixtures.repos import repo_w_no_tags_angular_commits
 from tests.util import assert_successful_exit_code
 
 if TYPE_CHECKING:
+    from pathlib import Path
     from typing import Any
 
     from click.testing import CliRunner
+
+    from tests.fixtures.example_project import ExProjectDir
 
 
 @pytest.fixture
@@ -24,44 +28,106 @@ def raw_config_dict() -> dict[str, Any]:
 
 
 @pytest.mark.parametrize("args", [(), ("--format", "toml"), ("--format", "TOML")])
+@pytest.mark.usefixtures(repo_w_no_tags_angular_commits.__name__)
 def test_generate_config_toml(
-    cli_runner: CliRunner, args: tuple[str], raw_config_dict: dict[str, Any]
+    cli_runner: CliRunner,
+    args: tuple[str],
+    raw_config_dict: dict[str, Any],
+    example_project_dir: ExProjectDir,
 ):
+    # Setup: Generate the expected configuration as a TOML string
     expected_config_as_str = tomlkit.dumps(
         {"semantic_release": raw_config_dict}
     ).strip()
 
+    # Act: Print the generated configuration to stdout
     cli_cmd = [MAIN_PROG_NAME, GENERATE_CONFIG_SUBCMD, *args]
-
     result = cli_runner.invoke(main, cli_cmd[1:])
 
+    # Evaluate: Check that the command ran successfully and that the output matches the expected configuration
     assert_successful_exit_code(result, cli_cmd)
     assert expected_config_as_str == result.output.strip()
 
+    # Setup: Write the generated configuration to a file
+    config_file = "releaserc.toml"
+    example_project_dir.joinpath(config_file).write_text(result.output)
+
+    # Act: Validate that the generated config is a valid configuration for PSR
+    cli_cmd = [
+        MAIN_PROG_NAME,
+        "--noop",
+        "--strict",
+        "-c",
+        config_file,
+        VERSION_SUBCMD,
+        "--print",
+    ]
+    result = cli_runner.invoke(main, cli_cmd[1:])
+
+    # Evaluate: Check that the version command in noop mode ran successfully
+    #   which means PSR loaded the configuration successfully
+    assert_successful_exit_code(result, cli_cmd)
+
 
 @pytest.mark.parametrize("args", [("--format", "json"), ("--format", "JSON")])
+@pytest.mark.usefixtures(repo_w_no_tags_angular_commits.__name__)
 def test_generate_config_json(
-    cli_runner: CliRunner, args: tuple[str], raw_config_dict: dict[str, Any]
+    cli_runner: CliRunner,
+    args: tuple[str],
+    raw_config_dict: dict[str, Any],
+    example_project_dir: ExProjectDir,
 ):
+    # Setup: Generate the expected configuration as a JSON string
     expected_config_as_str = json.dumps(
         {"semantic_release": raw_config_dict}, indent=4
     ).strip()
 
+    # Act: Print the generated configuration to stdout
     cli_cmd = [MAIN_PROG_NAME, GENERATE_CONFIG_SUBCMD, *args]
-
     result = cli_runner.invoke(main, cli_cmd[1:])
 
+    # Evaluate: Check that the command ran successfully and that the output matches the expected configuration
     assert_successful_exit_code(result, cli_cmd)
     assert expected_config_as_str == result.output.strip()
 
+    # Setup: Write the generated configuration to a file
+    config_file = "releaserc.json"
+    example_project_dir.joinpath(config_file).write_text(result.output)
 
+    # Act: Validate that the generated config is a valid configuration for PSR
+    cli_cmd = [
+        MAIN_PROG_NAME,
+        "--noop",
+        "--strict",
+        "-c",
+        config_file,
+        VERSION_SUBCMD,
+        "--print",
+    ]
+    result = cli_runner.invoke(main, cli_cmd[1:])
+
+    # Evaluate: Check that the version command in noop mode ran successfully
+    #   which means PSR loaded the configuration successfully
+    assert_successful_exit_code(result, cli_cmd)
+
+
+@pytest.mark.usefixtures(repo_w_no_tags_angular_commits.__name__)
 def test_generate_config_pyproject_toml(
-    cli_runner: CliRunner, raw_config_dict: dict[str, Any]
+    cli_runner: CliRunner,
+    raw_config_dict: dict[str, Any],
+    example_pyproject_toml: Path,
 ):
+    # Setup: Generate the expected configuration as a TOML string according to PEP 518
     expected_config_as_str = tomlkit.dumps(
         {"tool": {"semantic_release": raw_config_dict}}
     ).strip()
 
+    # Setup: Remove any current configuration from pyproject.toml
+    pyproject_config = tomlkit.loads(example_pyproject_toml.read_text(encoding="utf-8"))
+    pyproject_config.get("tool", {}).pop("semantic_release", None)
+    example_pyproject_toml.write_text(tomlkit.dumps(pyproject_config))
+
+    # Act: Print the generated configuration to stdout
     cli_cmd = [
         MAIN_PROG_NAME,
         GENERATE_CONFIG_SUBCMD,
@@ -69,8 +135,27 @@ def test_generate_config_pyproject_toml(
         "toml",
         "--pyproject",
     ]
-
     result = cli_runner.invoke(main, cli_cmd[1:])
 
+    # Evaluate: Check that the command ran successfully and that the output matches the expected configuration
     assert_successful_exit_code(result, cli_cmd)
     assert expected_config_as_str == result.output.strip()
+
+    # Setup: Write the generated configuration to a file
+    example_pyproject_toml.write_text(
+        str.join(
+            "\n\n",
+            [
+                example_pyproject_toml.read_text(encoding="utf-8").strip(),
+                result.output,
+            ],
+        )
+    )
+
+    # Act: Validate that the generated config is a valid configuration for PSR
+    cli_cmd = [MAIN_PROG_NAME, "--noop", "--strict", VERSION_SUBCMD, "--print"]
+    result = cli_runner.invoke(main, cli_cmd[1:])
+
+    # Evaluate: Check that the version command in noop mode ran successfully
+    #   which means PSR loaded the configuration successfully
+    assert_successful_exit_code(result, cli_cmd)


### PR DESCRIPTION
<!--
Please do not combine multiple features or fix actions that are not
directly dependent on one another. Please open multiple PRs instead because
one may be merged while the other is denied or has requested changes. This
will slow down the process of merging the accepted changes as reviews are
also more difficult to evaluate for edge cases.
-->

## Purpose
<!-- Reason for the PR (solves an issue/problem, adds a feature, etc) -->

- Resolve #1123

## Rationale
<!-- How did you come to this conclusion as the solution? What was your reasoning? What were you trying to do? What problems did you find and avoid? -->

Similar to the previous error with windows (#994), resolution must take place to make absolute paths and then be able to validate them against one another. I didn't previously run `resolve()` on the found repo directory so it would display a symlink like alias of the home drive.  When the changelog parents were evaluated, the changelog file was fully resolved to the network share that it represented, which caused the error to be thrown.

## How did you test?
<!--
Please explain the methodology for how you verified this solution. It helps to
describe the primary case and the possible edge cases that you considered and
ultimately how you tested them. If you didn't rulled out any edge cases, please
mention the rationale here.
-->

The issue reporter tried the fix manually and it seemed to work. I modified our generate configuration tests to also load the configuration and run `semantic-release --noop --strict version --print` which should load the configuration fully and then attempt to evaluate the repository. If any of that fails then it will throw an error.  This way we will be able to detect a problem in the future on Windows in the CI, however, the CI does not have networked shares so it will be as close as we can get.

