### PR TITLE
docs: +1/-1 fix readme typo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,5 +18,5 @@ The usage information and examples for this GitHub Action is available under
 the `GitHub Actions section`_ of `python-semantic-release.readthedocs.io`_.
 
 .. _python-semantic-release: https://pypi.org/project/python-semantic-release/
-.. _python-semantic-release.readthedocs.io: https://python-semantic-release.readthedocs.io/en/latest/
-.. _GitHub Actions section: https://python-semantic-release.readthedocs.io/en/latest/automatic-releases/github-actions.html
+.. _python-semantic-release.readthedocs.io: https://python-semantic-release.readthedocs.io/en/stable/
+.. _GitHub Actions section: https://python-semantic-release.readthedocs.io/en/stable/configuration/automatic-releases/github-actions.html


### PR DESCRIPTION
## Rationale
Hi, I noticed that the link in the documentation is no longer working.


---

## PR Completion Checklist

- [x] Reviewed & followed the [Contributor Guidelines](https://python-semantic-release.readthedocs.io/en/latest/contributing.html)

- [ ] Changes Implemented & Validation pipeline succeeds

- [x] Commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
  and are separated into the proper commit type and scope (recommended order: test, build, feat/fix, docs)

- [ ] Appropriate Unit tests added/updated

- [ ] Appropriate End-to-End tests added/updated

- [ ] Appropriate Documentation added/updated and syntax validated for sphinx build (see Contributor Guidelines)
