### PR TITLE
Ci/apply concurrency to workflow

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -122,24 +122,16 @@ jobs:
           name: ${{ needs.validate.outputs.distribution-artifacts }}
           path: dist
 
-      - name: Evaluate | Determine Next Version
-        id: version
-        uses: ./
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          root_options: "-v --noop"
-
       - name: Release | Bump Version in Docs
-        if: steps.version.outputs.released == 'true' && steps.version.outputs.is_prerelease == 'false'
+        if: needs.validate.outputs.new-release-is-prerelease == 'false'
         env:
-          NEW_VERSION: ${{ steps.version.outputs.version }}
-          NEW_RELEASE_TAG: ${{ steps.version.outputs.tag }}
+          NEW_VERSION: ${{ needs.validate.outputs.new-release-version }}
+          NEW_RELEASE_TAG: ${{ needs.validate.outputs.new-release-tag }}
         run: |
           python -m scripts.bump_version_in_docs
           git add docs/*
 
       - name: Evaluate | Verify upstream has NOT changed
-        if: steps.version.outputs.released == 'true'
         # Last chance to abort before causing an error as another PR/push was applied to the upstream branch
         # while this workflow was running. This is important because we are committing a version change
         shell: bash
@@ -147,8 +139,7 @@ jobs:
 
       - name: Release | Python Semantic Release
         id: release
-        uses: ./
-        if: steps.version.outputs.released == 'true'
+        uses: python-semantic-release/python-semantic-release@v9.20.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           root_options: "-v"
@@ -185,7 +176,8 @@ jobs:
 
     outputs:
       released: ${{ steps.release.outputs.released || 'false' }}
-      tag: ${{ steps.release.outputs.tag }}
+      new-release-version: ${{ steps.release.outputs.version }}
+      new-release-tag: ${{ steps.release.outputs.tag }}
 
 
   deploy:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -205,19 +205,6 @@ jobs:
       id-token: write  # needed for PyPI upload
 
     steps:
-      # Note: we need to checkout the repository at the workflow sha in case during the workflow
-      # the branch was updated. To keep PSR working with the configured release branches,
-      # we force a checkout of the desired release branch but at the workflow sha HEAD.
-      - name: Setup | Checkout Repository at workflow sha
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-          ref: ${{ github.sha }}
-
-      - name: Setup | Force correct release branch on workflow sha
-        run: |
-          git checkout -B ${{ github.ref_name }}
-
       - name: Setup | Download Build Artifacts
         uses: actions/download-artifact@v4
         id: artifact-download
@@ -228,6 +215,8 @@ jobs:
       # see https://docs.pypi.org/trusted-publishers/
       - name: Publish package distributions to PyPI
         id: pypi-publish
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
+          packages-dir: dist
+          print-hash: true
           verbose: true

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -65,6 +65,9 @@ jobs:
   validate:
     uses: ./.github/workflows/validate.yml
     needs: eval-changes
+    concurrency:
+      group: ${{ github.workflow }}-validate-${{ github.ref_name }}
+      cancel-in-progress: true
     with:
       python-versions-linux: '["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]'
       python-versions-windows: '["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]'
@@ -81,9 +84,12 @@ jobs:
   release:
     name: Semantic Release
     runs-on: ubuntu-latest
-    concurrency: push
     needs: validate
     if: ${{ needs.validate.outputs.new-release-detected == 'true' }}
+
+    concurrency:
+      group: ${{ github.workflow }}-release-${{ github.ref_name }}
+      cancel-in-progress: false
 
     permissions:
       contents: write
@@ -93,18 +99,21 @@ jobs:
       GITHUB_ACTIONS_AUTHOR_EMAIL: actions@users.noreply.github.com
 
     steps:
-      # Note: we need to checkout the repository at the workflow sha in case during the workflow
-      # the branch was updated. To keep PSR working with the configured release branches,
-      # we force a checkout of the desired release branch but at the workflow sha HEAD.
-      - name: Setup | Checkout Repository at workflow sha
+      # Note: We checkout the repository at the branch that triggered the workflow
+      # with the entire history to ensure to match PSR's release branch detection
+      # and history evaluation.
+      # However, we forcefully reset the branch to the workflow sha because it is
+      # possible that the branch was updated while the workflow was running. This
+      # prevents accidentally releasing un-evaluated changes.
+      - name: Setup | Checkout Repository on Release Branch
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.ref_name }}
           fetch-depth: 0
-          ref: ${{ github.sha }}
 
-      - name: Setup | Force correct release branch on workflow sha
+      - name: Setup | Force release branch to be at workflow sha
         run: |
-          git checkout -B ${{ github.ref_name }}
+          git reset --hard ${{ github.sha }}
 
       - name: Setup | Download Build Artifacts
         uses: actions/download-artifact@v4
@@ -129,9 +138,17 @@ jobs:
           python -m scripts.bump_version_in_docs
           git add docs/*
 
+      - name: Evaluate | Verify upstream has NOT changed
+        if: steps.version.outputs.released == 'true'
+        # Last chance to abort before causing an error as another PR/push was applied to the upstream branch
+        # while this workflow was running. This is important because we are committing a version change
+        shell: bash
+        run: bash .github/workflows/verify_upstream.sh
+
       - name: Release | Python Semantic Release
         id: release
         uses: ./
+        if: steps.version.outputs.released == 'true'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           root_options: "-v"
@@ -139,6 +156,7 @@ jobs:
 
       - name: Release | Add distribution artifacts to GitHub Release Assets
         uses: python-semantic-release/publish-action@v9.20.0
+        if: steps.release.outputs.released == 'true'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ steps.release.outputs.tag }}
@@ -166,7 +184,7 @@ jobs:
           git push -u origin "$MAJOR_VERSION_TAG" --force
 
     outputs:
-      released: ${{ steps.release.outputs.released }}
+      released: ${{ steps.release.outputs.released || 'false' }}
       tag: ${{ steps.release.outputs.tag }}
 
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -47,6 +47,15 @@ on:
       new-release-detected:
         description: Boolean string result for if new release is available
         value: ${{ jobs.build.outputs.new-release-detected }}
+      new-release-version:
+        description: Version string for the new release
+        value: ${{ jobs.build.outputs.new-release-version }}
+      new-release-tag:
+        description: Tag string for the new release
+        value: ${{ jobs.build.outputs.new-release-tag }}
+      new-release-is-prerelease:
+        description: Boolean string result for if new release is a pre-release
+        value: ${{ jobs.build.outputs.new-release-is-prerelease }}
       distribution-artifacts:
         description: Artifact Download name for the distribution artifacts
         value: ${{ jobs.build.outputs.distribution-artifacts }}
@@ -91,17 +100,31 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
           pip install -e .[build]
 
-      - name: Build | Create the distribution artifacts
+      - name: Build | Build next version artifacts
+        id: version
+        uses: python-semantic-release/python-semantic-release@v9.20.0
+        with:
+          github_token: ""
+          root_options: "-v"
+          build: true
+          changelog: true
+          commit: false
+          push: false
+          tag: false
+          vcs_release: false
+
+      - name: Build | Annotate next version
+        if: steps.version.outputs.released == 'true'
+        run: |
+          printf '%s\n' "::notice::Next release will be '${{ steps.version.outputs.tag }}'"
+
+      - name: Build | Create non-versioned distribution artifact
+        if: steps.version.outputs.released == 'false'
+        run: python -m build .
+
+      - name: Build | Set distribution artifact variables
         id: build
         run: |
-          if new_version="$(semantic-release --strict version --print)"; then
-            printf '%s\n' "::notice::Next version will be '$new_version'"
-            printf '%s\n' "new_release_detected=true" >> $GITHUB_OUTPUT
-            semantic-release version --changelog --no-commit --no-tag
-          else
-            printf '%s\n' "new_release_detected=false" >> $GITHUB_OUTPUT
-            python -m build .
-          fi
           printf '%s\n' "dist_dir=dist/*" >> $GITHUB_OUTPUT
           printf '%s\n' "artifacts_name=dist" >> $GITHUB_OUTPUT
 
@@ -114,7 +137,10 @@ jobs:
           retention-days: 2
 
     outputs:
-      new-release-detected: ${{ steps.build.outputs.new_release_detected }}
+      new-release-detected: ${{ steps.version.outputs.released }}
+      new-release-version: ${{ steps.version.outputs.version }}
+      new-release-tag: ${{ steps.version.outputs.tag }}
+      new-release-is-prerelease: ${{ steps.version.outputs.is_prerelease }}
       distribution-artifacts: ${{ steps.build.outputs.artifacts_name }}
 
 

--- a/.github/workflows/verify_upstream.sh
+++ b/.github/workflows/verify_upstream.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -eu +o pipefail
+
+# Example output of `git status -sb`:
+#   ## master...origin/master [behind 1]
+#   M .github/workflows/verify_upstream.sh
+UPSTREAM_BRANCH_NAME="$(git status -sb | head -n 1 | cut -d' ' -f2 | grep -E '\.{3}' | cut -d'.' -f4)"
+printf '%s\n' "Upstream branch name: $UPSTREAM_BRANCH_NAME"
+
+set -o pipefail
+
+if [ -z "$UPSTREAM_BRANCH_NAME" ]; then
+    printf >&2 '%s\n' "::error::Unable to determine upstream branch name!"
+    exit 1
+fi
+
+git fetch "${UPSTREAM_BRANCH_NAME%%/*}"
+
+if ! UPSTREAM_SHA="$(git rev-parse "$UPSTREAM_BRANCH_NAME")"; then
+    printf >&2 '%s\n' "::error::Unable to determine upstream branch sha!"
+    exit 1
+fi
+
+HEAD_SHA="$(git rev-parse HEAD)"
+
+if [ "$HEAD_SHA" != "$UPSTREAM_SHA" ]; then
+    printf >&2 '%s\n' "[HEAD SHA] $HEAD_SHA != $UPSTREAM_SHA [UPSTREAM SHA]"
+    printf >&2 '%s\n' "::error::Upstream has changed, aborting release..."
+    exit 1
+fi
+
+printf '%s\n' "Verified upstream branch has not changed, continuing with release..."


### PR DESCRIPTION
<!--
Please do not combine multiple features or fix actions that are not
directly dependent on one another. Please open multiple PRs instead because
one may be merged while the other is denied or has requested changes. This
will slow down the process of merging the accepted changes as reviews are
also more difficult to evaluate for edge cases.
-->

## Purpose
<!-- Reason for the PR (solves an issue/problem, adds a feature, etc) -->

- Solves concurrency issues within PSR's CI workflow
- Updates PSR Documentation for GitHub Actions recommended workflow
- Resolves: #1201

## Rationale
<!-- How did you come to this conclusion as the solution? What was your reasoning? What were you trying to do? What problems did you find and avoid? -->

See comment in issue #1201. Adds the documentation update to inform users on how to avoid concurrency issues while using the `--commit` mechanism (generally required for an updating changelog).

## How did you test?
<!--
Please explain the methodology for how you verified this solution. It helps to
describe the primary case and the possible edge cases that you considered and
ultimately how you tested them. If you didn't rule out any edge cases, please
mention the rationale here.
-->

I ran through a series of live tests on my fork's GitHub actions workflow on the default branch.  First was an push to master during the testing phase prior to release. Second test was the new push had a sleep build into it to make the release job extra long to where I could guarantee a push during the release job (and it not cancel due to concurrency but detect that upstream had moved and self-abort).  The third push removed the arbitrary `sleep` and successfully released since there was no change in the upstream branch. The third push pipeline also waited its turn for the job concurrency to allow it to start in the odd case that it was faster to get through testing than the other previously started pipeline. Not really applicable to PSR but was important to evaluate that `cancel-in-progress: false` actually had the other pipeline wait its turn.

## How to Verify
<!-- Please provide a list of steps to validate your solution -->

You should prep the commits for the following before walking master up the chain of commits pushing as you go because timing is critical for this evaluation.

```sh
# 1. create temporary branch to pre-stage actions
git checkout -b prep master

# 2. Add a fake fix or feature commit on top of the current (i modified spacing in a file)
# this ensures a release is triggered
git commit -m 'fix: a fake commit'

# 3. Insert a `sleep 1m` into the release job beginning step that resets the branch to the workflow sha
vim .github/workflows/cicd.yml
git commit -m 'fix: a fake commit - cicd workflow modified'

# 4. Revert the previous commit and adjust message to be valid conventional commit
git revert HEAD
git commit --amend -m 'fix: the 3rd pipeline - removes delay on workflow'

# 5. push to default branch to trigger the first workflow
git checkout master
git merge prep~2
git push
git merge prep~1

# 6. Monitor resulting pipeline is during the validation workflow concurrency stage and
# push the next modification to cause a cancelation of current testing
git push
git merge prep

# 7. Monitor the 2nd resulting pipeline for when it enters the release job and hits the arbitrary sleep.
# When it hits the sleep, push this next commit
git push

# 8. Monitor the 2 pipelines in different tabs and you should see the 3rd pipeline pause at its release job
# due to its concurrency directive

# 9. Monitor the 2nd pipeline that has now reached the upstream change detection step and it should
# fail with the message that upstream has changed, aborting release.

# 10. Lastly, on the 3rd pipeline it should successfully release the proper new version to
# include pushing to the remote as it will not detect a change in the upstream and continue with release.
```

---

## PR Completion Checklist

- [x] Reviewed & followed the [Contributor Guidelines](https://python-semantic-release.readthedocs.io/en/latest/contributing.html)

- [x] Changes Implemented & Validation pipeline succeeds

- [x] Commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
  and are separated into the proper commit type and scope (recommended order: test, build, feat/fix, docs)

- [x] N/A ~~Appropriate Unit tests added/updated~~

- [x] N/A ~~Appropriate End-to-End tests added/updated~~

- [x] Appropriate Documentation added/updated and syntax validated for sphinx build (see Contributor Guidelines)
