### PR TITLE
Ci/fix docs version reference updater

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -67,9 +67,6 @@ jobs:
     needs: eval-changes
     with:
       python-versions-linux: '["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]'
-      # Since the test suite takes ~4 minutes to complete on windows, and windows is billed higher
-      # we are only going to run it on the oldest version of python we support. The older version
-      # will be the most likely area to fail as newer minor versions maintain compatibility.
       python-versions-windows: '["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]'
       files-changed: ${{ needs.eval-changes.outputs.any-file-changes }}
       build-files-changed: ${{ needs.eval-changes.outputs.build-changes }}
@@ -115,6 +112,22 @@ jobs:
         with:
           name: ${{ needs.validate.outputs.distribution-artifacts }}
           path: dist
+
+      - name: Evaluate | Determine Next Version
+        id: version
+        uses: ./
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          root_options: "-v --noop"
+
+      - name: Release | Bump Version in Docs
+        if: steps.version.outputs.released == 'true' && steps.version.outputs.is_prerelease == 'false'
+        env:
+          NEW_VERSION: ${{ steps.version.outputs.version }}
+          NEW_RELEASE_TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          python -m scripts.bump_version_in_docs
+          git add docs/*
 
       - name: Release | Python Semantic Release
         id: release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -400,8 +400,6 @@ ignore_names = ["change_to_ex_proj_dir", "init_example_project"]
 logging_use_named_masks = true
 commit_parser = "angular"
 build_command = """
-    python -m scripts.bump_version_in_docs
-    git add docs/*
     python -m pip install -e .[build]
     python -m build .
 """

--- a/scripts/bump_version_in_docs.py
+++ b/scripts/bump_version_in_docs.py
@@ -3,35 +3,38 @@ from __future__ import annotations
 
 from os import getenv
 from pathlib import Path
-from re import compile as RegExp  # noqa: N812
+from re import compile as regexp
 
 PROJ_DIR = Path(__file__).resolve().parent.parent
 DOCS_DIR = PROJ_DIR / "docs"
 
 
-def update_github_actions_example(filepath: Path, new_version: str) -> None:
-    psr_regex = RegExp(r"(uses:.*python-semantic-release)@v\d+\.\d+\.\d+")
+def update_github_actions_example(filepath: Path, release_tag: str) -> None:
+    psr_regex = regexp(r"(uses: python-semantic-release/python-semantic-release)@\S+$")
+    psr_publish_action_regex = regexp(
+        r"(uses: python-semantic-release/publish-action)@\S+$"
+    )
     file_content_lines: list[str] = filepath.read_text().splitlines()
 
-    for regex in [psr_regex]:
+    for regex in [psr_regex, psr_publish_action_regex]:
         file_content_lines = list(
             map(
-                lambda line, regex=regex: regex.sub(r"\1@v" + new_version, line),  # type: ignore[misc]
+                lambda line, regex=regex: regex.sub(r"\1@" + release_tag, line),  # type: ignore[misc]
                 file_content_lines,
             )
         )
 
-    print(f"Bumping version in {filepath} to", new_version)
+    print(f"Bumping version in {filepath} to", release_tag)
     filepath.write_text(str.join("\n", file_content_lines) + "\n")
 
 
 if __name__ == "__main__":
-    new_version = getenv("NEW_VERSION")
+    new_release_tag = getenv("NEW_RELEASE_TAG")
 
-    if not new_version:
-        print("NEW_VERSION environment variable is not set")
+    if not new_release_tag:
+        print("NEW_RELEASE_TAG environment variable is not set")
         exit(1)
 
     update_github_actions_example(
-        DOCS_DIR / "automatic-releases" / "github-actions.rst", new_version
+        DOCS_DIR / "automatic-releases" / "github-actions.rst", new_release_tag
     )


### PR DESCRIPTION
<!--
Please do not combine multiple features or fix actions that are not
directly dependent on one another. Please open multiple PRs instead because
one may be merged while the other is denied or has requested changes. This
will slow down the process of merging the accepted changes as reviews are
also more difficult to evaluate for edge cases.
-->

## Purpose
<!-- Reason for the PR (solves an issue/problem, adds a feature, etc) -->

- Re-enables the automatic documentation updates of this repository that were configured prior to v9.13.0

## Rationale
<!-- How did you come to this conclusion as the solution? What was your reasoning? What were you trying to do? What problems did you find and avoid? -->

When I moved around the CI workflow to make sure we were testing the exact artifact that we were releasing it moved the build step forward in the workflow and removed it from the end. Because of this, the documentation update was no longer being executed during the release so the documentation was not getting updated. This PR, after #1140, makes the automated documentation update work again.

## How did you test?
<!--
Please explain the methodology for how you verified this solution. It helps to
describe the primary case and the possible edge cases that you considered and
ultimately how you tested them. If you didn't rulled out any edge cases, please
mention the rationale here.
-->

I ran a fake release on my own fork off of master to ensure that the release included the doc updates.  It worked. Unfortunately it takes a little longer because we have to run PSR twice now, but hopefully in the future when we have caching this will be sped up on the second run.

## How to Verify
<!-- Please provide a list of steps to validate your solution -->

