### PR TITLE
chore(changelog): update PSR template after v10 strips PR numbers from subject lines

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -420,7 +420,7 @@ v9.19.0 (2025-02-10)
 
 * Update references to Angular parser to Conventional Commit Parser (`PR#1177`_, `27ddf84`_)
 
-💡 ADDITIONAL RELEASE INFORMATION
+💡 Additional Release Information
 ---------------------------------
 
 * **parser-conventional**: The 'angular' commit parser has been renamed to 'conventional' to match

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -113,6 +113,12 @@ v10.0.0 (2025-05-25)
 💥 Breaking Changes
 -------------------
 
+.. seealso::
+    *For a summarized walkthrough, check out our* |v10 migration guide|_ *as well.*
+
+.. _v10 migration guide: ../upgrading/10-upgrade.html
+.. |v10 migration guide| replace:: *v10 migration guide*
+
 * **changelog-md**: The default Markdown changelog template and release notes template will no
   longer print out the entire commit message contents, instead, it will only print the commit
   subject line. This comes to meet the high demand of better formatted changelogs and requests for

--- a/config/release-templates/.components/first_release.md.j2
+++ b/config/release-templates/.components/first_release.md.j2
@@ -1,0 +1,18 @@
+{#  EXAMPLE:
+
+## vX.X.X (YYYY-MMM-DD)
+
+_This release is published under the MIT License._       # Release Notes Only
+
+- Initial Release
+
+#}{{
+"## %s (%s)\n" | format(
+    release.version.as_semver_tag(),
+    release.tagged_date.strftime("%Y-%m-%d")
+)
+}}{%  if license_name is defined and license_name
+%}{{    "\n_This release is published under the %s License._\n" | format(license_name)
+}}{%  endif
+%}
+- Initial Release

--- a/config/release-templates/.components/macros.md.j2
+++ b/config/release-templates/.components/macros.md.j2
@@ -58,13 +58,12 @@
           )
 %}{#
 #}{%      if commit.linked_merge_request != ""
-%}{%        set pr_num = commit.linked_merge_request
-%}{#        # TODO: breaking change v10, remove summary line replacers as PSR will do it for us
-#}{%        set summary_line = summary_line | replace("(pull request ", "(") | replace("(" ~ pr_num ~ ")", "") | trim
-%}{#
-   #        # Add PR references with a link to the PR
+%}{#        # Add PR references with a link to the PR
 #}{%        set _ = link_references.append(
-              format_link(pr_num | pull_request_url, "PR" ~ pr_num)
+              format_link(
+                commit.linked_merge_request | pull_request_url,
+                "PR" ~ commit.linked_merge_request
+              )
             )
 %}{%      endif
 %}{#

--- a/config/release-templates/.components/macros.rst.j2
+++ b/config/release-templates/.components/macros.rst.j2
@@ -131,10 +131,7 @@
 %}{%      endif
 %}{#
 #}{%      if commit.linked_merge_request != ""
-%}{#        # TODO: breaking change v10, remove summary line replacers as PSR will do it for us
-#}{%        set summary_line = summary_line | replace("(pull request ", "(") | replace("(" ~ commit.linked_merge_request ~ ")", "") | trim
-%}{#
-   #        # Add PR references with a link to the PR
+%}{#        # Add PR references with a link to the PR
 #}{%        set _ = link_references.append("`PR%s`_" | format(commit.linked_merge_request))
 %}{%      endif
 %}{#


### PR DESCRIPTION
<!--
Please do not combine multiple features or fix actions that are not
directly dependent on one another. Please open multiple PRs instead because
one may be merged while the other is denied or has requested changes. This
will slow down the process of merging the accepted changes as reviews are
also more difficult to evaluate for edge cases.
-->

## Purpose
<!-- Reason for the PR (solves an issue/problem, adds a feature, etc) -->



## Rationale
<!-- How did you come to this conclusion as the solution? What was your reasoning? What were you trying to do? What problems did you find and avoid? -->



## How did you test?
<!--
Please explain the methodology for how you verified this solution. It helps to
describe the primary case and the possible edge cases that you considered and
ultimately how you tested them. If you didn't rule out any edge cases, please
mention the rationale here.
-->



## How to Verify
<!-- Please provide a list of steps to validate your solution -->



---

## PR Completion Checklist

- [ ] Reviewed & followed the [Contributor Guidelines](https://python-semantic-release.readthedocs.io/en/latest/contributing.html)

- [ ] Changes Implemented & Validation pipeline succeeds

- [ ] Commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
  and are separated into the proper commit type and scope (recommended order: test, build, feat/fix, docs)

- [ ] Appropriate Unit tests added/updated

- [ ] Appropriate End-to-End tests added/updated

- [ ] Appropriate Documentation added/updated and syntax validated for sphinx build (see Contributor Guidelines)
