### PR TITLE
config, version_variables: allow @ as separator and v to precede the version

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1340,14 +1340,22 @@ to substitute the version number in the file. The replacement algorithm is **ONL
 pattern match and replace. It will **NOT** evaluate the code nor will PSR understand
 any internal object structures (ie. ``file:object.version`` will not work).
 
-.. important::
-    The Regular Expression expects a version value to exist in the file to be replaced.
-    It cannot be an empty string or a non-semver compliant string. If this is the very
-    first time you are using PSR, we recommend you set the version to ``0.0.0``.
+The regular expression generated from the ``version_variables`` definition will:
 
-    This may become more flexible in the future with resolution of issue `#941`_.
+1. Look for the specified ``variable`` name in the ``file``. The variable name can be
+   enclosed by single (``'``) or double (``"``) quotation marks but they must match.
 
-.. _#941: https://github.com/python-semantic-release/python-semantic-release/issues/941
+2. The variable name defined by ``variable`` and the version must be separated by
+   an operand symbol (``=``, ``:``, ``:=``, or ``@``). Whitespace is optional around
+   the symbol.
+
+3. The value of the variable must match a `SemVer`_ regular expression and can be
+   enclosed by single (``'``) or double (``"``) quotation marks but they must match. However,
+   the enclosing quotes of the value do not have to match the quotes surrounding the variable
+   name.
+
+4. If the format type is set to ``tf`` then the variable value must have the matching prefix
+   and suffix of the :ref:`config-tag_format` setting around the `SemVer`_ version number.
 
 Given the pattern matching nature of this feature, the Regular Expression is able to
 support most file formats because of the similarity of variable declaration across
@@ -1359,6 +1367,47 @@ regardless of file extension because it looks for a matching pattern string.
     This will also work for TOML but we recommend using :ref:`config-version_toml` for
     TOML files as it actually will interpret the TOML file and replace the version
     number before writing the file back to disk.
+
+This is a comprehensive list (but not all variations) of examples where the following versions
+will be matched and replaced by the new version:
+
+.. code-block::
+
+    # Common variable declaration formats
+    version='1.2.3'
+    version = "1.2.3"
+    release = "v1.2.3"     # if tag_format is set
+
+    # YAML
+    version: 1.2.3
+
+    # JSON
+    "version": "1.2.3"
+
+    # NPM & GitHub Actions YAML
+    version@1.2.3
+    version@v1.2.3        # if tag_format is set
+
+    # Walrus Operator
+    version := "1.2.3"
+
+    # Excessive whitespace
+    version        =    '1.2.3'
+
+    # Mixed Quotes
+    "version" = '1.2.3'
+
+    # Custom Tag Format with tag_format set (monorepos)
+    __release__ = "module-v1.2.3"
+
+.. important::
+    The Regular Expression expects a version value to exist in the file to be replaced.
+    It cannot be an empty string or a non-semver compliant string. If this is the very
+    first time you are using PSR, we recommend you set the version to ``0.0.0``.
+
+    This may become more flexible in the future with resolution of issue `#941`_.
+
+.. _#941: https://github.com/python-semantic-release/python-semantic-release/issues/941
 
 .. warning::
     If the file (ex. JSON) you are replacing has two of the same variable name in it,

--- a/src/semantic_release/version/declaration.py
+++ b/src/semantic_release/version/declaration.py
@@ -14,8 +14,6 @@ from semantic_release.version.declarations.pattern import PatternVersionDeclarat
 from semantic_release.version.declarations.toml import TomlVersionDeclaration
 
 if TYPE_CHECKING:  # pragma: no cover
-    from typing import Any
-
     from semantic_release.version.version import Version
 
 
@@ -66,13 +64,8 @@ class VersionDeclarationABC(ABC):
             self._content = self.path.read_text()
         return self._content
 
-    # mypy doesn't like properties?
-    @content.setter  # type: ignore[attr-defined]
-    def _(self, _: Any) -> None:
-        raise AttributeError("'content' cannot be set directly")
-
-    @content.deleter  # type: ignore[attr-defined]
-    def _(self) -> None:
+    @content.deleter
+    def content(self) -> None:
         log.debug("resetting instance-stored source file contents")
         self._content = None
 

--- a/src/semantic_release/version/declarations/pattern.py
+++ b/src/semantic_release/version/declarations/pattern.py
@@ -230,9 +230,9 @@ class PatternVersionDeclaration(IVersionReplacer):
                 # Supports optional matching quotations around variable name
                 # Negative lookbehind to ensure we don't match part of a variable name
                 f"""(?x)(?P<quote1>['"])?(?<![\\w.-]){regex_escape(variable)}(?P=quote1)?""",
-                # Supports walrus, equals sign, or colon as assignment operator ignoring
-                # whitespace separation
-                r"\s*(:=|[:=])\s*",
+                # Supports walrus, equals sign, colon, or @ as assignment operator
+                # ignoring whitespace separation
+                r"\s*(:=|[:=@])\s*",
                 # Supports optional matching quotations around a version pattern (tag or raw format)
                 f"""(?P<quote2>['"])?{value_replace_pattern_str}(?P=quote2)?""",
             ],

--- a/tests/unit/semantic_release/version/declarations/test_pattern_declaration.py
+++ b/tests/unit/semantic_release/version/declarations/test_pattern_declaration.py
@@ -93,6 +93,24 @@ def test_pattern_declaration_is_version_replacer():
                 f'''__version__ = "module-v{next_version}"''',
             ),
             (
+                # Based on https://github.com/python-semantic-release/python-semantic-release/issues/1156
+                "Using default tag format for github actions uses-directive",
+                f"{test_file}:repo/action-name:{VersionStampType.TAG_FORMAT.value}",
+                lazy_fixture(default_tag_format_str.__name__),
+                # Uses @ symbol separator without quotes or spaces
+                """  uses: repo/action-name@v1.0.0""",
+                f"""  uses: repo/action-name@v{next_version}""",
+            ),
+            (
+                # Based on https://github.com/python-semantic-release/python-semantic-release/issues/1156
+                "Using custom tag format for github actions uses-directive",
+                f"{test_file}:repo/action-name:{VersionStampType.TAG_FORMAT.value}",
+                "module-v{version}",
+                # Uses @ symbol separator without quotes or spaces
+                """  uses: repo/action-name@module-v1.0.0""",
+                f"""  uses: repo/action-name@module-v{next_version}""",
+            ),
+            (
                 # Based on https://github.com/python-semantic-release/python-semantic-release/issues/846
                 "Using default tag format for multi-line yaml",
                 f"{test_file}:newTag:{VersionStampType.TAG_FORMAT.value}",
@@ -205,7 +223,7 @@ def test_pattern_declaration_from_definition(
     When update_file_w_version() is called with a new version,
     Then the file is updated with the new version string in the specified tag or number format
 
-    Version variables can be separated by either "=", ":", or ':=' with optional whitespace
+    Version variables can be separated by either "=", ":", "@", or ':=' with optional whitespace
     between operator and variable name. The variable name or values can also be wrapped in either
     single or double quotes.
     """


### PR DESCRIPTION
<!--
Please do not combine multiple features or fix actions that are not
directly dependent on one another. Please open multiple PRs instead because
one may be merged while the other is denied or has requested changes. This
will slow down the process of merging the accepted changes as reviews are
also more difficult to evaluate for edge cases.
-->

## Purpose
As discussed in https://github.com/python-semantic-release/python-semantic-release/issues/1156 and https://github.com/python-semantic-release/python-semantic-release/issues/846, this adds two features to the version_variables configuration:

1. allow the @ separator between the search string and the version within the files
2. allow a single "v" without any spaces to precede the version

E.g. when running psr with the following configuration

```toml
[tool.semantic_release]
version_variables = ["my-versions.txt:version"]
```

and there is a `my-versions.txt` with content

```
version@v1.2.3
```

and the new version is `2.3.4` the content of `my-versions.txt` will be:

```
version@v2.3.4
```

## Rationale
<!-- How did you come to this conclusion as the solution? What was your reasoning? What were you trying to do? What problems did you find and avoid? -->
Simple adaption of the regex did the trick


## How did you test?
<!--
Please explain the methodology for how you verified this solution. It helps to
describe the primary case and the possible edge cases that you considered and
ultimately how you tested them. If you didn't rule out any edge cases, please
mention the rationale here.
-->
Unittesting was not easy as the implementation was entangled with other code. Therefore I did multiple commits:

* 49a93665984ea9770729e699b776aee86779f7b3 -> adapt the regex. This is the whole implementation of the features
* c3804fe4f1c63932b9f088b68b050f971b3462f8 -> documentation
* 47afae9fe73239babfaf388acd50c8f079c81d53 -> here i entangled the regex building from the config parsing. This way i was able to test the module on its own
* 456a2bfea730f4c1dbec3d4cf4cbe647b302b5c7 -> contains the unittests. This is my first time working with pytest. If i did something wrong, please let me know

Regarding the e2e tests: The tests are massive. I don't know where (and how i can expand those). I you point me to the right direction, i will add those tests.



## How to Verify
<!-- Please provide a list of steps to validate your solution -->
The new documentation gives an example how to configure


---

## PR Completion Checklist

- [x] Reviewed & followed the [Contributor Guidelines](https://python-semantic-release.readthedocs.io/en/latest/contributing.html)

- [x] Changes Implemented & Validation pipeline succeeds

- [x] Commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
  and are separated into the proper commit type and scope (recommended order: test, build, feat/fix, docs)

- [x] Appropriate Unit tests added/updated

- [x] Appropriate End-to-End tests added/updated

- [x] Appropriate Documentation added/updated and syntax validated for sphinx build (see Contributor Guidelines)
