### PR TITLE
test(cmd-version): add fixture to reproduce issue with empty changelog

### DIFF
--- a/tests/const.py
+++ b/tests/const.py
@@ -328,3 +328,4 @@ EXAMPLE_RELEASE_NOTES_TEMPLATE = r"""
 """.lstrip()  # noqa: E501
 
 RELEASE_NOTES = "# Release Notes"
+DEFAULT_MERGE_STRATEGY_OPTION = "theirs"

--- a/tests/e2e/cmd_version/bump_version/github_flow/test_repo_1_channel_branch_update_merge.py
+++ b/tests/e2e/cmd_version/bump_version/github_flow/test_repo_1_channel_branch_update_merge.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+import tomlkit
+from flatdict import FlatDict
+from freezegun import freeze_time
+
+from tests.const import (
+    DEFAULT_BRANCH_NAME,
+)
+from tests.fixtures.repos.github_flow import (
+    repo_w_github_flow_w_default_release_n_branch_update_merge_conventional_commits,
+    repo_w_github_flow_w_default_release_n_branch_update_merge_emoji_commits,
+    repo_w_github_flow_w_default_release_n_branch_update_merge_scipy_commits,
+)
+from tests.util import temporary_working_directory
+
+if TYPE_CHECKING:
+    from pathlib import Path
+    from unittest.mock import MagicMock
+
+    from requests_mock import Mocker
+
+    from tests.e2e.cmd_version.bump_version.conftest import (
+        InitMirrorRepo4RebuildFn,
+        RunPSReleaseFn,
+    )
+    from tests.e2e.conftest import GetSanitizedChangelogContentFn
+    from tests.fixtures.example_project import ExProjectDir
+    from tests.fixtures.git_repo import (
+        BuildRepoFromDefinitionFn,
+        BuildSpecificRepoFn,
+        CommitConvention,
+        GetGitRepo4DirFn,
+        RepoActionConfigure,
+        RepoActionRelease,
+        RepoActions,
+        SplitRepoActionsByReleaseTagsFn,
+    )
+
+
+@pytest.mark.xfail(
+    reason="Should pass after [#1252](https://github.com/python-semantic-release/python-semantic-release/issues/1252) is fixed",
+)
+@pytest.mark.parametrize(
+    "repo_fixture_name",
+    [
+        pytest.param(repo_fixture_name, marks=pytest.mark.comprehensive)
+        for repo_fixture_name in [
+            repo_w_github_flow_w_default_release_n_branch_update_merge_conventional_commits.__name__,
+            repo_w_github_flow_w_default_release_n_branch_update_merge_emoji_commits.__name__,
+            repo_w_github_flow_w_default_release_n_branch_update_merge_scipy_commits.__name__,
+        ]
+    ],
+)
+def test_github_flow_repo_w_default_release_n_branch_update_merge(
+    repo_fixture_name: str,
+    run_psr_release: RunPSReleaseFn,
+    build_github_flow_repo_w_default_release_n_branch_update_merge: BuildSpecificRepoFn,
+    split_repo_actions_by_release_tags: SplitRepoActionsByReleaseTagsFn,
+    init_mirror_repo_for_rebuild: InitMirrorRepo4RebuildFn,
+    example_project_dir: ExProjectDir,
+    git_repo_for_directory: GetGitRepo4DirFn,
+    build_repo_from_definition: BuildRepoFromDefinitionFn,
+    mocked_git_push: MagicMock,
+    post_mocker: Mocker,
+    default_tag_format_str: str,
+    version_py_file: Path,
+    get_sanitized_md_changelog_content: GetSanitizedChangelogContentFn,
+    get_sanitized_rst_changelog_content: GetSanitizedChangelogContentFn,
+):
+    # build target repo into a temporary directory
+    target_repo_dir = example_project_dir / repo_fixture_name
+    commit_type: CommitConvention = (
+        repo_fixture_name.split("commits", 1)[0].split("_")[-2]  # type: ignore[assignment]
+    )
+    target_repo_definition = (
+        build_github_flow_repo_w_default_release_n_branch_update_merge(
+            repo_name=repo_fixture_name,
+            commit_type=commit_type,
+            dest_dir=target_repo_dir,
+        )
+    )
+    target_git_repo = git_repo_for_directory(target_repo_dir)
+    target_repo_pyproject_toml = FlatDict(
+        tomlkit.loads((target_repo_dir / "pyproject.toml").read_text(encoding="utf-8")),
+        delimiter=".",
+    )
+    tag_format_str: str = target_repo_pyproject_toml.get(  # type: ignore[assignment]
+        "tool.semantic_release.tag_format",
+        default_tag_format_str,
+    )
+
+    # split repo actions by release actions
+    releasetags_2_steps: dict[str, list[RepoActions]] = (
+        split_repo_actions_by_release_tags(target_repo_definition, tag_format_str)
+    )
+    configuration_step: RepoActionConfigure = releasetags_2_steps.pop("")[0]  # type: ignore[assignment]
+
+    # Create the mirror repo directory
+    mirror_repo_dir = init_mirror_repo_for_rebuild(
+        mirror_repo_dir=(example_project_dir / "mirror"),
+        configuration_step=configuration_step,
+    )
+    mirror_git_repo = git_repo_for_directory(mirror_repo_dir)
+
+    # rebuild repo from scratch stopping before each release tag
+    for curr_release_tag, steps in releasetags_2_steps.items():
+        # make sure mocks are clear
+        mocked_git_push.reset_mock()
+        post_mocker.reset_mock()
+
+        # Extract expected result from target repo
+        head_reference_name = (
+            curr_release_tag
+            if curr_release_tag != "Unreleased"
+            else DEFAULT_BRANCH_NAME
+        )
+        target_git_repo.git.checkout(head_reference_name, detach=True)
+        expected_md_changelog_content = get_sanitized_md_changelog_content(
+            repo_dir=target_repo_dir
+        )
+        expected_rst_changelog_content = get_sanitized_rst_changelog_content(
+            repo_dir=target_repo_dir
+        )
+        expected_pyproject_toml_content = (
+            target_repo_dir / "pyproject.toml"
+        ).read_text()
+        expected_version_file_content = (target_repo_dir / version_py_file).read_text()
+        expected_release_commit_text = target_git_repo.head.commit.message
+
+        # In our repo env, start building the repo from the definition
+        build_repo_from_definition(
+            dest_dir=mirror_repo_dir,
+            repo_construction_steps=steps[:-1],  # stop before the release step
+        )
+        release_action_step: RepoActionRelease = steps[-1]  # type: ignore[assignment]
+
+        # Act: run PSR on the repo instead of the RELEASE step
+        with freeze_time(
+            release_action_step["details"]["datetime"]
+        ), temporary_working_directory(mirror_repo_dir):
+            run_psr_release(
+                next_version_str=release_action_step["details"]["version"],
+                git_repo=mirror_git_repo,
+            )
+
+        # take measurement after running the version command
+        actual_release_commit_text = mirror_git_repo.head.commit.message
+        actual_pyproject_toml_content = (mirror_repo_dir / "pyproject.toml").read_text()
+        actual_version_file_content = (mirror_repo_dir / version_py_file).read_text()
+        actual_md_changelog_content = get_sanitized_md_changelog_content(
+            repo_dir=mirror_repo_dir
+        )
+        actual_rst_changelog_content = get_sanitized_rst_changelog_content(
+            repo_dir=mirror_repo_dir
+        )
+
+        # Evaluate (normal release actions should have occurred as expected)
+        # ------------------------------------------------------------------
+        # Make sure version file is updated
+        assert expected_pyproject_toml_content == actual_pyproject_toml_content
+        assert expected_version_file_content == actual_version_file_content
+        # Make sure changelog is updated
+        assert expected_md_changelog_content == actual_md_changelog_content
+        assert expected_rst_changelog_content == actual_rst_changelog_content
+        # Make sure commit is created
+        assert expected_release_commit_text == actual_release_commit_text
+        # Make sure tag is created
+        assert curr_release_tag in [tag.name for tag in mirror_git_repo.tags]
+        assert mocked_git_push.call_count == 2  # 1 for commit, 1 for tag
+        assert post_mocker.call_count == 1  # vcs release creation occured

