### PR TITLE
feat(cmd-version): enable version stamp of vars with double-equals operand in `version_variables`

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1347,7 +1347,8 @@ The regular expression generated from the ``version_variables`` definition will:
 
 2. The variable name defined by ``variable`` and the version must be separated by
    an operand symbol (``=``, ``:``, ``:=``, or ``@``). Whitespace is optional around
-   the symbol.
+   the symbol. As of $NEW_VERSION, a double-equals (``==``) operator is also supported
+   as a valid operand symbol.
 
 3. The value of the variable must match a `SemVer`_ regular expression and can be
    enclosed by single (``'``) or double (``"``) quotation marks but they must match. However,
@@ -1399,6 +1400,9 @@ will be matched and replaced by the new version:
 
     # Custom Tag Format with tag_format set (monorepos)
     __release__ = "module-v1.2.3"
+
+    # requirements.txt
+    my-package == 1.2.3
 
 .. important::
     The Regular Expression expects a version value to exist in the file to be replaced.

--- a/src/semantic_release/version/declarations/pattern.py
+++ b/src/semantic_release/version/declarations/pattern.py
@@ -230,9 +230,9 @@ class PatternVersionDeclaration(IVersionReplacer):
                 # Supports optional matching quotations around variable name
                 # Negative lookbehind to ensure we don't match part of a variable name
                 f"""(?x)(?P<quote1>['"])?(?<![\\w.-]){regex_escape(variable)}(?P=quote1)?""",
-                # Supports walrus, equals sign, colon, or @ as assignment operator
+                # Supports walrus, equals sign, double-equals, colon, or @ as assignment operator
                 # ignoring whitespace separation
-                r"\s*(:=|[:=@])\s*",
+                r"\s*(:=|==|[:=@])\s*",
                 # Supports optional matching quotations around a version pattern (tag or raw format)
                 f"""(?P<quote2>['"])?{value_replace_pattern_str}(?P=quote2)?""",
             ],

--- a/tests/unit/semantic_release/version/declarations/test_pattern_declaration.py
+++ b/tests/unit/semantic_release/version/declarations/test_pattern_declaration.py
@@ -166,6 +166,15 @@ def test_pattern_declaration_is_version_replacer():
                 f"""if version := '{next_version}': """,
             ),
             (
+                "Explicit number format for requirements.txt file with double equals",
+                f"{test_file}:my-package:{VersionStampType.NUMBER_FORMAT.value}",
+                # irrelevant for this case
+                lazy_fixture(default_tag_format_str.__name__),
+                # Uses double equals separator
+                """my-package == 1.0.0""",
+                f"""my-package == {next_version}""",
+            ),
+            (
                 "Using default number format for multi-line & quoted json",
                 f"{test_file}:version:{VersionStampType.NUMBER_FORMAT.value}",
                 # irrelevant for this case


### PR DESCRIPTION
<!--
Please do not combine multiple features or fix actions that are not
directly dependent on one another. Please open multiple PRs instead because
one may be merged while the other is denied or has requested changes. This
will slow down the process of merging the accepted changes as reviews are
also more difficult to evaluate for edge cases.
-->

## Purpose
<!-- Reason for the PR (solves an issue/problem, adds a feature, etc) -->

- Adds the feature to stamp when the variable uses `==`.

## Rationale
<!-- How did you come to this conclusion as the solution? What was your reasoning? What were you trying to do? What problems did you find and avoid? -->

Needed to add a feature in order to stamp into `requirements.txt` for when PSR will update its Github Action dependencies definition which I needed to be in the `pip freeze` format of `requirements.txt`.

## How did you test?
<!--
Please explain the methodology for how you verified this solution. It helps to
describe the primary case and the possible edge cases that you considered and
ultimately how you tested them. If you didn't rule out any edge cases, please
mention the rationale here.
-->

Added a unit test to verify that a version definition with `==` will be updated with a new version.

---

## PR Completion Checklist

- [x] Reviewed & followed the [Contributor Guidelines](https://python-semantic-release.readthedocs.io/en/latest/contributing.html)

- [x] Changes Implemented & Validation pipeline succeeds

- [x] Commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
  and are separated into the proper commit type and scope (recommended order: test, build, feat/fix, docs)

- [x] Appropriate Unit tests added/updated

- [x] N/A ~~Appropriate End-to-End tests added/updated~~

- [x] Appropriate Documentation added/updated and syntax validated for sphinx build (see Contributor Guidelines)
