### PR TITLE
fix: Fix contradictory version specification

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ authors = [
 dependencies = [
   "click ~= 8.1.0; python_version == '3.8'",
   "click ~= 8.1.0; python_version == '3.9'",
-  "click ~= 8.1.0, < 8.5.0; python_version >= '3.10'",
+  "click >= 8.1.0, < 8.5.0; python_version >= '3.10'",
   "click-option-group ~= 0.5.0",
   "gitpython ~= 3.0",
   "requests ~= 2.25",


### PR DESCRIPTION
## Purpose

The previous specification was equivalent to `>= 8.1.0, == 8.1.*`, which doesn't make sense with the `<8.5`. I attempted what I think was the intention here.



## Rationale
Noticed when maintaining https://github.com/conda-forge/python-semantic-release-feedstock/pull/135


## How did you test?
https://github.com/conda-forge/python-semantic-release-feedstock/pull/135


## How to Verify
N/A



---

## PR Completion Checklist

- [x] Reviewed & followed the [Contributor Guidelines](https://python-semantic-release.readthedocs.io/en/stable/contributing/contributing_guide.html)

- [ ] Changes Implemented & Validation pipeline succeeds

- [x] Commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
  and are separated into the proper commit type and scope (recommended order: test, build, feat/fix, docs)

- [x] Appropriate Unit tests added/updated

- [x] Appropriate End-to-End tests added/updated

- [x] Appropriate Documentation added/updated and syntax validated for sphinx build (see Contributor Guidelines)