--- a/tests/fixtures/git_repo.py
+++ b/tests/fixtures/git_repo.py
@@ -33,6 +33,7 @@ import tests.util
 from tests.const import (
     COMMIT_MESSAGE,
     DEFAULT_BRANCH_NAME,
+    DEFAULT_MERGE_STRATEGY_OPTION,
     EXAMPLE_HVCS_DOMAIN,
     EXAMPLE_REPO_NAME,
     EXAMPLE_REPO_OWNER,
@@ -233,6 +234,7 @@ if TYPE_CHECKING:
             branch_name: str,
             commit_def: CommitDef,
             fast_forward: bool = True,
+            strategy_option: str = DEFAULT_MERGE_STRATEGY_OPTION,
         ) -> CommitDef: ...
 
     class CreateSquashMergeCommitFn(Protocol):
@@ -241,7 +243,7 @@ if TYPE_CHECKING:
             git_repo: Repo,
             branch_name: str,
             commit_def: CommitDef,
-            strategy_option: str = "theirs",
+            strategy_option: str = DEFAULT_MERGE_STRATEGY_OPTION,
         ) -> CommitDef: ...
 
     class CommitSpec(TypedDict):
@@ -311,7 +313,7 @@ if TYPE_CHECKING:
         branch_name: str
         commit_def: CommitDef
         fast_forward: Literal[False]
