### PR TITLE
fix(cmd-version): prevent errors when PSR is executed in non-GitHub CI environments

### DIFF
--- a/src/semantic_release/cli/commands/version.py
+++ b/src/semantic_release/cli/commands/version.py
@@ -471,11 +471,7 @@ def version(  # noqa: C901
     no_verify = runtime.no_git_verify
     opts = runtime.global_cli_options
     gha_output = VersionGitHubActionsOutput(
-        gh_client=(
-            hvcs_client
-            if isinstance(hvcs_client, Github)
-            else Github(hvcs_client.remote_url(use_token=False))
-        ),
+        gh_client=hvcs_client if isinstance(hvcs_client, Github) else None,
         mode=(
             PersistenceMode.TEMPORARY
             if opts.noop or (not commit_changes and not create_tag)
@@ -553,7 +549,8 @@ def version(  # noqa: C901
 
     # Update GitHub Actions output value with new version & set delayed write
     gha_output.version = new_version
-    ctx.call_on_close(gha_output.write_if_possible)
+    if isinstance(hvcs_client, Github):
+        ctx.call_on_close(gha_output.write_if_possible)
 
     # Make string variant of version or appropriate tag as necessary
     version_to_print = str(new_version) if not print_only_tag else new_version.as_tag()

--- a/src/semantic_release/cli/github_actions_output.py
+++ b/src/semantic_release/cli/github_actions_output.py
@@ -24,7 +24,7 @@ class VersionGitHubActionsOutput:
 
     def __init__(
         self,
-        gh_client: Github,
+        gh_client: Github | None = None,
         mode: PersistenceMode = PersistenceMode.PERMANENT,
         released: bool | None = None,
         version: Version | None = None,
@@ -106,6 +106,12 @@ class VersionGitHubActionsOutput:
             raise TypeError("output 'prev_version' should be a Version")
         self._prev_version = value
 
+    @property
+    def gh_client(self) -> Github:
+        if not self._gh_client:
+            raise ValueError("GitHub client not set, cannot create links")
+        return self._gh_client
+
     def to_output_text(self) -> str:
         missing: set[str] = set()
         if self.version is None:
@@ -128,7 +134,7 @@ class VersionGitHubActionsOutput:
             "version": str(self.version),
             "tag": self.tag,
             "is_prerelease": str(self.is_prerelease).lower(),
-            "link": self._gh_client.create_release_url(self.tag) if self.tag else "",
+            "link": self.gh_client.create_release_url(self.tag) if self.tag else "",
             "previous_version": str(self.prev_version) if self.prev_version else "",
             "commit_sha": self.commit_sha if self.commit_sha else "",
         }


### PR DESCRIPTION
## Purpose
<!-- Reason for the PR (solves an issue/problem, adds a feature, etc) -->

- Resolves: #1315

## Rationale
<!-- How did you come to this conclusion as the solution? What was your reasoning? What were you trying to do? What problems did you find and avoid? -->

Unfortunately, PSR introduced a bug in 10.3.0 when attempting to provide more CI outputs for GitHub Actions. It required our GitHub client interface to be loaded and even if it was not using GitHub CI to be run. This caused errors in Gitea and likely GitLab/Bitbucket environments. This change prevents that from happening but if any users pipelines were intentionally presenting the environment variable "GITHUB_OUTPUT" to enable action output to enable passing along internal outputs of PSR then their hack will no longer work after this change.

---

## PR Completion Checklist

- [x] Reviewed & followed the [Contributor Guidelines](https://python-semantic-release.readthedocs.io/en/latest/contributing.html)

- [x] Changes Implemented & Validation pipeline succeeds

- [x] Commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
  and are separated into the proper commit type and scope (recommended order: test, build, feat/fix, docs)

- [x] N/A ~~Appropriate Unit tests added/updated~~

- [x] N/A ~~Appropriate End-to-End tests added/updated~~

- [x] N/A ~~Appropriate Documentation added/updated and syntax validated for sphinx build (see Contributor Guidelines)~~
