### PR TITLE
chore(scripts): extend stamping to all docs with $NEW_VERSION & $NEW_RELEASE_TAG vars

### DIFF
--- a/scripts/bump_version_in_docs.py
+++ b/scripts/bump_version_in_docs.py
@@ -5,8 +5,11 @@ from os import getenv
 from pathlib import Path
 from re import compile as regexp
 
+# Constants
 PROJ_DIR = Path(__file__).resolve().parent.parent
 DOCS_DIR = PROJ_DIR / "docs"
+version_replace_pattern = regexp(r"\$(NEW_VERSION|{NEW_VERSION})")
+tag_replace_pattern = regexp(r"\$(NEW_RELEASE_TAG|{NEW_RELEASE_TAG})")
 
 
 def update_github_actions_example(filepath: Path, release_tag: str) -> None:
@@ -28,13 +31,37 @@ def update_github_actions_example(filepath: Path, release_tag: str) -> None:
     filepath.write_text(str.join("\n", file_content_lines) + "\n")
 
 
+def envsubst(filepath: Path, version: str, release_tag: str) -> None:
+    file_content = filepath.read_text()
+
+    found = False
+    for pattern, replacement in [
+        (version_replace_pattern, version),
+        (tag_replace_pattern, release_tag),
+    ]:
+        if not found and (found := bool(pattern.search(file_content))):
+            print(f"Applying envsubst to {filepath}")
+
+        file_content = pattern.sub(replacement, file_content)
+
+    filepath.write_text(file_content)
+
+
 if __name__ == "__main__":
     new_release_tag = getenv("NEW_RELEASE_TAG")
+    new_version = getenv("NEW_VERSION")
 
     if not new_release_tag:
         print("NEW_RELEASE_TAG environment variable is not set")
         exit(1)
 
+    if not new_version:
+        print("NEW_VERSION environment variable is not set")
+        exit(1)
+
     update_github_actions_example(
         DOCS_DIR / "automatic-releases" / "github-actions.rst", new_release_tag
     )
+
+    for doc_file in DOCS_DIR.rglob("*.rst"):
+        envsubst(filepath=doc_file, version=new_version, release_tag=new_release_tag)


### PR DESCRIPTION
<!--
Please do not combine multiple features or fix actions that are not
directly dependent on one another. Please open multiple PRs instead because
one may be merged while the other is denied or has requested changes. This
will slow down the process of merging the accepted changes as reviews are
also more difficult to evaluate for edge cases.
-->

## Purpose
<!-- Reason for the PR (solves an issue/problem, adds a feature, etc) -->

Simplify adding doc statements for when a feature is introduced

## Rationale
<!-- How did you come to this conclusion as the solution? What was your reasoning? What were you trying to do? What problems did you find and avoid? -->

Previously I would have to monitor which version was going to be released to make sure the docs would state when a feature was introduced. This change makes it automatic to replace key variables in the docs.

## How did you test?
<!--
Please explain the methodology for how you verified this solution. It helps to
describe the primary case and the possible edge cases that you considered and
ultimately how you tested them. If you didn't rulled out any edge cases, please
mention the rationale here.
-->

Manual execution of script

