### PR TITLE
feat(parser-emoji): render descriptive changelog labels

### DIFF
--- a/docs/concepts/commit_parsing.rst
+++ b/docs/concepts/commit_parsing.rst
@@ -337,6 +337,10 @@ how PSR's core features:
   :ref:`changelog.exclude_commit_patterns <config-changelog-exclude_commit_patterns>`
   to ignore those commit styles.
 
+  Set ``commit_parser_options.render_emoji`` to ``true`` to render the default shortcode
+  tags as descriptive Unicode headings, such as ``🐛 Bug Fixes``, and remove the leading
+  tag from each commit description.
+
 - **Pull/Merge Request Identifier Detection**: This parser implements PSR's
   :ref:`commit_parser-builtin-linked_merge_request_detection` to identify and extract
   pull/merge request numbers. The parser will return a string value if a pull/merge

--- a/src/semantic_release/commit_parser/emoji.py
+++ b/src/semantic_release/commit_parser/emoji.py
@@ -29,6 +29,34 @@ from semantic_release.errors import InvalidParserOptions
 from semantic_release.globals import logger
 from semantic_release.helpers import sort_numerically, text_reducer
 
+DEFAULT_EMOJI_CHANGELOG_SECTIONS = {
+    ":boom:": "💥 Breaking Changes",
+    ":sparkles:": "✨ Features",
+    ":children_crossing:": "🚸 User Experience",
+    ":lipstick:": "💄 UI and Style",
+    ":iphone:": "📱 Responsive Design",
+    ":egg:": "🥚 Easter Eggs",
+    ":chart_with_upwards_trend:": "📈 Analytics",
+    ":ambulance:": "🚑 Critical Hotfixes",
+    ":lock:": "🔒 Security",
+    ":bug:": "🐛 Bug Fixes",
+    ":zap:": "⚡ Performance",
+    ":goal_net:": "🥅 Error Handling",
+    ":alien:": "👽 External API Changes",
+    ":wheelchair:": "♿ Accessibility",
+    ":speech_balloon:": "💬 Text and Literals",
+    ":mag:": "🔍 SEO",
+    ":apple:": "🍎 macOS",
+    ":penguin:": "🐧 Linux",
+    ":checkered_flag:": "🏁 Windows",
+    ":robot:": "🤖 Android",
+    ":green_apple:": "🍏 iOS",
+    ":checkmark:": "✅ Tests",
+    ":construction_worker:": "👷 Continuous Integration",
+    ":memo:": "📝 Documentation",
+    ":recycle:": "♻️ Refactoring",
+}
+
 
 @dataclass
 class EmojiParserOptions(ParserOptions):
@@ -103,6 +131,12 @@ class EmojiParserOptions(ParserOptions):
     ignore_merge_commits: bool = True
     """Toggle flag for whether or not to ignore merge commits"""
 
+    render_emoji: bool = False
+    """
+    Render default emoji tags as descriptive Unicode changelog section headings
+    and remove the leading tag from commit descriptions.
+    """
+
     @property
     def tag_to_level(self) -> dict[str, LevelBump]:
         """A mapping of commit tags to the level bump they should result in."""
@@ -134,8 +168,9 @@ class EmojiCommitParser(CommitParser[ParseResult, EmojiParserOptions]):
     If the message does not contain any known emojis, then the level to bump
     will be 0 and the type of change "Other". This parser never raises
     UnknownCommitMessageStyleError.
