### PR TITLE
docs: do not update CHANGELOG.md on build command

### DIFF
--- a/docs/configuration/configuration-guides/uv_integration.rst
+++ b/docs/configuration/configuration-guides/uv_integration.rst
@@ -176,7 +176,7 @@ look like this:
           id: version
           env:
             GH_TOKEN: "none"
-          run: uv run semantic-release -v version --no-commit --no-tag
+          run: uv run semantic-release -v version --no-changelog --no-commit --no-tag
 
         - name: Upload | Distribution Artifacts
           if: ${{ steps.version.outputs.released == 'true' }}


### PR DESCRIPTION
<!--
Please do not combine multiple features or fix actions that are not
directly dependent on one another. Please open multiple PRs instead because
one may be merged while the other is denied or has requested changes. This
will slow down the process of merging the accepted changes as reviews are
also more difficult to evaluate for edge cases.
-->

## Purpose
This PR adds `--no-changelog` flag to build job as _CHANGELOG.md_ is not passed as an artefact to release job.