### PR TITLE
feat(hvcs-github): support creating GitHub releases as drafts

### DIFF
--- a/src/semantic_release/hvcs/bitbucket.py
+++ b/src/semantic_release/hvcs/bitbucket.py
@@ -240,9 +240,9 @@ class Bitbucket(RemoteHvcsBase):
         return super().upload_dists(tag, dist_glob)
 
     def create_or_update_release(
-        self, tag: str, release_notes: str, prerelease: bool = False
+        self, tag: str, release_notes: str, prerelease: bool = False, draft: bool = False
     ) -> int | str:
-        return super().create_or_update_release(tag, release_notes, prerelease)
+        return super().create_or_update_release(tag, release_notes, prerelease, draft)
 
     def create_release(
         self,
@@ -251,8 +251,9 @@ class Bitbucket(RemoteHvcsBase):
         prerelease: bool = False,
         assets: list[str] | None = None,
         noop: bool = False,
+        draft: bool = False,
     ) -> int | str:
-        return super().create_release(tag, release_notes, prerelease, assets, noop)
+        return super().create_release(tag, release_notes, prerelease, assets, noop, draft)
 
 
 RemoteHvcsBase.register(Bitbucket)

--- a/src/semantic_release/hvcs/gitea.py
+++ b/src/semantic_release/hvcs/gitea.py
@@ -86,6 +86,7 @@ class Gitea(RemoteHvcsBase):
         prerelease: bool = False,
         assets: list[str] | None = None,
         noop: bool = False,
+        draft: bool = False,
     ) -> int:
         """
         Create a new release
@@ -223,7 +224,7 @@ class Gitea(RemoteHvcsBase):
 
     @logged_function(logger)
     def create_or_update_release(
-        self, tag: str, release_notes: str, prerelease: bool = False
+        self, tag: str, release_notes: str, prerelease: bool = False, draft: bool = False
     ) -> int:
         """
         Post release changelog
@@ -234,7 +235,7 @@ class Gitea(RemoteHvcsBase):
         """
         logger.info("Creating release for %s", tag)
         try:
-            return self.create_release(tag, release_notes, prerelease)
+            return self.create_release(tag, release_notes, prerelease, draft=draft)
         except HTTPError as err:
             logger.debug("error creating release: %s", err)
             logger.debug("looking for an existing release to update")

--- a/src/semantic_release/hvcs/github.py
+++ b/src/semantic_release/hvcs/github.py
@@ -210,6 +210,7 @@ class Github(RemoteHvcsBase):
         prerelease: bool = False,
         assets: list[str] | None = None,
         noop: bool = False,
+        draft: bool = False,
     ) -> int:
         """
         Create a new release
@@ -223,6 +224,8 @@ class Github(RemoteHvcsBase):
         :param prerelease: Whether or not this release should be created as a prerelease
 
         :param assets: a list of artifacts to upload to the release
+
+        :param draft: Whether or not this release should be created as a draft
 
         :return: the ID of the release
         """
@@ -259,7 +262,7 @@ class Github(RemoteHvcsBase):
                 "tag_name": tag,
                 "name": tag,
                 "body": release_notes,
-                "draft": False,
+                "draft": draft,
                 "prerelease": prerelease,
             },
         )
@@ -348,18 +351,19 @@ class Github(RemoteHvcsBase):
 
     @logged_function(logger)
     def create_or_update_release(
-        self, tag: str, release_notes: str, prerelease: bool = False
+        self, tag: str, release_notes: str, prerelease: bool = False, draft: bool = False
     ) -> int:
         """
         Post release changelog
         :param tag: The version number
         :param release_notes: The release notes for this version
         :param prerelease: Whether or not this release should be created as a prerelease
