### PR TITLE
fix: Deal with remote urls aliased using insteadOf directives

### DIFF
--- a/src/semantic_release/cli/config.py
+++ b/src/semantic_release/cli/config.py
@@ -602,7 +602,12 @@ class RuntimeContext:
         # Retrieve details from repository
         with Repo(str(raw.repo_dir)) as git_repo:
             try:
-                remote_url = raw.remote.url or git_repo.remote(raw.remote.name).url
+                # Get the remote url by calling out to `git remote get-url`. This returns
+                # the expanded url, taking into account any insteadOf directives
+                # in the git configuration.
+                remote_url = raw.remote.url or git_repo.git.remote(
+                    "get-url", raw.remote.name
+                )
                 active_branch = git_repo.active_branch.name
             except ValueError as err:
                 raise MissingGitRemote(

--- a/src/semantic_release/hvcs/_base.py
+++ b/src/semantic_release/hvcs/_base.py
@@ -30,7 +30,7 @@ class HvcsBase(metaclass=ABCMeta):
     """
 
     def __init__(self, remote_url: str, *args: Any, **kwargs: Any) -> None:
-        self._remote_url = remote_url
+        self._remote_url = remote_url if parse_git_url(remote_url) else ""
         self._name: str | None = None
         self._owner: str | None = None
 

--- a/tests/unit/semantic_release/hvcs/test__base.py
+++ b/tests/unit/semantic_release/hvcs/test__base.py
@@ -57,9 +57,6 @@ def test_get_repository_name(remote_url, owner):
         "git@gitlab.com/somewhere",
     ],
 )
-def test_hvcs_parse_error(bad_url):
-    client = ArbitraryHvcs(bad_url)
+def test_hvcs_parse_error(bad_url: str):
     with pytest.raises(ValueError):
-        _ = client.repo_name
-    with pytest.raises(ValueError):
-        _ = client.owner
+        ArbitraryHvcs(bad_url)


### PR DESCRIPTION
## Purpose

- Add support for git insteadOf configuration for repository origin
- Resolves: #1150

## Rationale

Previously, python-semantic-release would attempt to use the raw url from
the repository configuration (`me:myproject` in the above example), and
would fail to parse it because it's not actually a url. With this change,
psr instead calls out to `git remote get-url`, which fully expands any aliases via git.

[1]: https://git-scm.com/docs/git-config#Documentation/git-config.txt-urlltbasegtinsteadOf

## How I tested

Created a unit test that will modify a git configuration with a remote origin defined with an alias and the associated alias defined separately.  The runtime context is loaded and then validated through the GitHub VCS client.

## How to Verify

```sh
git fetch pull/1151/head pr-1151
git checkout pr-1151~1 --detach

# validate the added test will replicate the failure on the original code
pytest -vv -k test_git_remote_url_w_insteadof_alias

# Checkout the latest
git checkout pr-1151

# Run the tests again and see the failure is resolved
pytest -vv -k test_git_remote_url_w_insteadof_alias
```
