### PR TITLE
fix(changelog-filters): fixes url resolution when prefix & path share letters

### DIFF
--- a/src/semantic_release/hvcs/remote_hvcs_base.py
+++ b/src/semantic_release/hvcs/remote_hvcs_base.py
@@ -95,10 +95,15 @@ class RemoteHvcsBase(HvcsBase, metaclass=ABCMeta):
         query: str | None = None,
         fragment: str | None = None,
     ) -> str:
-        # Ensure any path prefix is transfered but not doubled up on the derived url
+        # Ensure any path prefix is transferred but not doubled up on the derived url
+        normalized_path = (
+            f"{self.hvcs_domain.path}/{path}"
+            if self.hvcs_domain.path and not path.startswith(self.hvcs_domain.path)
+            else path
+        )
         return self._derive_url(
             self.hvcs_domain,
-            path=f"{self.hvcs_domain.path or ''}/{path.lstrip(self.hvcs_domain.path)}",
+            path=normalized_path,
             auth=auth,
             query=query,
             fragment=fragment,
@@ -123,10 +128,15 @@ class RemoteHvcsBase(HvcsBase, metaclass=ABCMeta):
         query: str | None = None,
         fragment: str | None = None,
     ) -> str:
-        # Ensure any api path prefix is transfered but not doubled up on the derived api url
+        # Ensure any api path prefix is transferred but not doubled up on the derived api url
+        normalized_endpoint = (
+            f"{self.api_url.path}/{endpoint}"
+            if self.api_url.path and not endpoint.startswith(self.api_url.path)
+            else endpoint
+        )
         return self._derive_url(
             self.api_url,
-            path=f"{self.api_url.path or ''}/{endpoint.lstrip(self.api_url.path)}",
+            path=normalized_endpoint,
             auth=auth,
             query=query,
             fragment=fragment,

--- a/tests/unit/semantic_release/hvcs/test_bitbucket.py
+++ b/tests/unit/semantic_release/hvcs/test_bitbucket.py
@@ -301,6 +301,29 @@ def test_commit_hash_url(default_bitbucket_client: Bitbucket):
     assert expected_url == default_bitbucket_client.commit_hash_url(sha)
 
 
+def test_commit_hash_url_w_custom_server():
+    """
+    Test the commit hash URL generation for a self-hosted Bitbucket server with prefix.
+
+    ref: https://github.com/python-semantic-release/python-semantic-release/issues/1204
+    """
+    sha = "244f7e11bcb1e1ce097db61594056bc2a32189a0"
+    expected_url = "{server}/{owner}/{repo}/commits/{sha}".format(
+        server=f"https://{EXAMPLE_HVCS_DOMAIN}/projects/demo-foo",
+        owner="foo",
+        repo=EXAMPLE_REPO_NAME,
+        sha=sha,
+    )
+
+    with mock.patch.dict(os.environ, {}, clear=True):
+        actual_url = Bitbucket(
+            remote_url=f"https://{EXAMPLE_HVCS_DOMAIN}/projects/demo-foo/foo/{EXAMPLE_REPO_NAME}.git",
+            hvcs_domain=f"https://{EXAMPLE_HVCS_DOMAIN}/projects/demo-foo",
+        ).commit_hash_url(sha)
+
+    assert expected_url == actual_url
+
+
 @pytest.mark.parametrize("pr_number", (666, "666", "#666"))
 def test_pull_request_url(default_bitbucket_client: Bitbucket, pr_number: int | str):
     expected_url = "{server}/{owner}/{repo}/pull-requests/{pr_number}".format(

--- a/tests/unit/semantic_release/hvcs/test_gitea.py
+++ b/tests/unit/semantic_release/hvcs/test_gitea.py
@@ -203,6 +203,29 @@ def test_commit_hash_url(default_gitea_client: Gitea):
     assert expected_url == default_gitea_client.commit_hash_url(sha)
 
 
+def test_commit_hash_url_w_custom_server():
+    """
+    Test the commit hash URL generation for a self-hosted Bitbucket server with prefix.
+
+    ref: https://github.com/python-semantic-release/python-semantic-release/issues/1204
+    """
+    sha = "244f7e11bcb1e1ce097db61594056bc2a32189a0"
+    expected_url = "{server}/{owner}/{repo}/commit/{sha}".format(
+        server=f"https://{EXAMPLE_HVCS_DOMAIN}/projects/demo-foo",
+        owner="foo",
+        repo=EXAMPLE_REPO_NAME,
+        sha=sha,
+    )
+
+    with mock.patch.dict(os.environ, {}, clear=True):
+        actual_url = Gitea(
+            remote_url=f"https://{EXAMPLE_HVCS_DOMAIN}/projects/demo-foo/foo/{EXAMPLE_REPO_NAME}.git",
+            hvcs_domain=f"https://{EXAMPLE_HVCS_DOMAIN}/projects/demo-foo",
+        ).commit_hash_url(sha)
+
+    assert expected_url == actual_url
+
+
 @pytest.mark.parametrize("issue_number", (666, "666", "#666"))
 def test_issue_url(default_gitea_client: Gitea, issue_number: int | str):
     expected_url = "{server}/{owner}/{repo}/issues/{issue_number}".format(

--- a/tests/unit/semantic_release/hvcs/test_github.py
+++ b/tests/unit/semantic_release/hvcs/test_github.py
@@ -375,6 +375,29 @@ def test_commit_hash_url(default_gh_client: Github):
     assert expected_url == default_gh_client.commit_hash_url(sha)
 
 
+def test_commit_hash_url_w_custom_server():
+    """
+    Test the commit hash URL generation for a self-hosted Bitbucket server with prefix.
+
+    ref: https://github.com/python-semantic-release/python-semantic-release/issues/1204
+    """
+    sha = "244f7e11bcb1e1ce097db61594056bc2a32189a0"
+    expected_url = "{server}/{owner}/{repo}/commit/{sha}".format(
+        server=f"https://{EXAMPLE_HVCS_DOMAIN}/projects/demo-foo",
+        owner="foo",
+        repo=EXAMPLE_REPO_NAME,
+        sha=sha,
+    )
+
+    with mock.patch.dict(os.environ, {}, clear=True):
+        actual_url = Github(
+            remote_url=f"https://{EXAMPLE_HVCS_DOMAIN}/projects/demo-foo/foo/{EXAMPLE_REPO_NAME}.git",
+            hvcs_domain=f"https://{EXAMPLE_HVCS_DOMAIN}/projects/demo-foo",
+        ).commit_hash_url(sha)
+
+    assert expected_url == actual_url
+
+
 @pytest.mark.parametrize("issue_number", (666, "666", "#666"))
 def test_issue_url(default_gh_client: Github, issue_number: str | int):
     expected_url = "{server}/{owner}/{repo}/issues/{issue_num}".format(

--- a/tests/unit/semantic_release/hvcs/test_gitlab.py
+++ b/tests/unit/semantic_release/hvcs/test_gitlab.py
@@ -260,6 +260,29 @@ def test_commit_hash_url(default_gl_client: Gitlab):
     assert expected_url == default_gl_client.commit_hash_url(REF)
 
 
+def test_commit_hash_url_w_custom_server():
+    """
+    Test the commit hash URL generation for a self-hosted Bitbucket server with prefix.
+
+    ref: https://github.com/python-semantic-release/python-semantic-release/issues/1204
+    """
+    sha = "244f7e11bcb1e1ce097db61594056bc2a32189a0"
+    expected_url = "{server}/{owner}/{repo}/-/commit/{sha}".format(
+        server=f"https://{EXAMPLE_HVCS_DOMAIN}/projects/demo-foo",
+        owner="foo",
+        repo=EXAMPLE_REPO_NAME,
+        sha=sha,
+    )
+
+    with mock.patch.dict(os.environ, {}, clear=True):
+        actual_url = Gitlab(
+            remote_url=f"https://{EXAMPLE_HVCS_DOMAIN}/projects/demo-foo/foo/{EXAMPLE_REPO_NAME}.git",
+            hvcs_domain=f"https://{EXAMPLE_HVCS_DOMAIN}/projects/demo-foo",
+        ).commit_hash_url(sha)
+
+    assert expected_url == actual_url
+
+
 @pytest.mark.parametrize("issue_number", (666, "666", "#666"))
 def test_issue_url(default_gl_client: Gitlab, issue_number: int | str):
     expected_url = "{server}/{owner}/{repo}/-/issues/{issue_num}".format(


### PR DESCRIPTION
<!--
Please do not combine multiple features or fix actions that are not
directly dependent on one another. Please open multiple PRs instead because
one may be merged while the other is denied or has requested changes. This
will slow down the process of merging the accepted changes as reviews are
also more difficult to evaluate for edge cases.
-->

## Purpose
<!-- Reason for the PR (solves an issue/problem, adds a feature, etc) -->

- The change adjusts the url normalization computation to remove any path prefix and only the path prefix even when letters are shared with the rest of the url path.
- Resolves: #1204

## Rationale
<!-- How did you come to this conclusion as the solution? What was your reasoning? What were you trying to do? What problems did you find and avoid? -->



## How did you test?
<!--
Please explain the methodology for how you verified this solution. It helps to
describe the primary case and the possible edge cases that you considered and
ultimately how you tested them. If you didn't rule out any edge cases, please
mention the rationale here.
-->



## How to Verify
<!-- Please provide a list of steps to validate your solution -->



---

## PR Completion Checklist

- [ ] Reviewed & followed the [Contributor Guidelines](https://python-semantic-release.readthedocs.io/en/latest/contributing.html)

- [ ] Changes Implemented & Validation pipeline succeeds

- [ ] Commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
  and are separated into the proper commit type and scope (recommended order: test, build, feat/fix, docs)

- [ ] Appropriate Unit tests added/updated

- [ ] Appropriate End-to-End tests added/updated

- [ ] Appropriate Documentation added/updated and syntax validated for sphinx build (see Contributor Guidelines)