-    Emojis are not removed from the description, and will appear alongside
-    the commit subject in the changelog.
+    By default, emojis are not removed from the description and will appear
+    alongside the commit subject in the changelog. Set ``render_emoji`` to
+    render descriptive Unicode headings and omit the leading tag.
     """
 
     # TODO: Deprecate in lieu of get_default_options()
@@ -289,7 +324,17 @@ class EmojiCommitParser(CommitParser[ParseResult, EmojiParserOptions]):
             primary_emoji, self.options.default_bump_level
         )
 
-        # All emojis will remain part of the returned description
+        category = primary_emoji
+        if (
+            self.options.render_emoji
+            and match
+            and (
+                rendered_category := DEFAULT_EMOJI_CHANGELOG_SECTIONS.get(primary_emoji)
+            )
+        ):
+            category = rendered_category
+            subject = subject[match.end() :].lstrip()
+
         body_components: dict[str, list[str]] = reduce(
             self.commit_body_components_separator,
             [
@@ -308,7 +353,7 @@ class EmojiCommitParser(CommitParser[ParseResult, EmojiParserOptions]):
         return ParsedMessageResult(
             bump=level_bump,
             type=primary_emoji,
-            category=primary_emoji,
+            category=category,
             scope=parsed_scope,
             descriptions=(
                 descriptions[:1] if level_bump is LevelBump.MAJOR else descriptions

--- a/tests/unit/semantic_release/commit_parser/test_emoji.py
+++ b/tests/unit/semantic_release/commit_parser/test_emoji.py
@@ -98,6 +98,33 @@ def test_default_emoji_parser(
 
 
 @pytest.mark.parametrize(
+    "message, category, scope, description",
+    [
+        (":bug: correct some text", "🐛 Bug Fixes", "", "correct some text"),
+        (
+            ":sparkles:(cli): add a new option",
+            "✨ Features",
+            "cli",
+            "add a new option",
+        ),
+    ],
+)
+def test_emoji_parser_render_emoji_for_changelog(
+    message: str,
+    category: str,
+    scope: str,
+    description: str,
+):
+    parser = EmojiCommitParser(EmojiParserOptions(render_emoji=True))
+
+    result = parser.parse_message(message)
+
+    assert category == result.category
+    assert scope == result.scope
+    assert (description,) == result.descriptions
+
+
+@pytest.mark.parametrize(
     "message, subject, merge_request_number",
     [
         # GitHub, Gitea style


### PR DESCRIPTION
## Purpose

Implements #1409 by adding an opt-in `commit_parser_options.render_emoji` setting for the built-in emoji parser. When enabled, default shortcode categories render as descriptive Unicode changelog headings (for example, `🐛 Bug Fixes`) and the classified leading tag is removed from the commit summary.

The default behavior remains unchanged, and custom tags that do not have a built-in display label continue to use their configured value.

## Rationale

The changelog already groups entries using `ParsedMessageResult.category` and renders the first description as the bullet text. Keeping the change in the emoji parser avoids a second template tree and avoids a runtime dependency: the parser can opt in to a static mapping for the tags it already supports, while preserving backward compatibility.

## How did you test?

- Added regression coverage for shortcode headings, tag-free summaries, and scoped commits.
- Focused parser and default changelog tests: `1055 passed`.
- Full non-comprehensive suite with six workers: `4266 passed, 15 skipped`.
- Repository-wide Ruff check and format check passed.
- Focused mypy check for the changed source passed. Full `mypy .` reaches four existing `importlib.resources`/`importlib_resources` `no-redef` errors in untouched files under Python 3.13.
- Sphinx completed rendering all pages; strict warning mode reports three existing warnings in untouched documentation/docstrings.
- `git diff --check` passed.

## How to Verify

1. Configure `commit_parser = "emoji"`.
2. Set `commit_parser_options.render_emoji = true`.
3. Parse `:bug: correct some text` and generate a changelog.
4. Confirm the section is `🐛 Bug Fixes` and the bullet begins with `Correct some text`, without the `:bug:` prefix.
5. Disable the option and confirm the existing shortcode output is unchanged.

## AI disclosure

I used OpenAI Codex to help investigate the issue, implement the change, and run validation. I reviewed the final diff, test results, and PR description before submission.

---

## PR Completion Checklist

- [x] Reviewed & followed the Contributor Guidelines
- [x] Changes Implemented & validation pipeline submitted
- [x] Commits follow Conventional Commits and are separated into test and feature commits
- [x] Appropriate Unit tests added
- [x] Existing End-to-End suite passed; no dedicated CLI E2E was needed for this parser data-contract change
- [x] Appropriate Documentation added and Sphinx syntax validated