+        :param draft: Whether or not this release should be created as a draft
         :return: The status of the request
         """
         logger.info("Creating release for %s", tag)
         try:
-            return self.create_release(tag, release_notes, prerelease)
+            return self.create_release(tag, release_notes, prerelease, draft=draft)
         except HTTPError as err:
             logger.debug("error creating release: %s", err)
             logger.debug("looking for an existing release to update")

--- a/src/semantic_release/hvcs/gitlab.py
+++ b/src/semantic_release/hvcs/gitlab.py
@@ -97,6 +97,7 @@ class Gitlab(RemoteHvcsBase):
         prerelease: bool = False,  # noqa: ARG002
         assets: list[str] | None = None,  # noqa: ARG002
         noop: bool = False,
+        draft: bool = False,  # noqa: ARG002 (no effect in GitLab)
     ) -> str:
         """
         Create a release in a remote VCS, adding any release notes and assets to it
@@ -178,7 +179,7 @@ class Gitlab(RemoteHvcsBase):
 
     @logged_function(logger)
     def create_or_update_release(
-        self, tag: str, release_notes: str, prerelease: bool = False
+        self, tag: str, release_notes: str, prerelease: bool = False, draft: bool = False
     ) -> str:
         """
         Create or update a release for the given tag in a remote VCS.
@@ -186,6 +187,7 @@ class Gitlab(RemoteHvcsBase):
         :param tag: The tag to create or update the release for
         :param release_notes: The changelog description for this version only
         :param prerelease: This parameter has no effect in GitLab
+        :param draft: This parameter has no effect in GitLab
 
         :return: The release id
 

--- a/src/semantic_release/hvcs/remote_hvcs_base.py
+++ b/src/semantic_release/hvcs/remote_hvcs_base.py
@@ -63,18 +63,21 @@ class RemoteHvcsBase(HvcsBase, metaclass=ABCMeta):
         prerelease: bool = False,
         assets: list[str] | None = None,
         noop: bool = False,
+        draft: bool = False,
     ) -> int | str:
         """
         Create a release in a remote VCS, if supported
 
         Which includes uploading any assets as part of the release
+
+        :param draft: Whether or not the release should be created as a draft (GitHub)
         """
         self._not_supported(self.create_release.__name__)
         return -1
 
     @abstractmethod
     def create_or_update_release(
-        self, tag: str, release_notes: str, prerelease: bool = False
+        self, tag: str, release_notes: str, prerelease: bool = False, draft: bool = False
     ) -> int | str:
         """
         Create or update a release for the given tag in a remote VCS, attaching the

--- a/tests/unit/semantic_release/hvcs/test_github.py
+++ b/tests/unit/semantic_release/hvcs/test_github.py
@@ -803,7 +803,7 @@ def test_create_or_update_release_when_create_succeeds(
 
         # Evaluate (expected -> actual)
         assert mock_release_id == result
-        mock_create_release.assert_called_once_with(tag, RELEASE_NOTES, prerelease)
+        mock_create_release.assert_called_once_with(tag, RELEASE_NOTES, prerelease, draft=False)
         mock_get_release_id_by_tag.assert_not_called()
         mock_edit_release_notes.assert_not_called()
 


### PR DESCRIPTION
Closes #1193. Adds support for creating GitHub releases as **drafts** (previously only pre-releases were supported).

**Change:** add `draft: bool = False` to `create_release` / `create_or_update_release` across the HVCS interface (github, bitbucket, gitea, gitlab + base). Backward-compatible. The GitHub provider now sends `"draft": draft` instead of a hardcoded `False`; other providers accept+ignore the param (default False preserves current behavior).

**Verified:** `python-semantic-release`'s github HVCS unit tests pass (179 passed; the `test_upload_release_asset_fails` errors are pre-existing test-env issues, present on clean `master` too). Added one assertion update to `test_create_or_update_release_when_create_succeeds` for the new call signature.

Note: only wires the HVCS-layer param. A follow-up can expose a `release_type=draft`/CLI+config option if maintainers want it surfaced end-to-end — happy to add if direction is confirmed.