### PR TITLE
feat: Disable writing Python bytecode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,6 @@ RUN \
 
 ENV PSR_DOCKER_GITHUB_ACTION=true
 
+ENV PYTHONDONTWRITEBYTECODE=1
+
 ENTRYPOINT ["/bin/bash", "-l", "/psr/action.sh"]


### PR DESCRIPTION
<!--
Please do not combine multiple features or fix actions that are not
directly dependent on one another. Please open multiple PRs instead because
one may be merged while the other is denied or has requested changes. This
will slow down the process of merging the accepted changes as reviews are
also more difficult to evaluate for edge cases.
-->

## Purpose
<!-- Reason for the PR (solves an issue/problem, adds a feature, etc) -->
Permission issues can occur on the Python bytecode files as the container entrypoint is being run as the root user. When e.g. using a custom parser the bytecode file will be owned by the root user instead of the user running the action.
This can cause subsequent steps to fail.
For example when running actions/checkout after python-semantic-release it will try to do a `git clean -ffdx` which will fail to remove the pyc file.


## Rationale
<!-- How did you come to this conclusion as the solution? What was your reasoning? What were you trying to do? What problems did you find and avoid? -->
This could probably also be avoided by running the entrypoint as a non privileged user, but this would require using sudo or alternative solutions for running e.g. the `git config --system` command.
In general the usage of the root user isn't really a problem for this action so this seems to be the most straightforward way to workaound the permission issues.


## How did you test?
<!--
Please explain the methodology for how you verified this solution. It helps to
describe the primary case and the possible edge cases that you considered and
ultimately how you tested them. If you didn't rulled out any edge cases, please
mention the rationale here.
-->
- Defined a workflow using the latest v9 of python-semantic-release with an additional checkout at the end: https://github.com/kwevers/stunnel/commit/3466e0e8b49760c863f84dae5e0b5fe863626b2f
- Workflow completes fine: https://github.com/kwevers/stunnel/actions/runs/12914296597
- Add custom commit parser: https://github.com/kwevers/stunnel/commit/0107a25dc295b90b1e8fa1df62fcae93127827f9
- Workflow fails with permissions errors on the pyc file: https://github.com/kwevers/stunnel/actions/runs/12914411688
- Reference https://github.com/kwevers/python-semantic-release/tree/bugfix/python-byte-code which disables bytecode writing: https://github.com/kwevers/stunnel/commit/00cf3f9d51b88af15c05d1064c4bf35c82ce78c6
- Workflow works fine: https://github.com/kwevers/stunnel/actions/runs/12914460530


## How to Verify
<!-- Please provide a list of steps to validate your solution -->
See linked actions in testing section.
