### PR TITLE
fix(changelog): reduce release history log volume

### DIFF
--- a/src/semantic_release/changelog/release_history.py
+++ b/src/semantic_release/changelog/release_history.py
@@ -108,7 +108,7 @@ class ReleaseHistory:
 
                 released.setdefault(the_version, release)
 
-            logger.info(
+            logger.debug(
                 "parsing commit [%s] %s",
                 commit.hexsha[:8],
                 str(commit.message).replace("\n", " ")[:54],
@@ -164,7 +164,7 @@ class ReleaseHistory:
                 )
 
                 if ignore_merge_commits and parsed_result.is_merge_commit():
-                    logger.info("Excluding merge commit[%s]", parsed_result.short_hash)
+                    logger.debug("Excluding merge commit[%s]", parsed_result.short_hash)
                     continue
 
                 # Skip excluded commits except for any commit causing a version bump
@@ -172,7 +172,7 @@ class ReleaseHistory:
                 # are included, then the changelog will be empty. Even if ther was other
                 # commits included, the true reason for a version bump would be missing.
                 if has_exclusion_match and commit_level_bump == LevelBump.NO_RELEASE:
-                    logger.info(
+                    logger.debug(
                         "Excluding %s commit[%s] %s",
                         "piece of squashed" if is_squash_commit else "",
                         parsed_result.short_hash,
@@ -184,7 +184,7 @@ class ReleaseHistory:
                     isinstance(parsed_result, ParsedCommit)
                     and not parsed_result.include_in_changelog
                 ):
-                    logger.info(
+                    logger.debug(
                         str.join(
                             " ",
                             [
@@ -197,7 +197,7 @@ class ReleaseHistory:
                     continue
 
                 if the_version is None:
-                    logger.info(
+                    logger.debug(
                         "[Unreleased] adding commit[%s] to unreleased '%s'",
                         parsed_result.short_hash,
                         commit_type,
@@ -205,7 +205,7 @@ class ReleaseHistory:
                     unreleased[commit_type].append(parsed_result)
                     continue
 
-                logger.info(
+                logger.debug(
                     "[%s] adding commit[%s] to release '%s'",
                     the_version,
                     parsed_result.short_hash,

--- a/tests/unit/semantic_release/changelog/test_release_history.py
+++ b/tests/unit/semantic_release/changelog/test_release_history.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging
+import re
 from datetime import datetime
 from typing import TYPE_CHECKING, NamedTuple
 
@@ -8,6 +10,7 @@ from git import Actor
 from pytest_lazy_fixtures.lazy_fixture import lf as lazy_fixture
 
 from semantic_release.changelog.release_history import ReleaseHistory
+from semantic_release.globals import logger
 from semantic_release.version.translator import VersionTranslator
 from semantic_release.version.version import Version
 
@@ -302,3 +305,41 @@ def test_all_matching_repo_tags_are_released(
 
     for tag in repo.tags:
         assert translator.from_tag(tag.name) in release_history.released
+
+
+@pytest.mark.order("last")
+def test_release_history_commit_details_are_debug_logs(
+    repo_w_no_tags_conventional_commits: BuiltRepoResult,
+    default_conventional_parser: ConventionalCommitParser,
+    caplog: pytest.LogCaptureFixture,
+):
+    with caplog.at_level(logging.DEBUG, logger=logger.name):
+        ReleaseHistory.from_git_history(
+            repo=repo_w_no_tags_conventional_commits["repo"],
+            translator=VersionTranslator(),
+            commit_parser=default_conventional_parser,  # type: ignore[arg-type]
+            exclude_commit_patterns=(re.compile(r"^Initial commit"),),
+        )
+
+    commit_detail_records = [
+        record
+        for record in caplog.records
+        if any(
+            message in record.getMessage()
+            for message in ("parsing commit", "Excluding", "adding commit")
+        )
+    ]
+
+    assert commit_detail_records
+    assert any(
+        "parsing commit" in record.getMessage() for record in commit_detail_records
+    )
+    assert any("Excluding" in record.getMessage() for record in commit_detail_records)
+    assert any(
+        "adding commit" in record.getMessage() for record in commit_detail_records
+    )
+    assert all(record.levelno == logging.DEBUG for record in commit_detail_records)
+    assert any(
+        record.levelno == logging.INFO and "previous tags" in record.getMessage()
+        for record in caplog.records
+    )


### PR DESCRIPTION
## Purpose

Resolve #1447 by keeping per-commit release-history details out of INFO output while retaining them at DEBUG verbosity.

## Rationale

ReleaseHistory emits parsing, exclusion, and destination details once or more for every traversed commit. On large repositories, those records dominate -v output and can exceed CI log limits. They are diagnostic details rather than summaries, so this change moves all six per-commit records to DEBUG while leaving aggregate INFO records, such as the number of previous tags, unchanged.

## How did you test?

- added a caplog regression that verifies parsing, exclusion, and addition details are DEBUG while the aggregate previous-tags record remains INFO
- verified the regression fails on the unmodified baseline and passes with this change
- ran the complete release-history comprehensive selection: 19 passed
- ran a real noop CLI comparison: -v emitted no per-commit details, while -vv retained them; aggregate tag counts remained visible
- Ruff check, Ruff format check, production-file Mypy, and git diff --check passed

## How to Verify

1. Run the release-history unit test file with --comprehensive.
2. Run semantic-release -v version --noop in a repository with history and confirm parsing, excluding, and adding records are absent.
3. Repeat with -vv and confirm those per-commit records are present.

---

## PR Completion Checklist

- [x] Reviewed and followed the Contributor Guidelines
- [ ] Changes implemented and validation pipeline succeeds
- [x] Commits follow Conventional Commits and are separated into source and unit-test commits
- [x] Appropriate unit tests added
- [x] End-to-end coverage evaluated; the existing CLI verbosity mapping is unchanged, and a real noop CLI comparison passed
- [x] Documentation evaluated; no user-facing option or API changed, and -vv retains the existing diagnostic details