### PR TITLE
build(deps): prevent update to `click@8.2.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 readme = "README.rst"
 authors = [{ name = "Rolf Erik Lekang", email = "me@rolflekang.com" }]
 dependencies = [
-  "click ~= 8.0",
+  "click ~= 8.1.0",
   "click-option-group ~= 0.5",
   "gitpython ~= 3.0",
   "requests ~= 2.25",


### PR DESCRIPTION
## Purpose
<!-- Reason for the PR (solves an issue/problem, adds a feature, etc) -->

- Prevent breaking change to test cases from click update

## Rationale
<!-- How did you come to this conclusion as the solution? What was your reasoning? What were you trying to do? What problems did you find and avoid? -->

click 8.2 has a breaking change in the test suite where it removes a parameter from the cli runner. There is additional deprecation warnings included as well so for now since it will break our tests limit this to 8.1.0 only.

## How did you test?
<!--
Please explain the methodology for how you verified this solution. It helps to
describe the primary case and the possible edge cases that you considered and
ultimately how you tested them. If you didn't rule out any edge cases, please
mention the rationale here.
-->

Verified the CI passed both the mypy lint step and the E2E tests worked.

---

## PR Completion Checklist

- [x] Reviewed & followed the [Contributor Guidelines](https://python-semantic-release.readthedocs.io/en/latest/contributing.html)

- [x] Changes Implemented & Validation pipeline succeeds

- [x] Commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
  and are separated into the proper commit type and scope (recommended order: test, build, feat/fix, docs)

- [x] N/A ~~Appropriate Unit tests added/updated~~

- [x] N/A ~~Appropriate End-to-End tests added/updated~~

- [x] N/A ~~Appropriate Documentation added/updated and syntax validated for sphinx build (see Contributor Guidelines)~~
