### PR TITLE
perf(logging): remove irrelevant debug logging statements

### DIFF
--- a/src/semantic_release/changelog/release_history.py
+++ b/src/semantic_release/changelog/release_history.py
@@ -131,9 +131,9 @@ class ReleaseHistory:
             # commits included, the true reason for a version bump would be missing.
             if has_exclusion_match and commit_level_bump == LevelBump.NO_RELEASE:
                 log.info(
-                    "Excluding commit [%s] %s",
-                    commit.hexsha[:8],
-                    commit_message.replace("\n", " ")[:50],
+                    "Excluding commit[%s] %s",
+                    parse_result.short_hash,
+                    commit_message.split("\n", maxsplit=1)[0][:40],
                 )
                 continue
 
@@ -145,29 +145,29 @@ class ReleaseHistory:
                     str.join(
                         " ",
                         [
-                            "Excluding commit %s (%s) because parser determined",
+                            "Excluding commit[%s] (%s) because parser determined",
                             "it should not included in the changelog",
                         ],
                     ),
-                    commit.hexsha[:8],
+                    parse_result.short_hash,
                     commit_message.replace("\n", " ")[:20],
                 )
                 continue
 
             if the_version is None:
                 log.info(
-                    "[Unreleased] adding '%s' commit(%s) to list",
-                    commit.hexsha[:8],
+                    "[Unreleased] adding commit[%s] to unreleased '%s'",
+                    parse_result.short_hash,
                     commit_type,
                 )
                 unreleased[commit_type].append(parse_result)
                 continue
 
             log.info(
-                "[%s] adding '%s' commit(%s) to release",
+                "[%s] adding commit[%s] to release '%s'",
                 the_version,
+                parse_result.short_hash,
                 commit_type,
-                commit.hexsha[:8],
             )
 
             released[the_version]["elements"][commit_type].append(parse_result)

--- a/src/semantic_release/changelog/template.py
+++ b/src/semantic_release/changelog/template.py
@@ -54,7 +54,6 @@ def environment(
         autoescape_value = dynamic_import(autoescape)
     else:
         autoescape_value = autoescape
-    log.debug("%s", locals())
 
     return ComplexDirectorySandboxedEnvironment(
         block_start_string=block_start_string,

--- a/src/semantic_release/cli/commands/version.py
+++ b/src/semantic_release/cli/commands/version.py
@@ -65,7 +65,7 @@ def is_forced_prerelease(
     log.debug(
         "%s: %s",
         is_forced_prerelease.__name__,
-        ", ".join(f"{k} = {v}" for k, v in local_vars),
+        str.join(", ", iter(f"{k} = {v}" for k, v in local_vars)),
     )
     return (
         as_prerelease

--- a/src/semantic_release/cli/masking_filter.py
+++ b/src/semantic_release/cli/masking_filter.py
@@ -27,7 +27,7 @@ class MaskingFilter(logging.Filter):
 
     def add_mask_for(self, data: str, name: str = "redacted") -> MaskingFilter:
         if data and data not in self._UNWANTED:
-            log.debug("Adding redact pattern %r to _redact_patterns", name)
+            log.debug("Adding redact pattern '%r' to redact_patterns", name)
             self._redact_patterns[name].add(data)
         return self
 

--- a/src/semantic_release/version/algorithm.py
+++ b/src/semantic_release/version/algorithm.py
@@ -89,7 +89,6 @@ def _traverse_graph_for_commits(
             # Add all parent commits to the stack from left to right so that the rightmost is popped first
             # as the left side is generally the merged into branch
             for parent in node.parents:
-                logger.debug("queuing parent commit %s", parent.hexsha[:7])
                 stack.put(parent)
 
         return commits


### PR DESCRIPTION
<!--
Please do not combine multiple features or fix actions that are not
directly dependent on one another. Please open multiple PRs instead because
one may be merged while the other is denied or has requested changes. This
will slow down the process of merging the accepted changes as reviews are
also more difficult to evaluate for edge cases.
-->

## Purpose
<!-- Reason for the PR (solves an issue/problem, adds a feature, etc) -->

- Remove extra debug statements

## Rationale
<!-- How did you come to this conclusion as the solution? What was your reasoning? What were you trying to do? What problems did you find and avoid? -->

It ends up most people run the CI in very verbose (`-vv`) mode because its hard to debug in an ephemeral environment. Unfortunately, PSR had some debug statements that really don't provide much value and end up just cluttering the output log. I got rid of those and then validated the rest of the logs messages are helpful and should be at the designated level or not.
