### PR TITLE
fix(github): publish release as draft first to attach assets

### DIFF
--- a/src/semantic_release/hvcs/github.py
+++ b/src/semantic_release/hvcs/github.py
@@ -250,6 +250,14 @@ class Github(RemoteHvcsBase):
             return -1
 
         logger.info("Creating release for tag %s", tag)
+
+        # GitHub's immutable releases feature freezes a release's assets the moment
+        # the release is published, so assets cannot be attached afterwards. When we
+        # have assets to upload, create the release as a draft, upload the assets
+        # while it is still mutable, and only then publish it. Releases without
+        # assets are published directly, leaving that common path unchanged.
+        create_as_draft = bool(assets)
+
         releases_endpoint = self.create_api_url(
             endpoint=f"/repos/{self.owner}/{self.repo_name}/releases",
         )
@@ -259,7 +267,7 @@ class Github(RemoteHvcsBase):
                 "tag_name": tag,
                 "name": tag,
                 "body": release_notes,
-                "draft": False,
+                "draft": create_as_draft,
                 "prerelease": prerelease,
             },
         )
@@ -287,15 +295,21 @@ class Github(RemoteHvcsBase):
                     )
                 )
 
-        if len(errors) < 1:
-            return release_id
+        if errors:
+            for error in errors:
+                logger.exception(error)
 
-        for error in errors:
-            logger.exception(error)
+            # Leave the release as a draft so the user can inspect, retry, or
+            # remove it; nothing is left half-published.
+            raise IncompleteReleaseError(
+                f"Failed to upload asset{'s' if len(errors) > 1 else ''} to release!"
+            )
 
-        raise IncompleteReleaseError(
-            f"Failed to upload asset{'s' if len(errors) > 1 else ''} to release!"
-        )
+        if create_as_draft:
+            # All assets are attached; publish the draft.
+            self.publish_release(release_id)
+
+        return release_id
 
     @logged_function(logger)
     @suppress_not_found
@@ -342,6 +356,29 @@ class Github(RemoteHvcsBase):
         )
 
         # Raise an error if the update was unsuccessful
+        response.raise_for_status()
+
+        return release_id
+
+    @logged_function(logger)
+    def publish_release(self, release_id: int) -> int:
+        """
+        Publish a draft release
+        https://docs.github.com/rest/releases/releases#update-a-release
+        :param release_id: ID of the draft release to publish
+        :return: The ID of the release that was published
+        """
+        logger.info("Publishing release %s", release_id)
+        release_endpoint = self.create_api_url(
+            endpoint=f"/repos/{self.owner}/{self.repo_name}/releases/{release_id}",
+        )
+
+        response = self.session.post(
+            release_endpoint,
+            json={"draft": False},
+        )
+
+        # Raise an error if publishing was unsuccessful
         response.raise_for_status()
 
         return release_id

--- a/tests/unit/semantic_release/hvcs/test_github.py
+++ b/tests/unit/semantic_release/hvcs/test_github.py
@@ -13,7 +13,7 @@ import requests_mock
 from requests import HTTPError, Response, Session
 from requests.auth import _basic_auth_str
 
-from semantic_release.errors import AssetUploadError
+from semantic_release.errors import AssetUploadError, IncompleteReleaseError
 from semantic_release.hvcs.github import Github
 from semantic_release.hvcs.token_auth import TokenAuth
 
