### PR TITLE
chore(conf): configure project to stamp ci action's `requirements.txt` w/ new version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -412,6 +412,9 @@ build_command = """
     python -m build .
 """
 major_on_zero = true
+version_variables = [
+  "src/gh_action/requirements.txt:python-semantic-release:nf",
+]
 version_toml = ["pyproject.toml:project.version"]
 
 [tool.semantic_release.changelog]


### PR DESCRIPTION
<!--
Please do not combine multiple features or fix actions that are not
directly dependent on one another. Please open multiple PRs instead because
one may be merged while the other is denied or has requested changes. This
will slow down the process of merging the accepted changes as reviews are
also more difficult to evaluate for edge cases.
-->

## Purpose
<!-- Reason for the PR (solves an issue/problem, adds a feature, etc) -->

- Automates the bump of the GitHub action dependency when a new version is released.

## Rationale
<!-- How did you come to this conclusion as the solution? What was your reasoning? What were you trying to do? What problems did you find and avoid? -->

With the refactor of the GitHub action Docker build, I changed it to actually download the published python-semantic-release package rather than just load the GitHub source code into the container. This ensures that we have less disparity between what users report errors as the runtimes are different.  We must now bump the version value in the `requirements.txt` that is used when building the GitHub Action when we bump the overall version.

## How did you test?
<!--
Please explain the methodology for how you verified this solution. It helps to
describe the primary case and the possible edge cases that you considered and
ultimately how you tested them. If you didn't rule out any edge cases, please
mention the rationale here.
-->

Manually with the stamp only command to make sure the newly defined version is inserted into `src/gh_action/requirements.txt`

---

## PR Completion Checklist

- [x] Reviewed & followed the [Contributor Guidelines](https://python-semantic-release.readthedocs.io/en/latest/contributing.html)

- [x] Changes Implemented & Validation pipeline succeeds

- [x] Commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
  and are separated into the proper commit type and scope (recommended order: test, build, feat/fix, docs)

- [x] N/A ~~Appropriate Unit tests added/updated~~

- [x] N/A ~~Appropriate End-to-End tests added/updated~~

- [x] N/A ~~Appropriate Documentation added/updated and syntax validated for sphinx build (see Contributor Guidelines)~~