-        # strategy_option: str
+        strategy_option: NotRequired[str]
 
     class RepoActionGitFFMergeDetails(DetailsBase):
         branch_name: str
@@ -763,6 +765,7 @@ def create_merge_commit(stable_now_date: GetStableDateNowFn) -> CreateMergeCommi
         branch_name: str,
         commit_def: CommitDef,
         fast_forward: bool = True,
+        strategy_option: str = DEFAULT_MERGE_STRATEGY_OPTION,
     ) -> CommitDef:
         curr_dt = stable_now_date()
         commit_dt = (
@@ -784,6 +787,7 @@ def create_merge_commit(stable_now_date: GetStableDateNowFn) -> CreateMergeCommi
                 ff=fast_forward,
                 no_ff=bool(not fast_forward),
                 m=commit_def["msg"],
+                strategy_option=strategy_option,
             )
 
         # return the commit definition with the sha & message updated
@@ -804,7 +808,7 @@ def create_squash_merge_commit(
         git_repo: Repo,
         branch_name: str,
         commit_def: CommitDef,
-        strategy_option: str = "theirs",
+        strategy_option: str = DEFAULT_MERGE_STRATEGY_OPTION,
     ) -> CommitDef:
         curr_dt = stable_now_date()
         commit_dt = (
@@ -1404,6 +1408,9 @@ def build_repo_from_definition(  # noqa: C901, its required and its just test co
                                 branch_name=merge_def["branch_name"],
                                 commit_def=merge_def["commit_def"],
                                 fast_forward=merge_def["fast_forward"],
+                                strategy_option=merge_def.get(
+                                    "strategy_option", DEFAULT_MERGE_STRATEGY_OPTION
+                                ),
                             )
                             if merge_def["commit_def"]["include_in_changelog"]:
                                 current_commits.append(merge_def["commit_def"])

--- a/tests/fixtures/repos/github_flow/__init__.py
+++ b/tests/fixtures/repos/github_flow/__init__.py
@@ -1,2 +1,3 @@
 from tests.fixtures.repos.github_flow.repo_w_default_release import *
+from tests.fixtures.repos.github_flow.repo_w_default_release_w_branch_update_merge import *
 from tests.fixtures.repos.github_flow.repo_w_release_channels import *

--- a/tests/fixtures/repos/github_flow/repo_w_default_release_w_branch_update_merge.py
+++ b/tests/fixtures/repos/github_flow/repo_w_default_release_w_branch_update_merge.py
@@ -1,0 +1,471 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from itertools import count
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from semantic_release.cli.config import ChangelogOutputFormat
+
+import tests.conftest
+import tests.const
+import tests.util
+from tests.const import (
+    DEFAULT_BRANCH_NAME,
+    EXAMPLE_HVCS_DOMAIN,
+    INITIAL_COMMIT_MESSAGE,
+    RepoActionStep,
+)
+
+if TYPE_CHECKING:
+    from typing import Sequence
+
+    from tests.conftest import (
+        GetCachedRepoDataFn,
+        GetMd5ForSetOfFilesFn,
+        GetStableDateNowFn,
+    )
+    from tests.fixtures.example_project import (
+        ExProjectDir,
+    )
+    from tests.fixtures.git_repo import (
+        BuildRepoFromDefinitionFn,
+        BuildRepoOrCopyCacheFn,
+        BuildSpecificRepoFn,
+        BuiltRepoResult,
+        CommitConvention,
+        ConvertCommitSpecsToCommitDefsFn,
+        ConvertCommitSpecToCommitDefFn,
+        ExProjectGitRepoFn,
+        FormatGitMergeCommitMsgFn,
+        GetRepoDefinitionFn,
+        RepoActions,
+        RepoActionWriteChangelogsDestFile,
+        TomlSerializableTypes,
+    )
+
+
+FEAT_BRANCH_NAME = "feat/feature"
+
+
+@pytest.fixture(scope="session")
+def deps_files_4_repo_w_default_release_n_branch_update_merge(
+    deps_files_4_example_git_project: list[Path],
+) -> list[Path]:
+    return [
+        *deps_files_4_example_git_project,
+        # This file
+        Path(__file__).absolute(),
+        # because of imports
+        Path(tests.const.__file__).absolute(),
+        Path(tests.util.__file__).absolute(),
+        # because of the fixtures
+        Path(tests.conftest.__file__).absolute(),
+    ]
+
+
+@pytest.fixture(scope="session")
+def build_spec_hash_4_repo_w_default_release_n_branch_update_merge(
+    get_md5_for_set_of_files: GetMd5ForSetOfFilesFn,
+    deps_files_4_repo_w_default_release_n_branch_update_merge: list[Path],
+) -> str:
+    # Generates a hash of the build spec to set when to invalidate the cache
+    return get_md5_for_set_of_files(
+        deps_files_4_repo_w_default_release_n_branch_update_merge
+    )
+
+
+@pytest.fixture(scope="session")
+def get_repo_definition_4_github_flow_repo_w_default_release_n_branch_update_merge(
+    convert_commit_specs_to_commit_defs: ConvertCommitSpecsToCommitDefsFn,
+    convert_commit_spec_to_commit_def: ConvertCommitSpecToCommitDefFn,
+    format_merge_commit_msg_git: FormatGitMergeCommitMsgFn,
+    changelog_md_file: Path,
+    changelog_rst_file: Path,
+    stable_now_date: GetStableDateNowFn,
+) -> GetRepoDefinitionFn:
+    """
+    This fixture provides a function that builds a repository definition for a trunk-based development
+    where a release in the default branch is made in parallel to a work in a feature branch,
+    feature branch is updated with the latest changes from the default branch and them merged back
+    into the default branch with a release.
+
+    It is the minimal reproducible example of the issue
+    [#1252](https://github.com/python-semantic-release/python-semantic-release/issues/1252).
+    """
+
+    def _get_repo_from_definition(
+        commit_type: CommitConvention,
+        hvcs_client_name: str = "github",
+        hvcs_domain: str = EXAMPLE_HVCS_DOMAIN,
+        tag_format_str: str | None = None,
+        extra_configs: dict[str, TomlSerializableTypes] | None = None,
+        mask_initial_release: bool = True,
+        ignore_merge_commits: bool = True,
+    ) -> Sequence[RepoActions]:
+        stable_now_datetime = stable_now_date()
+        commit_timestamp_gen = (
+            (stable_now_datetime + timedelta(seconds=i)).isoformat(timespec="seconds")
+            for i in count(step=1)
+        )
+
+        changelog_file_definitions: Sequence[RepoActionWriteChangelogsDestFile] = [
+            {
+                "path": changelog_md_file,
+                "format": ChangelogOutputFormat.MARKDOWN,
+            },
+            {
+                "path": changelog_rst_file,
+                "format": ChangelogOutputFormat.RESTRUCTURED_TEXT,
+            },
+        ]
+
+        repo_construction_steps: list[RepoActions] = []
+
+        repo_construction_steps.append(
+            {
+                "action": RepoActionStep.CONFIGURE,
+                "details": {
+                    "commit_type": commit_type,
+                    "hvcs_client_name": hvcs_client_name,
+                    "hvcs_domain": hvcs_domain,
+                    "tag_format_str": tag_format_str,
+                    "mask_initial_release": mask_initial_release,
+                    "extra_configs": {
+                        # Set the default release branch
+                        "tool.semantic_release.branches.main": {
+                            "match": r"^(main|master)$",
+                            "prerelease": False,
+                        },
+                        "tool.semantic_release.allow_zero_version": True,
+                        **(extra_configs or {}),
+                    },
+                },
+            }
+        )
+
+        # Make initial release
+        new_version = "0.1.0"
+
+        repo_construction_steps.extend(
+            [
+                {
+                    "action": RepoActionStep.MAKE_COMMITS,
+                    "details": {
+                        "commits": convert_commit_specs_to_commit_defs(
+                            [
+                                {
+                                    "conventional": INITIAL_COMMIT_MESSAGE,
+                                    "emoji": INITIAL_COMMIT_MESSAGE,
+                                    "scipy": INITIAL_COMMIT_MESSAGE,
+                                    "datetime": next(commit_timestamp_gen),
+                                    "include_in_changelog": bool(
+                                        commit_type == "emoji"
+                                    ),
+                                },
+                                {
+                                    "conventional": "feat: add new feature",
+                                    "emoji": ":sparkles: add new feature",
+                                    "scipy": "ENH: add new feature",
+                                    "datetime": next(commit_timestamp_gen),
+                                    "include_in_changelog": True,
+                                },
+                            ],
+                            commit_type,
+                        ),
+                    },
+                },
+                {
+                    "action": RepoActionStep.RELEASE,
+                    "details": {
+                        "version": new_version,
+                        "datetime": next(commit_timestamp_gen),
+                        "pre_actions": [
+                            {
+                                "action": RepoActionStep.WRITE_CHANGELOGS,
+                                "details": {
+                                    "new_version": new_version,
+                                    "dest_files": changelog_file_definitions,
+                                },
+                            },
+                        ],
+                    },
+                },
+            ]
+        )
+
+        # Create a feature branch (without commits yet, just to pin a commit)
+        repo_construction_steps.extend(
+            [
+                {
+                    "action": RepoActionStep.GIT_CHECKOUT,
+                    "details": {
+                        "create_branch": {
+                            "name": FEAT_BRANCH_NAME,
+                            "start_branch": DEFAULT_BRANCH_NAME,
+                        }
+                    },
+                },
+                {
+                    "action": RepoActionStep.GIT_CHECKOUT,
+                    "details": {"branch": DEFAULT_BRANCH_NAME},
+                },
+            ]
+        )
+
+        # Make another release in default branch
+        new_version = "0.2.0"
+
+        repo_construction_steps.extend(
+            [
+                {
+                    "action": RepoActionStep.MAKE_COMMITS,
+                    "details": {
+                        "commits": convert_commit_specs_to_commit_defs(
+                            [
+                                {
+                                    "conventional": "feat: add another feature",
+                                    "emoji": ":sparkles: add another feature",
+                                    "scipy": "ENH: add another feature",
+                                    "datetime": next(commit_timestamp_gen),
+                                    "include_in_changelog": True,
+                                },
+                            ],
+                            commit_type,
+                        ),
+                    },
+                },
+                {
+                    "action": RepoActionStep.RELEASE,
+                    "details": {
+                        "version": new_version,
+                        "datetime": next(commit_timestamp_gen),
+                        "pre_actions": [
+                            {
+                                "action": RepoActionStep.WRITE_CHANGELOGS,
+                                "details": {
+                                    "new_version": new_version,
+                                    "dest_files": changelog_file_definitions,
+                                },
+                            },
+                        ],
+                    },
+                },
+            ]
+        )
+
+        # Add commit to the feature branch
+        repo_construction_steps.extend(
+            [
+                {
+                    "action": RepoActionStep.GIT_CHECKOUT,
+                    "details": {"branch": FEAT_BRANCH_NAME},
+                },
+                {
+                    "action": RepoActionStep.MAKE_COMMITS,
+                    "details": {
+                        "commits": convert_commit_specs_to_commit_defs(
+                            [
+                                {
+                                    "conventional": "feat: add new feature in the feature branch",
+                                    "emoji": ":sparkles: add new feature in the feature branch",
+                                    "scipy": "ENH: add new feature in the feature branch",
+                                    "datetime": next(commit_timestamp_gen),
+                                    "include_in_changelog": True,
+                                },
+                            ],
+                            commit_type,
+                        ),
+                    },
+                },
+            ]
+        )
+
+        # Merge default branch into the feature branch to keep it up to date
+        repo_construction_steps.extend(
+            [
+                {
+                    "action": RepoActionStep.GIT_MERGE,
+                    "details": {
+                        "branch_name": DEFAULT_BRANCH_NAME,
+                        "fast_forward": False,
+                        "commit_def": convert_commit_spec_to_commit_def(
+                            {
+                                "conventional": format_merge_commit_msg_git(
+                                    branch_name=DEFAULT_BRANCH_NAME,
+                                    tgt_branch_name=FEAT_BRANCH_NAME,
+                                ),
+                                "emoji": format_merge_commit_msg_git(
+                                    branch_name=DEFAULT_BRANCH_NAME,
+                                    tgt_branch_name=FEAT_BRANCH_NAME,
+                                ),
+                                "scipy": format_merge_commit_msg_git(
+                                    branch_name=DEFAULT_BRANCH_NAME,
+                                    tgt_branch_name=FEAT_BRANCH_NAME,
+                                ),
+                                "datetime": next(commit_timestamp_gen),
+                                "include_in_changelog": not ignore_merge_commits,
+                            },
+                            commit_type,
+                        ),
+                    },
+                },
+                {
+                    "action": RepoActionStep.GIT_CHECKOUT,
+                    "details": {"branch": DEFAULT_BRANCH_NAME},
+                },
+            ]
+        )
+
+        # Merge the feature branch into the default branch and make a release
+        new_version = "0.3.0"
+
+        repo_construction_steps.extend(
+            [
+                {
+                    "action": RepoActionStep.GIT_MERGE,
+                    "details": {
+                        "branch_name": FEAT_BRANCH_NAME,
+                        "fast_forward": False,
+                        "commit_def": convert_commit_spec_to_commit_def(
+                            {
+                                "conventional": format_merge_commit_msg_git(
+                                    branch_name=FEAT_BRANCH_NAME,
+                                    tgt_branch_name=DEFAULT_BRANCH_NAME,
+                                ),
+                                "emoji": format_merge_commit_msg_git(
+                                    branch_name=FEAT_BRANCH_NAME,
+                                    tgt_branch_name=DEFAULT_BRANCH_NAME,
+                                ),
+                                "scipy": format_merge_commit_msg_git(
+                                    branch_name=FEAT_BRANCH_NAME,
+                                    tgt_branch_name=DEFAULT_BRANCH_NAME,
+                                ),
+                                "datetime": next(commit_timestamp_gen),
+                                "include_in_changelog": not ignore_merge_commits,
+                            },
+                            commit_type,
+                        ),
+                    },
+                },
+                {
+                    "action": RepoActionStep.RELEASE,
+                    "details": {
+                        "version": new_version,
+                        "datetime": next(commit_timestamp_gen),
+                        "pre_actions": [
+                            {
+                                "action": RepoActionStep.WRITE_CHANGELOGS,
+                                "details": {
+                                    "new_version": new_version,
+                                    "dest_files": changelog_file_definitions,
+                                },
+                            },
+                        ],
+                    },
+                },
+            ]
+        )
+
+        return repo_construction_steps
+
+    return _get_repo_from_definition
+
+
+@pytest.fixture(scope="session")
+def build_github_flow_repo_w_default_release_n_branch_update_merge(
+    build_repo_from_definition: BuildRepoFromDefinitionFn,
+    get_repo_definition_4_github_flow_repo_w_default_release_n_branch_update_merge: GetRepoDefinitionFn,
+    get_cached_repo_data: GetCachedRepoDataFn,
+    build_repo_or_copy_cache: BuildRepoOrCopyCacheFn,
+    build_spec_hash_4_repo_w_default_release_n_branch_update_merge: str,
+) -> BuildSpecificRepoFn:
+    def _build_specific_repo_type(
+        repo_name: str, commit_type: CommitConvention, dest_dir: Path
+    ) -> Sequence[RepoActions]:
+        def _build_repo(cached_repo_path: Path) -> Sequence[RepoActions]:
+            repo_construction_steps = get_repo_definition_4_github_flow_repo_w_default_release_n_branch_update_merge(
+                commit_type=commit_type,
+            )
+            return build_repo_from_definition(cached_repo_path, repo_construction_steps)
+
+        build_repo_or_copy_cache(
+            repo_name=repo_name,
+            build_spec_hash=build_spec_hash_4_repo_w_default_release_n_branch_update_merge,
+            build_repo_func=_build_repo,
+            dest_dir=dest_dir,
+        )
+
+        if not (cached_repo_data := get_cached_repo_data(proj_dirname=repo_name)):
+            raise ValueError("Failed to retrieve repo data from cache")
+
+        return cached_repo_data["build_definition"]
+
+    return _build_specific_repo_type
+
+
+# --------------------------------------------------------------------------- #
+# Test-level fixtures that will cache the built directory & set up test case  #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def repo_w_github_flow_w_default_release_n_branch_update_merge_conventional_commits(
+    build_github_flow_repo_w_default_release_n_branch_update_merge: BuildSpecificRepoFn,
+    example_project_git_repo: ExProjectGitRepoFn,
+    example_project_dir: ExProjectDir,
+    change_to_ex_proj_dir: None,
+) -> BuiltRepoResult:
+    repo_name = repo_w_github_flow_w_default_release_n_branch_update_merge_conventional_commits.__name__
+    commit_type: CommitConvention = repo_name.split("_")[-2]  # type: ignore[assignment]
+
+    return {
+        "definition": build_github_flow_repo_w_default_release_n_branch_update_merge(
+            repo_name=repo_name,
+            commit_type=commit_type,
+            dest_dir=example_project_dir,
+        ),
+        "repo": example_project_git_repo(),
+    }
+
+
+@pytest.fixture
+def repo_w_github_flow_w_default_release_n_branch_update_merge_emoji_commits(
+    build_github_flow_repo_w_default_release_n_branch_update_merge: BuildSpecificRepoFn,
+    example_project_git_repo: ExProjectGitRepoFn,
+    example_project_dir: ExProjectDir,
+    change_to_ex_proj_dir: None,
+) -> BuiltRepoResult:
+    repo_name = repo_w_github_flow_w_default_release_n_branch_update_merge_emoji_commits.__name__
+    commit_type: CommitConvention = repo_name.split("_")[-2]  # type: ignore[assignment]
+
+    return {
+        "definition": build_github_flow_repo_w_default_release_n_branch_update_merge(
+            repo_name=repo_name,
+            commit_type=commit_type,
+            dest_dir=example_project_dir,
+        ),
+        "repo": example_project_git_repo(),
+    }
+
+
+@pytest.fixture
+def repo_w_github_flow_w_default_release_n_branch_update_merge_scipy_commits(
+    build_github_flow_repo_w_default_release_n_branch_update_merge: BuildSpecificRepoFn,
+    example_project_git_repo: ExProjectGitRepoFn,
+    example_project_dir: ExProjectDir,
+    change_to_ex_proj_dir: None,
+) -> BuiltRepoResult:
+    repo_name = repo_w_github_flow_w_default_release_n_branch_update_merge_scipy_commits.__name__
+    commit_type: CommitConvention = repo_name.split("_")[-2]  # type: ignore[assignment]
+
+    return {
+        "definition": build_github_flow_repo_w_default_release_n_branch_update_merge(
+            repo_name=repo_name,
+            commit_type=commit_type,
+            dest_dir=example_project_dir,
+        ),
+        "repo": example_project_git_repo(),
+    }


