### PR TITLE
fix(github-actions): add filesystem UID/GID fixer after action workspace modification

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -145,7 +145,7 @@ jobs:
 
       - name: Release | Python Semantic Release
         id: release
-        uses: python-semantic-release/python-semantic-release@917a2c730cb8f6c8cd3d00f23c876d724a4a844c  # v10.0.1
+        uses: ./
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           verbosity: 1

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -165,7 +165,6 @@ jobs:
           GIT_COMMITTER_NAME: ${{ env.GITHUB_ACTIONS_AUTHOR_NAME }}
           GIT_COMMITTER_EMAIL: ${{ env.GITHUB_ACTIONS_AUTHOR_EMAIL }}
         run: |
-          ls -la .git/
           MINOR_VERSION_TAG="$(echo "$FULL_VERSION_TAG" | cut -d. -f1,2)"
           git tag --force --annotate "$MINOR_VERSION_TAG" "${FULL_VERSION_TAG}^{}" -m "$MINOR_VERSION_TAG"
           git push -u origin "$MINOR_VERSION_TAG" --force

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -393,7 +393,7 @@ jobs:
   test-gh-action:
     name: Validate Action Build & Execution
     runs-on: ubuntu-latest
-    if: inputs.gha-src-files-changed == 'true' || inputs.gha-test-files-changed == 'true' || inputs.ci-files-changed == 'true'
+    if: ${{ inputs.gha-src-files-changed == 'true' || inputs.gha-test-files-changed == 'true' || inputs.ci-files-changed == 'true' }}
 
     needs:
       - build


### PR DESCRIPTION
<!--
Please do not combine multiple features or fix actions that are not
directly dependent on one another. Please open multiple PRs instead because
one may be merged while the other is denied or has requested changes. This
will slow down the process of merging the accepted changes as reviews are
also more difficult to evaluate for edge cases.
-->

## Purpose
<!-- Reason for the PR (solves an issue/problem, adds a feature, etc) -->

- Solves the issue with random file permissions errors after release

## Rationale
<!-- How did you come to this conclusion as the solution? What was your reasoning? What were you trying to do? What problems did you find and avoid? -->

I found that here on PSR we had some issues writing the partial tags occasionally after PSR had created a commit. I discovered that this was because while in the Docker container, the commit action had turned certain files within the git repository (which is mounted into the container) to root owned files. Then afterword if the sha1 for the tag matched the first few characters of the sha1 of the commit then it would collide and fail with permissions errors on the `.git/objects/` folder.

## How did you test?
<!--
Please explain the methodology for how you verified this solution. It helps to
describe the primary case and the possible edge cases that you considered and
ultimately how you tested them. If you didn't rule out any edge cases, please
mention the rationale here.
-->

I ran this on my repository fork with a full file listing of the `.git/` directory. I could see in comparison to when this project released to after this fix was implemented how the file ownership was corrected from `root:root` to `runner:docker`.

---

## PR Completion Checklist

- [x] Reviewed & followed the [Contributor Guidelines](https://python-semantic-release.readthedocs.io/en/latest/contributing.html)

- [x] Changes Implemented & Validation pipeline succeeds

- [x] Commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
  and are separated into the proper commit type and scope (recommended order: test, build, feat/fix, docs)

- [x] N/A ~~Appropriate Unit tests added/updated~~

- [x] N/A ~~Appropriate End-to-End tests added/updated~~

- [x] N/A ~~Appropriate Documentation added/updated and syntax validated for sphinx build (see Contributor Guidelines)~~