@@ -479,6 +479,88 @@ def test_create_release_succeeds(
         assert expected_http_method == m.last_request.method
         assert expected_request_url == m.last_request.url
         assert expected_request_body == m.last_request.json()
+
+
+@pytest.mark.parametrize("prerelease", (True, False))
+def test_create_release_with_assets_creates_draft_then_publishes(
+    default_gh_client: Github,
+    prerelease: bool,
+):
+    """When assets are provided, the release is created as a draft, the assets are
+    uploaded while it is still mutable, and only then is it published. This is the
+    sequence GitHub's immutable releases feature requires.
+    """
+    tag = "v1.0.0"
+    release_id = 5
+    assets = ["dist/pkg-1.0.0.tar.gz", "dist/pkg-1.0.0-py3-none-any.whl"]
+    releases_url = "{api_url}/repos/{owner}/{repo_name}/releases".format(
+        api_url=default_gh_client.api_url,
+        owner=default_gh_client.owner,
+        repo_name=default_gh_client.repo_name,
+    )
+    publish_url = f"{releases_url}/{release_id}"
+    expected_num_requests = 2  # create draft + publish
+
+    with requests_mock.Mocker(session=default_gh_client.session) as m, mock.patch.object(
+        default_gh_client,
+        default_gh_client.upload_release_asset.__name__,
+        return_value=True,
+    ) as mock_upload_release_asset:
+        m.register_uri(
+            "POST", github_api_matcher, json={"id": release_id}, status_code=201
+        )
+
+        actual_rtn_val = default_gh_client.create_release(
+            tag, RELEASE_NOTES, prerelease, assets=assets
+        )
+
+        assert release_id == actual_rtn_val
+        assert expected_num_requests == len(m.request_history)
+
+        create_request, publish_request = m.request_history
+
+        # The release is created as a draft
+        assert releases_url == create_request.url
+        assert create_request.json()["draft"] is True
+
+        # Every asset is uploaded
+        assert len(assets) == mock_upload_release_asset.call_count
+
+        # The final request publishes the draft
+        assert publish_url == publish_request.url
+        assert {"draft": False} == publish_request.json()
+
+
+def test_create_release_leaves_draft_when_asset_upload_fails(
+    default_gh_client: Github,
+):
+    """When an asset upload fails, the release is left as a draft (never published)
+    and IncompleteReleaseError is raised, so nothing is half-published.
+    """
+    tag = "v1.0.0"
+    release_id = 7
+    assets = ["dist/pkg-1.0.0.tar.gz"]
+    expected_num_requests = 1  # only the draft-create; no publish
+
+    http_error = HTTPError("500 Server Error")
+    http_error.response = Response()
+    http_error.response.status_code = 500
+
+    with requests_mock.Mocker(session=default_gh_client.session) as m, mock.patch.object(
+        default_gh_client,
+        default_gh_client.upload_release_asset.__name__,
+        side_effect=http_error,
+    ):
+        m.register_uri(
+            "POST", github_api_matcher, json={"id": release_id}, status_code=201
+        )
+
+        with pytest.raises(IncompleteReleaseError):
+            default_gh_client.create_release(tag, RELEASE_NOTES, assets=assets)
+
+        # Only the draft-create request was made; the draft was never published
+        assert expected_num_requests == len(m.request_history)
+        assert m.last_request.json()["draft"] is True
 
 
 @pytest.mark.parametrize("status_code", (400, 404, 429, 500, 503))


### PR DESCRIPTION
## What

The GitHub publish flow creates and **publishes** the release first, then uploads distribution assets in a separate request. GitHub's [immutable releases](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/immutable-releases) freeze a release's assets the moment it is published, so that second upload now fails on any org with the feature enabled:

```
HTTPError: 422 Client Error: Unprocessable Entity
Cannot upload assets to an immutable release
```

The release still gets created, but with **no assets**, and it can never be backfilled because it is immutable. Closes #1478.

## The fix

`create_release` now creates the release as a **draft** when assets are present, uploads the assets while it is still mutable, then publishes it via a new `publish_release` method — the sequence immutable releases require.

- **No-assets path is unchanged.** With no assets there is nothing to freeze, so the release is created published directly (`draft: False`), as today. The extra publish round-trip only happens when assets are actually uploaded.
- **Fail-safe on upload error.** If an asset upload fails, the release is left as a draft and `IncompleteReleaseError` is raised, so nothing is published without its assets. The leftover draft is not auto-published or cleaned up on a re-run — it stays for the user to inspect, retry, or delete.

Scoped to the GitHub HVCS; the other providers don't have this ordering.

## Testing

- `test_create_release_with_assets_creates_draft_then_publishes` — asserts create-as-draft, all assets uploaded, then a publish request.
- `test_create_release_leaves_draft_when_asset_upload_fails` — asserts the draft is never published on upload failure.
- All existing `test_github.py` tests pass unmodified, confirming the no-assets path is untouched.

`pytest tests/unit/semantic_release/hvcs/test_github.py` → 203 passed. `ruff check` and `mypy` clean.

## Related

This overlaps with #1193 (native draft-release support) — filed separately as a breakage on immutable-release orgs rather than a convenience feature. Heads-up: the `create_release` rewrite in #1436 keeps the `draft=False`-then-upload order, so it would reintroduce this once merged.

