### PR TITLE
docs(getting_started.rst): Remove exclude_commit_pattern self-reference.

### DIFF
--- a/docs/concepts/getting_started.rst
+++ b/docs/concepts/getting_started.rst
@@ -215,7 +215,7 @@ To set commit exclusion patterns for a conventional commits parsers, add the fol
 
 .. code-block:: toml
 
-    [tool.semantic_release.changelog.exclude_commit_patterns]
+    [tool.semantic_release.changelog]
     # Recommended patterns for conventional commits parser that is scope aware
     exclude_commit_patterns = [
         '''chore(?:\([^)]*?\))?: .+''',


### PR DESCRIPTION
## Purpose
Fixes typo in getting started doc. Resolves: #1291

## Rationale
Solves issue by removing duplicate naming.


## How did you test?
Simple change to docs only, built & examined web output using `sphinx-autobuild --open-browser docs docs/_build/html` as per contributing guidelines.


## How to Verify
Follow `getting_started.rst` for a basic python package. Output should be
```
> semantic-release -v --noop version

🛡 You are running in no-operation mode, because the '--noop' flag was supplied
[23:57:33] INFO     Loading configuration from pyproject.toml                                                                                  util.py:77
branch 'main' isn't in any release groups; no release will be made
```
instead of 

```
> semantic-release -v --noop version

🛡 You are running in no-operation mode, because the '--noop' flag was supplied
[23:54:38] INFO     Loading configuration from pyproject.toml                                                                                  util.py:77
1 validation error for RawConfig
changelog.exclude_commit_patterns
  Input should be a valid tuple [type=tuple_type, input_value={'exclude_commit_patterns... 'Initial [Cc]ommit.*']}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.11/v/tuple_type
```

Apologies, haven't used semantic-release yet, so I may have incorrectly done something.

---

## PR Completion Checklist
- [x] Reviewed & followed the [Contributor Guidelines](https://python-semantic-release.readthedocs.io/en/latest/contributing.html)

- [x] Changes Implemented & Validation pipeline succeeds

- [x] Commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
  and are separated into the proper commit type and scope (recommended order: test, build, feat/fix, docs)

- [x] N/A ~~Appropriate Unit tests added/updated~~

- [x] N/A ~~Appropriate End-to-End tests added/updated~~

- [x] Appropriate Documentation added/updated and syntax validated for sphinx build (see Contributor Guidelines)
