### PR TITLE
fix(parser-custom): handle relative parent directory paths to module file better

### DIFF
--- a/src/semantic_release/helpers.py
+++ b/src/semantic_release/helpers.py
@@ -69,7 +69,6 @@ def dynamic_import(import_path: str) -> Any:
     Dynamically import an object from a conventionally formatted "module:attribute"
     string
     """
-    log.debug("Trying to import %s", import_path)
     module_name, attr = import_path.split(":", maxsplit=1)
 
     # Check if the module is a file path, if it can be resolved and exists on disk then import as a file
@@ -78,10 +77,11 @@ def dynamic_import(import_path: str) -> Any:
         module_path = (
             module_filepath.stem
             if Path(module_name).is_absolute()
-            else str(Path(module_name).with_suffix("")).replace(os.sep, ".")
+            else str(Path(module_name).with_suffix("")).replace(os.sep, ".").lstrip(".")
         )
 
         if module_path not in sys.modules:
+            log.debug("Loading '%s' from file '%s'", module_path, module_filepath)
             spec = importlib.util.spec_from_file_location(
                 module_path, str(module_filepath)
             )
@@ -96,7 +96,9 @@ def dynamic_import(import_path: str) -> Any:
 
     # Otherwise, import as a module
     try:
+        log.debug("Importing module '%s'", module_name)
         module = importlib.import_module(module_name)
+        log.debug("Loading '%s' from module '%s'", attr, module_name)
         return getattr(module, attr)
     except TypeError as err:
         raise ImportError(


### PR DESCRIPTION
<!--
Please do not combine multiple features or fix actions that are not
directly dependent on one another. Please open multiple PRs instead because
one may be merged while the other is denied or has requested changes. This
will slow down the process of merging the accepted changes as reviews are
also more difficult to evaluate for edge cases.
-->

## Purpose
<!-- Reason for the PR (solves an issue/problem, adds a feature, etc) -->

- Avoids any issues with dynamic importing given a file name with parent path traversals

## Rationale
<!-- How did you come to this conclusion as the solution? What was your reasoning? What were you trying to do? What problems did you find and avoid? -->

The dynamic import originally would just replace "/" with "." to make the import module name more pythonic, however this would be problematic in monorepos which would use "../../misc/commit_parser.py" to locate the parser and so the resulting `sys.modules` entry would have numerous periods (.) as a prefix. This removes that possibility. Still always an issue if the imported module name matches an existing module but the likelihood is low.

## How did you test?
<!--
Please explain the methodology for how you verified this solution. It helps to
describe the primary case and the possible edge cases that you considered and
ultimately how you tested them. If you didn't rulled out any edge cases, please
mention the rationale here.
-->

Used my codejedi365/psr-monorepo-poweralpha repository to test a custom monorepo parser and release
