### PR TITLE
Updated github actions example - gh-action-pypi-publish path

### DIFF
--- a/docs/automatic-releases/github-actions.rst
+++ b/docs/automatic-releases/github-actions.rst
@@ -735,7 +735,7 @@ to the GitHub Release Assets as well.
               git_committer_email: "actions@users.noreply.github.com"
 
           - name: Publish | Upload package to PyPI
-            uses: pypa/gh-action-pypi-publish@v1
+            uses: pypa/gh-action-pypi-publish@release/v1
             if: steps.release.outputs.released == 'true'
 
           - name: Publish | Upload to GitHub Release Assets


### PR DESCRIPTION
Fixing the PyPI github action path.
pypa/gh-action-pypi-publish@release/v1

## Purpose
Fixes the path for the github action for using pypi publishing




## Rationale
<!-- How did you come to this conclusion as the solution? What was your reasoning? What were you trying to do? What problems did you find and avoid? -->
I used the example in my pipeline and it crashed on not finding the path. 

`Missing download info for pypa/gh-action-pypi-publish@v1`


## How did you test?
I used the correct path from another working pipeline.


## How to Verify
My project is using that path.
https://github.com/bartdorlandt/convert_poetry2uv

