### PR TITLE
docs(config): fix remote token block reference

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -82,7 +82,7 @@ environment variable is:
 
 .. code-block:: toml
 
-    [semantic_release.variable]
+    [semantic_release.remote.token]
     env = "ENV_VAR"
     default_env = "FALLBACK_ENV_VAR"
     default = "default value"


### PR DESCRIPTION
Set the header to a proper value for a remote token configuration block.

<!--
Please do not combine multiple features or fix actions that are not
directly dependent on one another. Please open multiple PRs instead because
one may be merged while the other is denied or has requested changes. This
will slow down the process of merging the accepted changes as reviews are
also more difficult to evaluate for edge cases.
-->

## Purpose
Fixes a wrong block header in remote token configuration documentation.


## Rationale
I tried using the provided `[semantic_release.variable]` header from the
https://python-semantic-release.readthedocs.io/en/latest/configuration.html#environment-variables
documentation section. It does not work. Though, the header from the above documentation works `[semantic_release.remote.token]`.

![image](https://github.com/user-attachments/assets/4f85fb98-246b-40f6-8d78-6b268094af8e)


## How did you test?
Ran semantic-release version with two different configurations.


## How to Verify
- Add a configuration block to your `semantic-release.toml` (from current documentation):
```sh
[semantic_release.variable]
env = "ENV_VAR"
default_env = "FALLBACK_ENV_VAR"
default = "default value"
```
- Run semantic-release:
```sh
$ semantic-release --strict --config semantic-release.toml version --no-commit --no-push --no-changelog
[11:06:48] WARNING  [config.from_raw_config] Token value is missing!                                                                                          config.py:774
0.1.0
The next version is: 0.1.0! 🚀
No build command specified, skipping
```
- See the `[11:06:48] WARNING  [config.from_raw_config] Token value is missing!` message.
- Change the block header to `[semantic_release.remote.token]`
- Run semantic-release:
```sh
$ semantic-release --strict --config semantic-release.toml version --no-commit --no-push --no-changelog
0.1.0
The next version is: 0.1.0! 🚀
No build command specified, skipping
```
- Don't see the warning message.

---

## PR Completion Checklist

- [ ] Reviewed & followed the [Contributor Guidelines](https://python-semantic-release.readthedocs.io/en/latest/contributing.html)

- [ ] Changes Implemented & Validation pipeline succeeds

- [ ] Commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
  and are separated into the proper commit type and scope (recommended order: test, build, feat/fix, docs)

- [ ] Appropriate Unit tests added/updated

- [ ] Appropriate End-to-End tests added/updated

- [ ] Appropriate Documentation added/updated and syntax validated for sphinx build (see Contributor Guidelines)