### PR DESCRIPTION
## Purpose
Provides a repo fixture to reproduce the problem described in https://github.com/python-semantic-release/python-semantic-release/issues/1252 (based on [this comment](https://github.com/python-semantic-release/python-semantic-release/issues/1252#issuecomment-2905368729)) 


## Rationale
Added a new repo following the examples in other fixtures.
Had to made one more addition: `simulate_change_commits_n_rtn_changelog_entry()` fixture always worked with the `file_in_repo`. For this specific flow it caused merge conflicts, because commit in the feature branch was made before default branch was merged into a feature branch. Made this parameter configurable.



## How did you test?
I ran the test and it failed with the expected error (empty `## v0.3.0 (2025-05-31)` changelog entry)
```text
>           assert expected_md_changelog_content == actual_md_changelog_content
E           assert == failed. [pytest-clarity diff shown]
E             
E             LHS vs RHS shown below
E             
E               # CHANGELOG
E               
E               <!-- version list -->
E               
E               ## v0.3.0 (2025-05-31)
E             + 
E             + ### Features
E             + 
E             + - Add new feature in the feature branch
E             +   
E             ([`0000000`](https://example.com/example_owner/example_repo/commit/0000000000000
E             000000000000000000000000000))
E               
E               
E               ## v0.2.0 (2025-05-31)
E               
E               ### Features
E               
E               - Add another feature
E                 ([`0000000`](https://example.com/example_owner/example_repo/commit/000000000
E             0000000000000000000000000000000))
E               
E               
E               ## v0.1.0 (2025-05-31)
E               
E               - Initial Release
E             
```

## How to Verify
1. Comment (or remove `@pytest.mark.xfail` decorator on the `tests/e2e/cmd_version/bump_version/trunk_based_dev/test_repo_w_feature_branch_and_release_in_default.py` test.
2. run `pytest  -vv --comprehensive tests/e2e/cmd_version/bump_version/trunk_based_dev/test_repo_w_feature_branch_and_release_in_default.py`



---

## PR Completion Checklist

- [x] Reviewed & followed the [Contributor Guidelines](https://python-semantic-release.readthedocs.io/en/latest/contributing.html)

- [x] Changes Implemented & Validation pipeline succeeds

- [x] Commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
  and are separated into the proper commit type and scope (recommended order: test, build, feat/fix, docs)

- [ ] Appropriate Unit tests added/updated

- [x] Appropriate End-to-End tests added/updated

- [ ] Appropriate Documentation added/updated and syntax validated for sphinx build (see Contributor Guidelines)
