### PR TITLE
docs(github-actions): add packages-dir configuration in monorepo example

### DIFF
--- a/docs/automatic-releases/github-actions.rst
+++ b/docs/automatic-releases/github-actions.rst
@@ -832,3 +832,10 @@ Publish Action.
      with:
        directory: ./project2
        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+   # Adjust the packages-dir in the upload step
+   - name: Publish | Upload package to PyPI
+     uses: pypa/gh-action-pypi-publish@v1
+     if: steps.release.outputs.released == 'true'
+     with:
+        packages-dir: project1/dist


### PR DESCRIPTION
<!--
Please do not combine multiple features or fix actions that are not
directly dependent on one another. Please open multiple PRs instead because
one may be merged while the other is denied or has requested changes. This
will slow down the process of merging the accepted changes as reviews are
also more difficult to evaluate for edge cases.
-->

## Purpose
<!-- Reason for the PR (solves an issue/problem, adds a feature, etc) -->
extends the github-actions monorepo documentation


## Rationale
<!-- How did you come to this conclusion as the solution? What was your reasoning? What were you trying to do? What problems did you find and avoid? -->
I followed the monorepo approach for configuring the github-actions workflow setting a specific directory for the build. I did not update the configuration in the pypi publish action, thus running into an error. With the fix provided this error could be resolved.


## How did you test?
<!--
Please explain the methodology for how you verified this solution. It helps to
describe the primary case and the possible edge cases that you considered and
ultimately how you tested them. If you didn't rule out any edge cases, please
mention the rationale here.
-->
1. Not passing the packages-dir line in the workflow >> FileNotFoundError: [Errno 2] No such file or directory: '/github/workspace/dist'
2. Adding the configuration >> passed successfully
https://github.com/marketplace/actions/pypi-publish#customizing-target-package-dists-directory

## How to Verify
<!-- Please provide a list of steps to validate your solution -->
-


---

## PR Completion Checklist

- [x] Reviewed & followed the [Contributor Guidelines](https://python-semantic-release.readthedocs.io/en/latest/contributing.html)

- [x] Changes Implemented & Validation pipeline succeeds

- [x] Commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
  and are separated into the proper commit type and scope (recommended order: test, build, feat/fix, docs)

- [x] Appropriate Unit tests added/updated

- [x] Appropriate End-to-End tests added/updated

- [x] Appropriate Documentation added/updated and syntax validated for sphinx build (see Contributor Guidelines)
